### PR TITLE
fix: move MOTD display to extension files for persistent disk compatibility

### DIFF
--- a/terraform-gpu-devservers/docker/bash_profile
+++ b/terraform-gpu-devservers/docker/bash_profile
@@ -8,8 +8,5 @@ if [ -f ~/.bashrc ]; then
     source ~/.bashrc
 fi
 
-# Show MOTD only for interactive login shells (skip for Claude Code, scripts, etc.)
-# Check: stdin is a terminal AND stdout is a terminal
-if [ -t 0 ] && [ -t 1 ] && [ -f /etc/motd ]; then
-    cat /etc/motd
-fi
+# MOTD is now handled by .bashrc_ext with proper TTY checks
+# This ensures it works correctly on persistent disks without needing profile updates

--- a/terraform-gpu-devservers/docker/bashrc_ext
+++ b/terraform-gpu-devservers/docker/bashrc_ext
@@ -5,6 +5,12 @@
 # User identification (set by Lambda on startup)
 export GPU_DEV_USER_ID="dev"
 
+# Show MOTD once per session, only for interactive terminals (skip for Claude Code, scripts, etc.)
+if [ -z "$GPU_DEV_MOTD_SHOWN" ] && [ -t 0 ] && [ -t 1 ] && [ -f /etc/motd ]; then
+    cat /etc/motd
+    export GPU_DEV_MOTD_SHOWN=1
+fi
+
 # Function to check for GPU reservation expiry warnings and startup script status
 check_warnings() {
     # Check for startup script still running

--- a/terraform-gpu-devservers/docker/profile
+++ b/terraform-gpu-devservers/docker/profile
@@ -8,8 +8,5 @@ if [ -n "$BASH_VERSION" ] && [ -f ~/.bashrc ]; then
     source ~/.bashrc
 fi
 
-# Show MOTD only for interactive login shells (skip for Claude Code, scripts, etc.)
-# Check: stdin is a terminal AND stdout is a terminal
-if [ -t 0 ] && [ -t 1 ] && [ -f /etc/motd ]; then
-    cat /etc/motd
-fi
+# MOTD is now handled by .bashrc_ext with proper TTY checks
+# This ensures it works correctly on persistent disks without needing profile updates

--- a/terraform-gpu-devservers/docker/zprofile
+++ b/terraform-gpu-devservers/docker/zprofile
@@ -3,8 +3,5 @@ if [ -f ~/.zshrc ]; then
     source ~/.zshrc
 fi
 
-# Show MOTD only for interactive login shells (skip for Claude Code, scripts, etc.)
-# Check: stdin is a terminal AND stdout is a terminal
-if [ -t 0 ] && [ -t 1 ] && [ -f /etc/motd ]; then
-    cat /etc/motd
-fi
+# MOTD is now handled by .zshrc_ext with proper TTY checks
+# This ensures it works correctly on persistent disks without needing profile updates

--- a/terraform-gpu-devservers/docker/zshrc_ext
+++ b/terraform-gpu-devservers/docker/zshrc_ext
@@ -5,6 +5,12 @@
 # User identification (set by Lambda on startup)
 export GPU_DEV_USER_ID="dev"
 
+# Show MOTD once per session, only for interactive terminals (skip for Claude Code, scripts, etc.)
+if [[ -z "$GPU_DEV_MOTD_SHOWN" ]] && [[ -t 0 ]] && [[ -t 1 ]] && [[ -f /etc/motd ]]; then
+    cat /etc/motd
+    export GPU_DEV_MOTD_SHOWN=1
+fi
+
 # Function to check for GPU reservation expiry warnings and startup script status
 check_warnings() {
     # Check for startup script still running

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -3913,6 +3913,12 @@ EOF_PROFILE
 # User identification
 export GPU_DEV_USER_ID="{user_id or 'dev'}"
 
+# Show MOTD once per session, only for interactive terminals (skip for Claude Code, scripts, etc.)
+if [ -z "\$GPU_DEV_MOTD_SHOWN" ] && [ -t 0 ] && [ -t 1 ] && [ -f /etc/motd ]; then
+    cat /etc/motd
+    export GPU_DEV_MOTD_SHOWN=1
+fi
+
 # Function to check for GPU reservation expiry warnings and startup script status
 check_warnings() {{
     # Check for startup script still running
@@ -3940,6 +3946,12 @@ EOF_BASHRC_EXT
 
 # User identification
 export GPU_DEV_USER_ID="{user_id or 'dev'}"
+
+# Show MOTD once per session, only for interactive terminals (skip for Claude Code, scripts, etc.)
+if [[ -z "\$GPU_DEV_MOTD_SHOWN" ]] && [[ -t 0 ]] && [[ -t 1 ]] && [[ -f /etc/motd ]]; then
+    cat /etc/motd
+    export GPU_DEV_MOTD_SHOWN=1
+fi
 
 # Function to check for GPU reservation expiry warnings and startup script status
 check_warnings() {{
@@ -3979,6 +3991,19 @@ EOF_ZSHRC_EXT
                             fi
                         done
                         echo "[STARTUP] ✓ Shell extension sourcing configured"
+
+                        # Always update system profile files (these control login behavior)
+                        # MOTD is now handled by extension files, so remove from profiles
+                        echo "[STARTUP] Updating system profile files..."
+                        if [ -d "/devserver-setup" ]; then
+                            for profile_file in .bash_profile .zprofile .profile; do
+                                if [ -f "/devserver-setup/$profile_file" ]; then
+                                    cp "/devserver-setup/$profile_file" "/home/dev/$profile_file"
+                                    echo "[STARTUP] ✓ Updated $profile_file"
+                                fi
+                            done
+                        fi
+                        echo "[STARTUP] ✓ System profile files updated"
 
                         # Ensure correct ownership
                         chown -R dev:dev /home/dev


### PR DESCRIPTION
## Summary
- Move MOTD display from profile files to extension files (.bashrc_ext, .zshrc_ext)
- Add TTY checks to skip MOTD for Claude Code and non-interactive sessions
- Add GPU_DEV_MOTD_SHOWN flag to prevent duplicate MOTD display

## Why
Profile files (.bash_profile, .profile, .zprofile) are only copied on first reservation with a new persistent disk. Extension files are sourced on every shell session, making them the right place for MOTD display.

## Test plan
- [ ] Create new reservation, verify MOTD displays once on first login
- [ ] Open second terminal, verify MOTD doesn't display again (same session)
- [ ] Test with persistent disk - verify MOTD works without profile updates
- [ ] Test Claude Code - verify MOTD doesn't interfere with non-interactive sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)