### PR TITLE
fix: add Claude Code installation for ARM CPU pods

### DIFF
--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -3743,6 +3743,9 @@ EOF
                             echo "[STARTUP] PyTorch ARM64 installation complete"
                         fi
 
+                        # Install Claude Code for ARM64 CPU instances (runs after dev user setup below)
+                        INSTALL_CLAUDE_CODE_ARM="{gpu_type}"
+
                         echo "[STARTUP] Setting up dev user..."
                         # Create dev user with UID 1081 to avoid conflicts with common base image users (e.g., ubuntu=1000)
                         # Use zsh as default shell, fallback to bash if not available
@@ -4425,6 +4428,19 @@ EOF
                             echo "[STARTUP] ✓ Automatic dotfiles backup configured"
                         else
                             echo "[STARTUP] No shared storage - skipping backup setup"
+                        fi
+
+                        # Install Claude Code for ARM64 CPU instances (not in base image)
+                        if [ "$INSTALL_CLAUDE_CODE_ARM" = "cpu-arm" ]; then
+                            echo "[STARTUP] Installing Claude Code for ARM64..."
+                            # Install as dev user so it goes to ~/.local/bin
+                            su - dev -c 'curl -fsSL https://claude.ai/install.sh | bash' || echo "[STARTUP] Warning: Claude Code installation failed"
+                            # Add PATH and Bedrock config to shell RC files
+                            echo 'export PATH="$HOME/.local/bin:$PATH"' >> /home/dev/.zshrc
+                            echo 'export CLAUDE_CODE_USE_BEDROCK=1' >> /home/dev/.zshrc
+                            echo 'export PATH="$HOME/.local/bin:$PATH"' >> /home/dev/.bashrc
+                            echo 'export CLAUDE_CODE_USE_BEDROCK=1' >> /home/dev/.bashrc
+                            echo "[STARTUP] ✓ Claude Code installed for ARM64"
                         fi
 
                         # Run user's custom startup script if it exists


### PR DESCRIPTION
## Summary
- Install Claude Code on ARM64 CPU instances during pod startup
- ARM pods use `python:3.11-slim` base image which doesn't include Claude Code
- Configure PATH and Bedrock integration automatically

## Changes
- Set `INSTALL_CLAUDE_CODE_ARM` flag when `gpu_type=cpu-arm`
- Install Claude Code via `curl -fsSL https://claude.ai/install.sh | bash`
- Add `~/.local/bin` to PATH in both `.bashrc` and `.zshrc`
- Set `CLAUDE_CODE_USE_BEDROCK=1` for AWS Bedrock integration

## Test plan
- [ ] Create ARM CPU reservation: `gpu-dev reserve --gpu-type cpu-arm`
- [ ] SSH into pod and verify `claude` command is available
- [ ] Verify Bedrock integration works

🤖 Generated with [Claude Code](https://claude.com/claude-code)