### PR TITLE
Adds logic in `availability-updater-service` to sync postgres disks DB to reflect current AWS disks status

### DIFF
--- a/terraform-gpu-devservers/CLAUDE.md
+++ b/terraform-gpu-devservers/CLAUDE.md
@@ -99,8 +99,11 @@
 1. **EKS Cluster** - Kubernetes cluster with GPU and CPU node groups
 2. **PostgreSQL + PGMQ** - Database with message queue for job management
 3. **API Service** - REST API for job submission with AWS IAM auth
-4. **SSH Proxy** - Secure access to development environments
-5. **Registry Cache** - Docker image caching (GHCR)
+4. **Job Processor Pod** - Polls PGMQ and manages reservation lifecycle
+5. **Availability Updater CronJob** - Updates GPU availability + reconciles disk state from AWS (every 5 min)
+6. **Reservation Expiry CronJob** - Expires reservations and cleans up pods (every 5 min)
+7. **SSH Proxy** - Secure access to development environments
+8. **Registry Cache** - Docker image caching (GHCR)
 
 ## 🏗️ Architecture
 

--- a/terraform-gpu-devservers/api-service/README.md
+++ b/terraform-gpu-devservers/api-service/README.md
@@ -176,6 +176,18 @@ $ gpu-dev submit --image my-model:v2 --instance p5.48xlarge
 - ✅ Implemented and functional
 - 🚧 In progress/planned
 
+**Note on Disk State Synchronization:**
+
+Disk metadata in the database is automatically reconciled with AWS EBS state every 5 minutes by the `availability-updater` service. This means:
+
+- **Attachment state** (`in_use`) reflects actual AWS attachment status
+- **Snapshot counts** are synced from AWS EBS snapshots
+- **Disk sizes** match actual EBS volume sizes
+- **Orphaned volumes** (deleted in AWS) are detected and marked
+- **Reservation associations** (`reservation_id`) are preserved for audit trails
+
+The API provides the interface for disk operations, while the reconciliation service ensures database consistency with AWS as the source of truth.
+
 ## 🔄 How It Works
 
 ### Complete Workflow

--- a/terraform-gpu-devservers/availability-updater-service/updater/main.py
+++ b/terraform-gpu-devservers/availability-updater-service/updater/main.py
@@ -5,11 +5,10 @@ Updates GPU availability table by querying ASG and Kubernetes API
 Migrated from Lambda function to Kubernetes CronJob
 """
 
-import sys
-import os
 import logging
-from datetime import datetime, UTC
-from typing import Dict, Any
+import os
+import sys
+from datetime import UTC, datetime
 
 # Add parent directory to path for shared imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -20,6 +19,7 @@ from kubernetes import client
 from shared.db_pool import init_connection_pool, close_connection_pool
 from shared.availability_db import update_gpu_availability, get_supported_gpu_types
 from shared.k8s_client import setup_kubernetes_client
+from shared.disk_reconciler import reconcile_all_disks
 
 # Setup logging
 logging.basicConfig(
@@ -31,10 +31,13 @@ logger = logging.getLogger(__name__)
 
 # AWS clients
 autoscaling = boto3.client("autoscaling")
+ec2 = boto3.client("ec2")
 
 # Environment variables
 AWS_REGION = os.environ.get("AWS_REGION", "us-east-2")
-EKS_CLUSTER_NAME = os.environ.get("EKS_CLUSTER_NAME", "pytorch-gpu-dev-cluster")
+EKS_CLUSTER_NAME = os.environ.get(
+    "EKS_CLUSTER_NAME", "pytorch-gpu-dev-cluster"
+)
 
 # Kubernetes client singleton
 _k8s_client = None
@@ -50,62 +53,86 @@ def get_k8s_client():
     return _k8s_client
 
 
-def update_gpu_availability_for_type(gpu_type: str, gpu_config: Dict[str, Any], k8s_client) -> None:
+def update_gpu_availability_for_type(
+    gpu_type: str, gpu_config: dict[str, any], k8s_client
+) -> None:
     """Update availability information for a specific GPU type"""
     try:
         logger.info(f"Starting availability update for GPU type: {gpu_type}")
 
-        # Get current ASG capacity - handle multiple ASGs per GPU type (e.g., capacity reservations)
+        # Get current ASG capacity - handle multiple ASGs per GPU type
+        # (e.g., capacity reservations)
         # Get GPU configuration to check if this is a CPU type
         gpus_per_instance = gpu_config.get("gpus_per_instance", 8)
-        
+
         # Validate configuration
         if gpus_per_instance < 0:
-            logger.error(f"Invalid gpus_per_instance for {gpu_type}: {gpus_per_instance} (must be >= 0)")
+            logger.error(
+                f"Invalid gpus_per_instance for {gpu_type}: "
+                f"{gpus_per_instance} (must be >= 0)"
+            )
             return
-        
+
         if gpus_per_instance == 0:
-            logger.info(f"GPU type {gpu_type} has gpus_per_instance=0, treating as CPU-only instance type")
-        
+            logger.info(
+                f"GPU type {gpu_type} has gpus_per_instance=0, "
+                "treating as CPU-only instance type"
+            )
+
         is_cpu_type = gpus_per_instance == 0
-        
+
         # Build ASG name patterns to try
         # CPU types may use different naming conventions
         asg_patterns = []
         if is_cpu_type:
             # Try multiple patterns for CPU types
             asg_patterns = [
-                f"pytorch-gpu-dev-gpu-nodes-{gpu_type}",  # Standard pattern
-                f"pytorch-gpu-dev-cpu-nodes-{gpu_type}",  # CPU-specific pattern
-                "pytorch-gpu-dev-cpu-nodes",               # Generic CPU pattern
+                # Standard pattern
+                f"pytorch-gpu-dev-gpu-nodes-{gpu_type}",
+                # CPU-specific pattern
+                f"pytorch-gpu-dev-cpu-nodes-{gpu_type}",
+                # Generic CPU pattern
+                "pytorch-gpu-dev-cpu-nodes",
             ]
-            logger.info(f"CPU type detected, trying multiple ASG patterns: {asg_patterns}")
+            logger.info(
+                "CPU type detected, trying multiple ASG patterns: "
+                f"{asg_patterns}"
+            )
         else:
             # GPU types use standard pattern
             asg_patterns = [f"pytorch-gpu-dev-gpu-nodes-{gpu_type}"]
-            logger.info(f"Checking ASGs matching pattern: {asg_patterns[0]}*")
+            logger.info(
+                f"Checking ASGs matching pattern: {asg_patterns[0]}*"
+            )
 
         # Get all ASGs and filter by name pattern
         all_asgs_response = autoscaling.describe_auto_scaling_groups()
-        
+
         # Try each pattern until we find matching ASGs
         matching_asgs = []
-        matched_pattern = None
         for pattern in asg_patterns:
             matching_asgs = [
                 asg for asg in all_asgs_response["AutoScalingGroups"]
                 if asg["AutoScalingGroupName"].startswith(pattern)
             ]
             if matching_asgs:
-                matched_pattern = pattern
-                logger.info(f"Found {len(matching_asgs)} ASGs using pattern: {pattern}*")
+                logger.info(
+                    f"Found {len(matching_asgs)} ASGs using pattern: "
+                    f"{pattern}*"
+                )
                 break
 
         if not matching_asgs:
-            logger.warning(f"No ASGs found for {gpu_type}. Tried patterns: {asg_patterns}")
+            logger.warning(
+                f"No ASGs found for {gpu_type}. "
+                f"Tried patterns: {asg_patterns}"
+            )
             # For CPU types, this might be expected if no CPU ASGs exist yet
             if is_cpu_type:
-                logger.info(f"No CPU ASGs found - this may be normal if CPU nodes not yet deployed")
+                logger.info(
+                    "No CPU ASGs found - this may be normal if CPU nodes "
+                    "not yet deployed"
+                )
             return
 
         asg_names = [asg["AutoScalingGroupName"] for asg in matching_asgs]
@@ -123,34 +150,57 @@ def update_gpu_availability_for_type(gpu_type: str, gpu_config: Dict[str, Any], 
         # gpus_per_instance and is_cpu_type already determined above
 
         if is_cpu_type:
-            # For CPU nodes, report instance slots (assuming 3 users per node)
+            # For CPU nodes, report instance slots
+            # (assuming 3 users per node)
             max_users_per_node = 3
             total_gpus = running_instances * max_users_per_node
             logger.info(
-                f"CPU ASG calculation: {running_instances} instances * {max_users_per_node} slots = {total_gpus} total slots")
+                f"CPU ASG calculation: {running_instances} instances * "
+                f"{max_users_per_node} slots = {total_gpus} total slots"
+            )
 
             # Check actual pod usage on CPU nodes
             if k8s_client is not None:
                 try:
-                    logger.info(f"Checking CPU node availability for {gpu_type}")
-                    # Count available slots by checking pod count on each node
+                    logger.info(
+                        f"Checking CPU node availability for {gpu_type}"
+                    )
+                    # Count available slots by checking pod count on
+                    # each node
                     v1 = client.CoreV1Api(k8s_client)
-                    nodes = v1.list_node(label_selector=f"GpuType={gpu_type}")
+                    nodes = v1.list_node(
+                        label_selector=f"GpuType={gpu_type}"
+                    )
 
                     total_available_slots = 0
                     for node in nodes.items:
                         if is_node_ready_and_schedulable(node):
                             # Count gpu-dev pods on this node
-                            pods = v1.list_pod_for_all_namespaces(field_selector=f"spec.nodeName={node.metadata.name}")
-                            gpu_dev_pods = [p for p in pods.items if p.metadata.name.startswith('gpu-dev-')]
+                            pods = v1.list_pod_for_all_namespaces(
+                                field_selector=(
+                                    f"spec.nodeName={node.metadata.name}"
+                                )
+                            )
+                            gpu_dev_pods = [
+                                p for p in pods.items
+                                if p.metadata.name.startswith('gpu-dev-')
+                            ]
                             used_slots = len(gpu_dev_pods)
-                            available_slots = max(0, max_users_per_node - used_slots)
+                            available_slots = max(
+                                0, max_users_per_node - used_slots
+                            )
                             total_available_slots += available_slots
 
                     available_gpus = total_available_slots
-                    logger.info(f"Found {available_gpus} available CPU slots across {len(nodes.items)} nodes")
+                    logger.info(
+                        f"Found {available_gpus} available CPU slots "
+                        f"across {len(nodes.items)} nodes"
+                    )
                 except Exception as k8s_error:
-                    logger.warning(f"Failed to query Kubernetes for {gpu_type} CPU availability: {k8s_error}")
+                    logger.warning(
+                        f"Failed to query Kubernetes for {gpu_type} "
+                        f"CPU availability: {k8s_error}"
+                    )
                     available_gpus = total_gpus
             else:
                 available_gpus = total_gpus
@@ -158,27 +208,47 @@ def update_gpu_availability_for_type(gpu_type: str, gpu_config: Dict[str, Any], 
             # GPU nodes - use existing logic
             total_gpus = running_instances * gpus_per_instance
             logger.info(
-                f"ASG calculation: {running_instances} instances * {gpus_per_instance} GPUs = {total_gpus} total GPUs")
+                f"ASG calculation: {running_instances} instances * "
+                f"{gpus_per_instance} GPUs = {total_gpus} total GPUs"
+            )
 
             # Query Kubernetes API for actual GPU allocations
             if k8s_client is not None:
                 try:
-                    logger.info(f"Starting Kubernetes query for {gpu_type} GPU availability")
-                    available_gpus = check_schedulable_gpus_for_type(k8s_client, gpu_type)
-                    logger.info(f"Kubernetes reports {available_gpus} schedulable {gpu_type.upper()} GPUs")
+                    logger.info(
+                        f"Starting Kubernetes query for {gpu_type} "
+                        "GPU availability"
+                    )
+                    available_gpus = check_schedulable_gpus_for_type(
+                        k8s_client, gpu_type
+                    )
+                    logger.info(
+                        f"Kubernetes reports {available_gpus} schedulable "
+                        f"{gpu_type.upper()} GPUs"
+                    )
 
                 except Exception as k8s_error:
-                    logger.warning(f"Failed to query Kubernetes for {gpu_type} availability: {k8s_error}")
-                    # Fallback to ASG-based calculation (assume all GPUs available)
+                    logger.warning(
+                        f"Failed to query Kubernetes for {gpu_type} "
+                        f"availability: {k8s_error}"
+                    )
+                    # Fallback to ASG-based calculation
+                    # (assume all GPUs available)
                     available_gpus = total_gpus
             else:
-                logger.warning(f"No Kubernetes client available for {gpu_type}, using ASG-based calculation")
-                # Fallback to ASG-based calculation (assume all GPUs available)
+                logger.warning(
+                    f"No Kubernetes client available for {gpu_type}, "
+                    "using ASG-based calculation"
+                )
+                # Fallback to ASG-based calculation
+                # (assume all GPUs available)
                 available_gpus = total_gpus
 
-        # Calculate full nodes available (nodes with all GPUs free) and max reservable
+        # Calculate full nodes available (nodes with all GPUs free) and
+        # max reservable
         full_nodes_available = 0
-        max_reservable = 0  # Maximum GPUs reservable (considering multinode for high-end GPUs)
+        # Maximum GPUs reservable (considering multinode for high-end GPUs)
+        max_reservable = 0
         if k8s_client is not None and not is_cpu_type:
             try:
                 v1 = client.CoreV1Api(k8s_client)
@@ -187,49 +257,80 @@ def update_gpu_availability_for_type(gpu_type: str, gpu_config: Dict[str, Any], 
                 single_node_max = 0  # Max available on any single node
                 for node in nodes.items:
                     if is_node_ready_and_schedulable(node):
-                        available_on_node = get_available_gpus_on_node(v1, node)
+                        available_on_node = get_available_gpus_on_node(
+                            v1, node
+                        )
                         total_on_node = 0
                         if node.status.allocatable:
-                            gpu_allocatable = node.status.allocatable.get("nvidia.com/gpu", "0")
+                            gpu_allocatable = (
+                                node.status.allocatable.get(
+                                    "nvidia.com/gpu", "0"
+                                )
+                            )
                             try:
                                 total_on_node = int(gpu_allocatable)
                             except (ValueError, TypeError):
                                 pass
 
                         # Track max available on any single node
-                        single_node_max = max(single_node_max, available_on_node)
+                        single_node_max = max(
+                            single_node_max, available_on_node
+                        )
 
                         # Count as full node if all GPUs are available
-                        if total_on_node > 0 and available_on_node == total_on_node:
+                        if (
+                            total_on_node > 0
+                            and available_on_node == total_on_node
+                        ):
                             full_nodes_available += 1
 
                 # Calculate max reservable considering multinode scenarios
-                # Only high-end GPU types support multinode (up to 4 nodes = 32 GPUs)
+                # Only high-end GPU types support multinode
+                # (up to 4 nodes = 32 GPUs)
                 multinode_gpu_types = ['h100', 'h200', 'b200', 'a100']
-                if gpu_type in multinode_gpu_types and gpus_per_instance == 8:
-                    max_nodes = min(4, full_nodes_available)  # Up to 4 nodes
-                    max_reservable = max_nodes * gpus_per_instance  # e.g., 4 * 8 = 32 GPUs
+                if (
+                    gpu_type in multinode_gpu_types
+                    and gpus_per_instance == 8
+                ):
+                    # Up to 4 nodes
+                    max_nodes = min(4, full_nodes_available)
+                    # e.g., 4 * 8 = 32 GPUs
+                    max_reservable = max_nodes * gpus_per_instance
 
                     # If no full nodes available, fall back to single node max
                     if max_reservable == 0:
                         max_reservable = single_node_max
                 else:
-                    # For all other GPU types (T4, L4, T4-small, etc.), only single node
+                    # For all other GPU types (T4, L4, T4-small, etc.),
+                    # only single node
                     max_reservable = single_node_max
 
-                logger.info(f"Found {full_nodes_available} full nodes available for {gpu_type}, max reservable: {max_reservable} (single node max: {single_node_max})")
+                logger.info(
+                    f"Found {full_nodes_available} full nodes available "
+                    f"for {gpu_type}, max reservable: {max_reservable} "
+                    f"(single node max: {single_node_max})"
+                )
             except Exception as e:
-                logger.warning(f"Could not calculate full nodes available for {gpu_type}: {str(e)}")
+                logger.warning(
+                    f"Could not calculate full nodes available for "
+                    f"{gpu_type}: {str(e)}"
+                )
                 full_nodes_available = 0
                 max_reservable = 0
         elif is_cpu_type:
             # For CPU nodes, each node supports 1 reservation
-            full_nodes_available = available_gpus  # Each "GPU" represents one CPU node slot
-            max_reservable = 1 if available_gpus > 0 else 0  # Max 1 CPU node per reservation
+            # Each "GPU" represents one CPU node slot
+            full_nodes_available = available_gpus
+            # Max 1 CPU node per reservation
+            max_reservable = 1 if available_gpus > 0 else 0
 
         # Get pod name for tracking (Kubernetes sets HOSTNAME to pod name)
         # Fallback chain: HOSTNAME -> POD_NAME -> generic name
-        pod_name = os.environ.get("HOSTNAME") or os.environ.get("POD_NAME") or "availability-updater-unknown"
+        pod_name = (
+            os.environ.get("HOSTNAME")
+            or os.environ.get("POD_NAME")
+            or "availability-updater-unknown"
+        )
 
         # Update PostgreSQL table
         update_gpu_availability(
@@ -245,8 +346,10 @@ def update_gpu_availability_for_type(gpu_type: str, gpu_config: Dict[str, Any], 
         )
 
         logger.info(
-            f"Updated {gpu_type}: {available_gpus}/{total_gpus} GPUs available "
-            f"({running_instances} instances, {full_nodes_available} full nodes, max reservable: {max_reservable})"
+            f"Updated {gpu_type}: {available_gpus}/{total_gpus} "
+            f"GPUs available ({running_instances} instances, "
+            f"{full_nodes_available} full nodes, "
+            f"max reservable: {max_reservable})"
         )
 
     except Exception as e:
@@ -255,18 +358,28 @@ def update_gpu_availability_for_type(gpu_type: str, gpu_config: Dict[str, Any], 
 
 
 def check_schedulable_gpus_for_type(k8s_client, gpu_type: str) -> int:
-    """Check how many GPUs of a specific type are schedulable (available for new pods)"""
+    """
+    Check how many GPUs of a specific type are schedulable (available
+    for new pods)
+    """
     try:
-        logger.info(f"Starting schedulable GPU check for type: {gpu_type}")
+        logger.info(
+            f"Starting schedulable GPU check for type: {gpu_type}"
+        )
         v1 = client.CoreV1Api(k8s_client)
         logger.info(f"Created CoreV1Api client for {gpu_type}")
 
         # Get all nodes with the specified GPU type
         gpu_type_selector = f"GpuType={gpu_type}"
-        logger.info(f"Querying nodes with label selector: {gpu_type_selector}")
+        logger.info(
+            f"Querying nodes with label selector: {gpu_type_selector}"
+        )
 
         nodes = v1.list_node(label_selector=gpu_type_selector)
-        logger.info(f"Retrieved {len(nodes.items) if nodes.items else 0} nodes for {gpu_type}")
+        logger.info(
+            f"Retrieved {len(nodes.items) if nodes.items else 0} "
+            f"nodes for {gpu_type}"
+        )
 
         if not nodes.items:
             logger.warning(f"No nodes found for GPU type {gpu_type}")
@@ -275,23 +388,42 @@ def check_schedulable_gpus_for_type(k8s_client, gpu_type: str) -> int:
         total_schedulable = 0
 
         for i, node in enumerate(nodes.items):
-            logger.info(f"Processing node {i + 1}/{len(nodes.items)}: {node.metadata.name}")
+            logger.info(
+                f"Processing node {i + 1}/{len(nodes.items)}: "
+                f"{node.metadata.name}"
+            )
 
             if not is_node_ready_and_schedulable(node):
-                logger.info(f"Node {node.metadata.name} is not ready/schedulable, skipping")
+                logger.info(
+                    f"Node {node.metadata.name} is not "
+                    "ready/schedulable, skipping"
+                )
                 continue
 
-            logger.info(f"Node {node.metadata.name} is ready, checking GPU availability")
+            logger.info(
+                f"Node {node.metadata.name} is ready, "
+                "checking GPU availability"
+            )
             # Get available GPUs on this node
             available_on_node = get_available_gpus_on_node(v1, node)
             total_schedulable += available_on_node
-            logger.info(f"Node {node.metadata.name}: {available_on_node} GPUs available")
+            logger.info(
+                f"Node {node.metadata.name}: {available_on_node} "
+                "GPUs available"
+            )
 
-        logger.info(f"Found {total_schedulable} schedulable {gpu_type.upper()} GPUs across {len(nodes.items)} nodes")
+        logger.info(
+            f"Found {total_schedulable} schedulable "
+            f"{gpu_type.upper()} GPUs across {len(nodes.items)} nodes"
+        )
         return total_schedulable
 
     except Exception as e:
-        logger.error(f"Error checking schedulable GPUs for type {gpu_type}: {str(e)}", exc_info=True)
+        logger.error(
+            f"Error checking schedulable GPUs for type {gpu_type}: "
+            f"{str(e)}",
+            exc_info=True
+        )
         return 0
 
 
@@ -326,7 +458,9 @@ def get_available_gpus_on_node(v1_api, node) -> int:
 
         # Get all pods on this node
         logger.debug(f"Querying pods on node {node_name}")
-        pods = v1_api.list_pod_for_all_namespaces(field_selector=f"spec.nodeName={node_name}")
+        pods = v1_api.list_pod_for_all_namespaces(
+            field_selector=f"spec.nodeName={node_name}"
+        )
         logger.debug(f"Found {len(pods.items)} pods on node {node_name}")
 
         # Calculate GPU usage
@@ -334,7 +468,10 @@ def get_available_gpus_on_node(v1_api, node) -> int:
         for pod in pods.items:
             if pod.status.phase in ["Running", "Pending"]:
                 for container in pod.spec.containers:
-                    if container.resources and container.resources.requests:
+                    if (
+                        container.resources
+                        and container.resources.requests
+                    ):
                         gpu_request = container.resources.requests.get(
                             "nvidia.com/gpu", "0"
                         )
@@ -346,20 +483,26 @@ def get_available_gpus_on_node(v1_api, node) -> int:
         # Get total GPUs on this node
         total_gpus = 0
         if node.status.allocatable:
-            gpu_allocatable = node.status.allocatable.get("nvidia.com/gpu", "0")
+            gpu_allocatable = node.status.allocatable.get(
+                "nvidia.com/gpu", "0"
+            )
             try:
                 total_gpus = int(gpu_allocatable)
             except (ValueError, TypeError):
                 pass
 
         available_gpus = max(0, total_gpus - used_gpus)
-        logger.debug(f"Node {node_name}: {available_gpus}/{total_gpus} GPUs available")
+        logger.debug(
+            f"Node {node_name}: {available_gpus}/{total_gpus} "
+            "GPUs available"
+        )
 
         return available_gpus
 
     except Exception as e:
         logger.error(
-            f"Error getting available GPUs on node {node.metadata.name}: {str(e)}"
+            f"Error getting available GPUs on node "
+            f"{node.metadata.name}: {str(e)}"
         )
         return 0
 
@@ -367,73 +510,163 @@ def get_available_gpus_on_node(v1_api, node) -> int:
 def run_availability_update():
     """Main availability update logic"""
     logger.info("=== Starting GPU Availability Update ===")
-    
+
     # Set up Kubernetes client once for all GPU types
     k8s_client = None
     try:
-        logger.info("Setting up shared Kubernetes client for all GPU types")
+        logger.info(
+            "Setting up shared Kubernetes client for all GPU types"
+        )
         k8s_client = get_k8s_client()
         logger.info("Shared Kubernetes client ready")
     except Exception as k8s_setup_error:
-        logger.error(f"Failed to setup Kubernetes client: {k8s_setup_error}", exc_info=True)
+        logger.error(
+            f"Failed to setup Kubernetes client: {k8s_setup_error}",
+            exc_info=True
+        )
         k8s_client = None
 
     # Get supported GPU types from database
     logger.info("Fetching supported GPU types from database")
     gpu_types = get_supported_gpu_types()
-    logger.info(f"Found {len(gpu_types)} GPU types to update: {list(gpu_types.keys())}")
+    logger.info(
+        f"Found {len(gpu_types)} GPU types to update: "
+        f"{list(gpu_types.keys())}"
+    )
 
     # Update availability for ALL GPU types
     updated_types = []
     failed_types = []
-    
+
     for gpu_type, gpu_config in gpu_types.items():
         try:
-            logger.info(f"=== Starting update for GPU type: {gpu_type} ===")
-            update_gpu_availability_for_type(gpu_type, gpu_config, k8s_client)
+            logger.info(
+                f"=== Starting update for GPU type: {gpu_type} ==="
+            )
+            update_gpu_availability_for_type(
+                gpu_type, gpu_config, k8s_client
+            )
             updated_types.append(gpu_type)
-            logger.info(f"=== Successfully updated availability for GPU type: {gpu_type} ===")
+            logger.info(
+                "=== Successfully updated availability for GPU type: "
+                f"{gpu_type} ==="
+            )
         except Exception as gpu_error:
-            logger.error(f"=== Failed to update availability for {gpu_type}: {gpu_error} ===", exc_info=True)
+            logger.error(
+                f"=== Failed to update availability for {gpu_type}: "
+                f"{gpu_error} ===",
+                exc_info=True
+            )
             failed_types.append(gpu_type)
             # Continue with other GPU types
 
-    logger.info(f"=== Availability Update Complete ===")
-    logger.info(f"Successfully updated: {len(updated_types)} GPU types: {updated_types}")
+    logger.info("=== Availability Update Complete ===")
+    logger.info(
+        f"Successfully updated: {len(updated_types)} GPU types: "
+        f"{updated_types}"
+    )
     if failed_types:
-        logger.warning(f"Failed to update: {len(failed_types)} GPU types: {failed_types}")
-    
+        logger.warning(
+            f"Failed to update: {len(failed_types)} GPU types: "
+            f"{failed_types}"
+        )
+
     # Return success if at least one GPU type was updated
     return len(updated_types) > 0
+
+
+def run_disk_reconciliation():
+    """Main disk reconciliation logic"""
+    logger.info("=== Starting Disk Reconciliation ===")
+
+    try:
+        # Use global ec2 client
+        stats = reconcile_all_disks(ec2)
+
+        logger.info("=== Disk Reconciliation Complete ===")
+        logger.info(f"AWS Volumes: {stats['aws_volumes']}")
+        logger.info(f"DB Records: {stats['db_records']}")
+        logger.info(f"Synced (no changes): {stats['synced']}")
+        logger.info(f"Updated: {stats['updated']}")
+        logger.info(f"Created: {stats['created']}")
+        logger.info(f"Errors: {stats['errors']}")
+        logger.info(f"Volume ID Conflicts: {stats['volume_id_conflicts']}")
+        logger.info(f"Orphaned (DB active): {stats['orphaned_db_active']}")
+        logger.info(
+            f"Orphaned (DB deleted): {stats['orphaned_db_deleted']}"
+        )
+
+        # Return success if no errors occurred
+        return stats["errors"] == 0
+
+    except Exception as e:
+        logger.error(f"Disk reconciliation failed: {e}", exc_info=True)
+        return False
 
 
 def main():
     """Main entry point for CronJob execution"""
     start_time = datetime.now(UTC)
-    logger.info(f"Availability updater starting at {start_time.isoformat()}")
-    
+    logger.info(
+        "Cluster state reconciliation starting at "
+        f"{start_time.isoformat()}"
+    )
+
     try:
         # Initialize database connection pool
         logger.info("Initializing database connection pool")
         init_connection_pool()
         logger.info("Database connection pool initialized")
-        
-        # Run availability update
-        success = run_availability_update()
-        
+
+        # Phase 1: Update GPU availability
+        gpu_start = datetime.now(UTC)
+        gpu_success = run_availability_update()
+        gpu_duration = (datetime.now(UTC) - gpu_start).total_seconds()
+        logger.info(
+            "GPU availability update completed in "
+            f"{gpu_duration:.2f} seconds"
+        )
+
+        # Phase 2: Reconcile disk state
+        disk_start = datetime.now(UTC)
+        disk_success = run_disk_reconciliation()
+        disk_duration = (datetime.now(UTC) - disk_start).total_seconds()
+        logger.info(
+            "Disk reconciliation completed in "
+            f"{disk_duration:.2f} seconds"
+        )
+
+        # Summary
         end_time = datetime.now(UTC)
-        duration = (end_time - start_time).total_seconds()
-        logger.info(f"Availability update completed in {duration:.2f} seconds")
-        
-        if success:
-            logger.info("Availability update completed successfully")
+        total_duration = (end_time - start_time).total_seconds()
+        logger.info("=== RECONCILIATION SUMMARY ===")
+        logger.info(f"Total duration: {total_duration:.2f} seconds")
+        logger.info(
+            f"GPU availability: {gpu_duration:.2f}s - "
+            f"{'SUCCESS' if gpu_success else 'FAILED'}"
+        )
+        logger.info(
+            f"Disk reconciliation: {disk_duration:.2f}s - "
+            f"{'SUCCESS' if disk_success else 'FAILED'}"
+        )
+
+        if gpu_success and disk_success:
+            logger.info(
+                "Cluster state reconciliation completed successfully"
+            )
             return 0
         else:
-            logger.error("Availability update failed - no GPU types were updated")
+            logger.error(
+                "Cluster state reconciliation completed with errors"
+            )
             return 1
-            
+
     except Exception as e:
-        logger.error(f"Availability update failed with exception: {e}", exc_info=True)
+        logger.error(
+            "Cluster state reconciliation failed with exception: "
+            f"{e}",
+            exc_info=True
+        )
         return 1
     finally:
         # Close database connection pool
@@ -442,9 +675,10 @@ def main():
             close_connection_pool()
             logger.info("Database connection pool closed")
         except Exception as cleanup_error:
-            logger.error(f"Error closing connection pool: {cleanup_error}")
+            logger.error(
+                f"Error closing connection pool: {cleanup_error}"
+            )
 
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/terraform-gpu-devservers/shared/disk_db.py
+++ b/terraform-gpu-devservers/shared/disk_db.py
@@ -69,7 +69,7 @@ def create_disk(disk_data: Dict[str, Any]) -> bool:
                     WHERE table_name = 'disks' AND column_name = 'disk_size'
                 )
             """)
-            disk_size_column_exists = cur.fetchone()[0]
+            disk_size_column_exists = cur.fetchone()['exists']
             
             if disk_size_column_exists:
                 # New schema with disk_size column

--- a/terraform-gpu-devservers/shared/disk_reconciler.py
+++ b/terraform-gpu-devservers/shared/disk_reconciler.py
@@ -1,0 +1,852 @@
+"""
+Disk Reconciliation Module
+
+Syncs EBS volume state from AWS into PostgreSQL database, ensuring
+database records accurately reflect AWS reality.
+
+Single source of truth: AWS EBS volumes
+
+Reconciliation Rules:
+1. Volume in AWS but not in DB → Create DB entry (is_deleted=False)
+2. Volume in DB but deleted from AWS:
+   - If is_deleted=False → Keep DB record, update in_use=False only
+   - If is_deleted=True → Update all fields normally
+3. Volume in both → Sync state from AWS to DB
+"""
+
+import logging
+import random
+import time
+from datetime import UTC, datetime
+
+from botocore.exceptions import ClientError
+
+from .db_pool import get_db_cursor, get_db_transaction
+from .disk_db import create_disk, update_disk
+
+logger = logging.getLogger(__name__)
+
+
+def ensure_utc(dt: datetime | None) -> datetime | None:
+    """
+    Ensure a datetime is timezone-aware and in UTC.
+
+    This is a defensive function to handle cases where datetimes might
+    be naive (from AWS SDK or database). Per project timezone standard,
+    all datetimes should be timezone-aware UTC.
+
+    Args:
+        dt: A datetime object (timezone-aware or naive) or None
+
+    Returns:
+        A timezone-aware datetime in UTC, or None if input was None
+    """
+    if dt is None:
+        return None
+
+    # If already timezone-aware, convert to UTC
+    if dt.tzinfo is not None:
+        return dt.astimezone(UTC)
+
+    # If naive, assume it's already in UTC and make it aware
+    # This shouldn't happen with TIMESTAMP WITH TIME ZONE columns,
+    # but we handle it defensively
+    logger.warning(
+        f"Encountered naive datetime {dt}, assuming UTC. "
+        f"This should not happen - investigate data source."
+    )
+    return dt.replace(tzinfo=UTC)
+
+
+def reconcile_all_disks(ec2_client) -> dict[str, int]:
+    """
+    Reconcile all disk records from AWS EBS volumes.
+
+    Args:
+        ec2_client: Boto3 EC2 client
+
+    Returns:
+        Dictionary with reconciliation statistics
+    """
+    stats = {
+        "aws_volumes": 0,
+        "db_records": 0,
+        "synced": 0,
+        "updated": 0,
+        "created": 0,
+        "errors": 0,
+        "volume_id_conflicts": 0,
+        "orphaned_db_active": 0,
+        "orphaned_db_deleted": 0,
+    }
+
+    try:
+        # 1. Get all gpu-dev volumes from AWS
+        logger.info("Fetching all EBS volumes with gpu-dev-user tag")
+        aws_volumes, aws_error = get_all_gpudev_volumes(ec2_client)
+
+        if aws_error:
+            # AWS fetch failed - abort reconciliation
+            logger.error(
+                f"Failed to fetch AWS volumes: {aws_error}. "
+                f"Aborting reconciliation to prevent marking all "
+                f"DB records as orphaned."
+            )
+            stats["errors"] += 1
+            return stats
+
+        stats["aws_volumes"] = len(aws_volumes)
+        logger.info(f"Found {len(aws_volumes)} volumes in AWS")
+
+        # 2. Get all disk records from database
+        logger.info("Fetching all disk records from database")
+        db_disks = get_all_disks_from_db()
+        stats["db_records"] = len(db_disks)
+        logger.info(f"Found {len(db_disks)} disk records in database")
+
+        # 3. Build indexes for fast lookup
+        aws_by_volume_id = {vol["volume_id"]: vol for vol in aws_volumes}
+        db_by_volume_id = {
+            disk["ebs_volume_id"]: disk
+            for disk in db_disks
+            if disk.get("ebs_volume_id")
+        }
+
+        # Also index DB by (user_id, disk_name) for orphaned AWS volumes
+        # Detect and handle duplicates
+        db_by_user_disk = {}
+        for disk in db_disks:
+            key = (disk["user_id"], disk["disk_name"])
+            if key in db_by_user_disk:
+                # Duplicate found - log critical error
+                existing_disk = db_by_user_disk[key]
+                logger.error(
+                    f"DUPLICATE DISK DETECTED: disk_name='{disk['disk_name']}' "
+                    f"user_id='{disk['user_id']}' appears multiple times. "
+                    f"Disk IDs: {existing_disk['disk_id']} (kept), "
+                    f"{disk['disk_id']} (skipped). "
+                    f"Volume IDs: {existing_disk.get('ebs_volume_id')} vs "
+                    f"{disk.get('ebs_volume_id')}. "
+                    f"Manual cleanup required!"
+                )
+                stats["errors"] += 1
+                # Keep the first occurrence (already in dict)
+                continue
+            db_by_user_disk[key] = disk
+
+        # 4. Reconcile AWS volumes into database
+        # Each volume is reconciled in its own transaction for atomicity
+        for volume_id, aws_vol in aws_by_volume_id.items():
+            try:
+                # Wrap each volume reconciliation in a transaction
+                # This ensures all DB operations for this volume are atomic
+                # and prevents race conditions between concurrent runs
+                with get_db_transaction():
+                    if volume_id in db_by_volume_id:
+                        # Volume exists in both - sync state
+                        db_disk = db_by_volume_id[volume_id]
+                        result = sync_volume_to_db(
+                            aws_vol, db_disk, ec2_client
+                        )
+                        if result == "synced":
+                            stats["synced"] += 1
+                        elif result == "updated":
+                            stats["updated"] += 1
+                    else:
+                        # Volume exists in AWS but not DB - import it
+                        # Check if DB record by (user_id, disk_name) exists
+                        # without volume_id
+                        user_id = aws_vol.get("user_id")
+                        disk_name = aws_vol.get("disk_name")
+
+                        existing_record = db_by_user_disk.get(
+                            (user_id, disk_name)
+                        )
+
+                        if existing_record:
+                            # DB record exists - check for conflicts
+                            existing_vol_id = existing_record.get(
+                                "ebs_volume_id"
+                            )
+
+                            if existing_vol_id and existing_vol_id != volume_id:
+                                # Different volume_id - check if it's
+                                # a conflict or volume replacement
+                                if existing_vol_id in aws_by_volume_id:
+                                    # OLD volume still exists in AWS
+                                    # This is a REAL conflict:
+                                    # two volumes claiming same disk name
+                                    logger.error(
+                                        f"CONFLICT: DB record {disk_name} "
+                                        f"for user {user_id} has volume_id "
+                                        f"{existing_vol_id} (still in AWS) "
+                                        f"but AWS volume {volume_id} has "
+                                        f"same (user_id, disk_name). "
+                                        f"Skipping - manual intervention "
+                                        f"required."
+                                    )
+                                    stats["volume_id_conflicts"] += 1
+                                    stats["errors"] += 1
+                                    # Skip this volume, don't overwrite
+                                    continue
+                                else:
+                                    # OLD volume deleted from AWS
+                                    # This is volume replacement (OK)
+                                    logger.info(
+                                        f"Volume replacement detected: "
+                                        f"{disk_name} for user {user_id} "
+                                        f"was {existing_vol_id} (deleted), "
+                                        f"now {volume_id}. Updating DB."
+                                    )
+                                    # Fall through to update logic
+
+                            # Safe to link: volume_id is NULL, matches,
+                            # or old volume was deleted (replacement)
+                            logger.info(
+                                f"Linking DB record {disk_name} to volume "
+                                f"{volume_id}"
+                            )
+                            if update_volume_id_in_db(
+                                existing_record, volume_id, aws_vol,
+                                ec2_client
+                            ):
+                                stats["updated"] += 1
+                            else:
+                                stats["errors"] += 1
+                        else:
+                            # No DB record at all - create new one
+                            if import_volume_to_db(aws_vol, ec2_client):
+                                stats["created"] += 1
+                                logger.info(
+                                    f"Imported orphaned AWS volume "
+                                    f"{volume_id} to database"
+                                )
+                            else:
+                                stats["errors"] += 1
+                # Transaction auto-commits on success, auto-rollbacks on error
+            except Exception as vol_error:
+                # Transaction automatically rolled back by context manager
+                logger.error(
+                    f"Error reconciling volume {volume_id}: {vol_error}",
+                    exc_info=True
+                )
+                stats["errors"] += 1
+
+        # 5. Check for orphaned database records (volume deleted in AWS)
+        # Each orphaned record update is also done in a transaction
+        for volume_id, db_disk in db_by_volume_id.items():
+            if volume_id and volume_id not in aws_by_volume_id:
+                # Database record exists but volume doesn't exist in AWS
+                user_id = db_disk["user_id"]
+                disk_name = db_disk["disk_name"]
+                is_deleted = db_disk.get("is_deleted", False)
+
+                if not is_deleted:
+                    # Volume deleted in AWS but DB record is still active
+                    # Rule: Keep DB record but update in_use=False
+                    stats["orphaned_db_active"] += 1
+                    logger.warning(
+                        f"Orphaned active DB record: {disk_name} for "
+                        f"user {user_id} (volume {volume_id} not in "
+                        f"AWS) - marking in_use=False"
+                    )
+
+                    try:
+                        # Wrap orphaned record update in transaction
+                        with get_db_transaction():
+                            updates = {
+                                "in_use": False,
+                                # Keep reservation_id for historical tracking
+                                # Don't clear - allows audit of which
+                                # reservation last used this disk
+                            }
+                            update_disk(user_id, disk_name, updates)
+                            stats["updated"] += 1
+                        # Transaction auto-commits on success
+                    except Exception as update_error:
+                        # Transaction auto-rollbacks on error
+                        logger.error(
+                            f"Error updating orphaned record "
+                            f"{disk_name}: {update_error}"
+                        )
+                        stats["errors"] += 1
+                else:
+                    # Volume already marked as deleted in DB
+                    stats["orphaned_db_deleted"] += 1
+                    logger.debug(
+                        f"DB record {disk_name} already marked deleted, "
+                        f"volume {volume_id} not in AWS (expected)"
+                    )
+
+        logger.info(f"Disk reconciliation complete: {stats}")
+        return stats
+
+    except Exception as e:
+        logger.error(
+            f"Error during disk reconciliation: {e}",
+            exc_info=True
+        )
+        stats["errors"] += 1
+        return stats
+
+
+def get_all_gpudev_volumes(
+    ec2_client,
+    max_retries: int = 5
+) -> tuple[list[dict], str | None]:
+    """
+    Get all EBS volumes tagged with gpu-dev-user with retry logic.
+
+    Handles AWS API rate limiting with exponential backoff.
+
+    Args:
+        ec2_client: Boto3 EC2 client
+        max_retries: Maximum retry attempts (default: 5)
+
+    Returns:
+        Tuple of (volumes_list, error_message)
+        - volumes_list: List of volume dictionaries with parsed metadata
+        - error_message: None on success, error string on failure
+
+        This allows caller to distinguish between:
+        - ([], None): No volumes exist (legitimate empty state)
+        - ([], "error"): AWS fetch failed (don't reconcile)
+    """
+    volumes = []
+
+    for attempt in range(max_retries):
+        try:
+            # Use pagination to handle large number of volumes
+            paginator = ec2_client.get_paginator('describe_volumes')
+            page_iterator = paginator.paginate(
+                Filters=[
+                    {"Name": "tag-key", "Values": ["gpu-dev-user"]}
+                ]
+            )
+
+            for page in page_iterator:
+                for vol in page.get("Volumes", []):
+                    # Parse volume into standardized format
+                    volume_data = parse_volume_from_aws(vol)
+                    if volume_data:
+                        volumes.append(volume_data)
+
+            # Success - return volumes with no error
+            return volumes, None
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+
+            # Check if it's a throttling error
+            if error_code in [
+                "RequestLimitExceeded",
+                "Throttling",
+                "TooManyRequestsException",
+            ]:
+                if attempt < max_retries - 1:
+                    # Exponential backoff with jitter
+                    base_wait = 2 ** attempt
+                    jitter = random.uniform(0, 0.5 * base_wait)
+                    wait_time = base_wait + jitter
+
+                    logger.warning(
+                        f"AWS API throttling fetching volumes "
+                        f"(attempt {attempt + 1}/{max_retries}), "
+                        f"waiting {wait_time:.2f}s before retry"
+                    )
+                    time.sleep(wait_time)
+                    # Clear volumes list before retry
+                    volumes = []
+                    continue
+                else:
+                    # Max retries exhausted
+                    error_msg = (
+                        f"AWS API throttling: max retries "
+                        f"({max_retries}) exhausted"
+                    )
+                    logger.error(error_msg)
+                    return [], error_msg
+            else:
+                # Non-throttling error
+                error_msg = f"AWS API error: {error_code} - {str(e)}"
+                logger.error(
+                    f"AWS API error fetching volumes: "
+                    f"{error_code} - {e}",
+                    exc_info=True
+                )
+                return [], error_msg
+
+        except Exception as e:
+            error_msg = f"Unexpected error: {str(e)}"
+            logger.error(
+                f"Error fetching volumes from AWS: {e}",
+                exc_info=True
+            )
+            return [], error_msg
+
+    # Should not reach here, but return error as fallback
+    return [], "Max retries reached without success or error"
+
+
+def parse_volume_from_aws(aws_volume: dict) -> dict | None:
+    """
+    Parse AWS volume response into standardized format.
+
+    Extracts:
+    - volume_id
+    - size_gb
+    - state (available, in-use, etc.)
+    - attached_to (instance_id if attached)
+    - created_at
+    - tags (disk_name, user_id, reservation_id)
+    """
+    try:
+        # Extract tags
+        tags = {
+            tag["Key"]: tag["Value"]
+            for tag in aws_volume.get("Tags", [])
+        }
+
+        # Get attachment info
+        # AWS allows multi-attach volumes in some configurations
+        # A volume is "in use" if ANY attachment is in "attached" state
+        attachments = aws_volume.get("Attachments", [])
+
+        # Check all attachments, not just the first one
+        attached_instances = [
+            att.get("InstanceId")
+            for att in attachments
+            if att.get("State") == "attached"
+        ]
+
+        is_attached = len(attached_instances) > 0
+        # Use first attached instance for backward compatibility
+        # (most volumes have single attachment)
+        attached_instance = (
+            attached_instances[0] if attached_instances else None
+        )
+
+        # Log multi-attach volumes for observability
+        if len(attached_instances) > 1:
+            logger.info(
+                f"Volume {aws_volume['VolumeId']} has multiple "
+                f"attachments: {attached_instances}"
+            )
+
+        # Get disk_name from tags (try multiple keys)
+        disk_name = (
+            tags.get("disk-name") or
+            tags.get("disk_name") or
+            tags.get("Name")
+        )
+
+        # Get user_id from tags
+        user_id = tags.get("gpu-dev-user")
+
+        # Skip volumes without required tags
+        if not disk_name or not user_id:
+            logger.debug(
+                f"Skipping volume {aws_volume['VolumeId']}: "
+                f"missing disk_name={disk_name} or user_id={user_id}"
+            )
+            return None
+
+        return {
+            "volume_id": aws_volume["VolumeId"],
+            "size_gb": aws_volume["Size"],
+            "state": aws_volume["State"],
+            "availability_zone": aws_volume["AvailabilityZone"],
+            "created_at": aws_volume["CreateTime"],
+            "is_attached": is_attached,
+            "attached_instance": attached_instance,
+            "disk_name": disk_name,
+            "user_id": user_id,
+            "reservation_id": (
+                tags.get("reservation_id") or
+                tags.get("reservation-id")
+            ),
+            "tags": tags,
+        }
+    except Exception as e:
+        logger.error(
+            f"Error parsing volume {aws_volume.get('VolumeId')}: {e}",
+            exc_info=True
+        )
+        return None
+
+
+def sync_volume_to_db(
+    aws_vol: dict,
+    db_disk: dict,
+    ec2_client
+) -> str:
+    """
+    Sync AWS volume state into existing database record.
+
+    Returns:
+        "synced" if no updates needed
+        "updated" if updates were applied
+        "error" if update failed
+    """
+    user_id = db_disk["user_id"]
+    disk_name = db_disk["disk_name"]
+    needs_update = False
+    updates = {}
+
+    # Check for state differences
+
+    # 1. EBS Volume ID (in case it was missing before)
+    if aws_vol["volume_id"] != db_disk.get("ebs_volume_id"):
+        logger.info(
+            f"Volume ID mismatch for {disk_name}: "
+            f"AWS={aws_vol['volume_id']}, "
+            f"DB={db_disk.get('ebs_volume_id')}"
+        )
+        updates["ebs_volume_id"] = aws_vol["volume_id"]
+        needs_update = True
+
+    # 2. Volume size
+    if aws_vol["size_gb"] != db_disk.get("size_gb"):
+        logger.info(
+            f"Size mismatch for {disk_name}: "
+            f"AWS={aws_vol['size_gb']}GB, DB={db_disk.get('size_gb')}GB"
+        )
+        updates["size_gb"] = aws_vol["size_gb"]
+        needs_update = True
+
+    # 3. In-use status
+    aws_in_use = aws_vol["is_attached"]
+    db_in_use = db_disk.get("in_use", False)
+
+    if aws_in_use != db_in_use:
+        logger.info(
+            f"In-use mismatch for {disk_name}: "
+            f"AWS={aws_in_use}, DB={db_in_use}"
+        )
+        updates["in_use"] = aws_in_use
+
+        # Keep reservation_id even when detached
+        # Don't clear - disk may be temporarily detached during:
+        # - Migration between instances
+        # - Backup operations
+        # - Instance termination before reattachment
+        # Preserving reservation_id allows tracking which reservation
+        # last used this disk and aids in debugging/audit trails
+
+        needs_update = True
+
+    # 4. Snapshot count and backing up status
+    try:
+        snapshot_info = get_snapshot_info(
+            ec2_client, aws_vol["volume_id"], user_id
+        )
+
+        if snapshot_info["count"] != db_disk.get("snapshot_count", 0):
+            logger.info(
+                f"Snapshot count mismatch for {disk_name}: "
+                f"AWS={snapshot_info['count']}, "
+                f"DB={db_disk.get('snapshot_count')}"
+            )
+            updates["snapshot_count"] = snapshot_info["count"]
+            needs_update = True
+
+        if (snapshot_info["is_backing_up"] !=
+                db_disk.get("is_backing_up", False)):
+            logger.info(
+                f"Backup status mismatch for {disk_name}: "
+                f"AWS={snapshot_info['is_backing_up']}, "
+                f"DB={db_disk.get('is_backing_up')}"
+            )
+            updates["is_backing_up"] = snapshot_info["is_backing_up"]
+            needs_update = True
+
+        if snapshot_info["last_snapshot_at"]:
+            # Only update if different (compare timestamps)
+            # Normalize both to timezone-aware UTC for proper comparison
+            db_last_snapshot = db_disk.get("last_snapshot_at")
+            aws_snapshot_time = snapshot_info["last_snapshot_at"]
+
+            # Ensure both are timezone-aware UTC datetimes
+            db_last_snapshot_utc = ensure_utc(db_last_snapshot)
+            aws_snapshot_time_utc = ensure_utc(aws_snapshot_time)
+
+            if db_last_snapshot_utc != aws_snapshot_time_utc:
+                logger.info(
+                    f"Snapshot timestamp mismatch for {disk_name}: "
+                    f"DB={db_last_snapshot_utc}, AWS={aws_snapshot_time_utc}"
+                )
+                updates["last_snapshot_at"] = aws_snapshot_time_utc
+                needs_update = True
+
+    except Exception as snapshot_error:
+        logger.warning(
+            f"Error getting snapshot info for {disk_name}: "
+            f"{snapshot_error}"
+        )
+        # Continue without snapshot updates
+
+    # Apply updates if needed
+    if needs_update:
+        logger.info(
+            f"Syncing {disk_name} from AWS: {list(updates.keys())}"
+        )
+        success = update_disk(user_id, disk_name, updates)
+        return "updated" if success else "error"
+
+    return "synced"
+
+
+def update_volume_id_in_db(
+    db_disk: dict,
+    volume_id: str,
+    aws_vol: dict,
+    ec2_client
+) -> bool:
+    """
+    Update an existing DB record with volume_id from AWS and sync
+    other fields.
+
+    This handles the case where a DB record exists but is missing the
+    ebs_volume_id.
+    """
+    user_id = db_disk["user_id"]
+    disk_name = db_disk["disk_name"]
+
+    try:
+        updates = {
+            "ebs_volume_id": volume_id,
+            "size_gb": aws_vol["size_gb"],
+            "in_use": aws_vol["is_attached"],
+        }
+
+        # Keep reservation_id for historical tracking
+        # Don't clear even if not attached - preserves audit trail
+        # of which reservation last used this disk
+
+        # Get snapshot info
+        snapshot_info = get_snapshot_info(ec2_client, volume_id, user_id)
+        updates["snapshot_count"] = snapshot_info["count"]
+        updates["is_backing_up"] = snapshot_info["is_backing_up"]
+        if snapshot_info["last_snapshot_at"]:
+            updates["last_snapshot_at"] = (
+                snapshot_info["last_snapshot_at"]
+            )
+
+        logger.info(
+            f"Linking DB record {disk_name} to volume {volume_id}"
+        )
+        return update_disk(user_id, disk_name, updates)
+
+    except Exception as e:
+        logger.error(
+            f"Error updating volume_id for {disk_name}: {e}",
+            exc_info=True
+        )
+        return False
+
+
+def import_volume_to_db(aws_vol: dict, ec2_client) -> bool:
+    """
+    Import an AWS volume that doesn't exist in database.
+
+    This handles "orphaned" volumes that exist in AWS but aren't
+    tracked.
+    Per user requirements: Create entry with is_deleted=False,
+    operation_id=NULL, last_used=NULL
+    """
+    try:
+        disk_name = aws_vol.get("disk_name")
+        user_id = aws_vol.get("user_id")
+
+        if not disk_name or not user_id:
+            logger.warning(
+                f"Volume {aws_vol['volume_id']} missing disk_name or "
+                f"user_id tags, skipping"
+            )
+            return False
+
+        # Get snapshot information
+        snapshot_info = get_snapshot_info(
+            ec2_client, aws_vol["volume_id"], user_id
+        )
+
+        # Create disk record per user requirements:
+        # - is_deleted = False
+        # - operation_id = NULL (not included)
+        # - last_used = NULL (not included)
+        disk_data = {
+            "disk_name": disk_name,
+            "user_id": user_id,
+            "ebs_volume_id": aws_vol["volume_id"],
+            "size_gb": aws_vol["size_gb"],
+            "created_at": aws_vol["created_at"],
+            "in_use": aws_vol["is_attached"],
+            "reservation_id": aws_vol.get("reservation_id"),
+            "is_backing_up": snapshot_info["is_backing_up"],
+            "is_deleted": False,  # Per user requirements
+            "snapshot_count": snapshot_info["count"],
+            "last_snapshot_at": snapshot_info["last_snapshot_at"],
+            # operation_id: NULL (not set)
+            # last_used: NULL (not set)
+        }
+
+        logger.info(
+            f"Importing orphaned volume {aws_vol['volume_id']} as "
+            f"disk '{disk_name}' for user {user_id}"
+        )
+        return create_disk(disk_data)
+
+    except Exception as e:
+        logger.error(
+            f"Error importing volume {aws_vol.get('volume_id')}: {e}",
+            exc_info=True
+        )
+        return False
+
+
+def get_snapshot_info(
+    ec2_client,
+    volume_id: str,
+    user_id: str,
+    max_retries: int = 5
+) -> dict:
+    """
+    Get snapshot information for a volume with retry logic.
+
+    Handles AWS API rate limiting with exponential backoff + jitter.
+
+    Args:
+        ec2_client: Boto3 EC2 client
+        volume_id: EBS volume ID
+        user_id: User ID (for logging)
+        max_retries: Maximum retry attempts (default: 5)
+
+    Returns:
+        Dictionary with:
+        - count: Total completed snapshots
+        - is_backing_up: Whether a snapshot is in progress
+        - last_snapshot_at: Timestamp of most recent completed snapshot
+    """
+    info = {
+        "count": 0,
+        "is_backing_up": False,
+        "last_snapshot_at": None,
+    }
+
+    for attempt in range(max_retries):
+        try:
+            # Check for in-progress snapshots
+            pending_response = ec2_client.describe_snapshots(
+                OwnerIds=["self"],
+                Filters=[
+                    {"Name": "volume-id", "Values": [volume_id]},
+                    {"Name": "status", "Values": ["pending"]},
+                ]
+            )
+
+            info["is_backing_up"] = (
+                len(pending_response.get("Snapshots", [])) > 0
+            )
+
+            # Get completed snapshots
+            completed_response = ec2_client.describe_snapshots(
+                OwnerIds=["self"],
+                Filters=[
+                    {"Name": "volume-id", "Values": [volume_id]},
+                    {"Name": "status", "Values": ["completed"]},
+                ]
+            )
+
+            snapshots = completed_response.get("Snapshots", [])
+            info["count"] = len(snapshots)
+
+            if snapshots:
+                # Find most recent snapshot
+                sorted_snapshots = sorted(
+                    snapshots,
+                    key=lambda s: s["StartTime"],
+                    reverse=True
+                )
+                info["last_snapshot_at"] = (
+                    sorted_snapshots[0]["StartTime"]
+                )
+
+            return info
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+
+            # Check if it's a throttling error
+            if error_code in [
+                "RequestLimitExceeded",
+                "Throttling",
+                "TooManyRequestsException",
+            ]:
+                if attempt < max_retries - 1:
+                    # Exponential backoff with jitter
+                    base_wait = 2 ** attempt
+                    jitter = random.uniform(0, 0.5 * base_wait)
+                    wait_time = base_wait + jitter
+
+                    logger.warning(
+                        f"AWS API throttling on volume {volume_id} "
+                        f"(attempt {attempt + 1}/{max_retries}), "
+                        f"waiting {wait_time:.2f}s before retry"
+                    )
+                    time.sleep(wait_time)
+                    continue
+                else:
+                    # Max retries exhausted
+                    logger.error(
+                        f"AWS API throttling on volume {volume_id}, "
+                        f"max retries ({max_retries}) exhausted"
+                    )
+                    return info
+            else:
+                # Non-throttling error, log and return defaults
+                logger.error(
+                    f"AWS API error getting snapshots for volume "
+                    f"{volume_id}: {error_code} - {e}",
+                    exc_info=True
+                )
+                return info
+
+        except Exception as e:
+            # Unexpected error
+            logger.error(
+                f"Error getting snapshot info for volume "
+                f"{volume_id}: {e}",
+                exc_info=True
+            )
+            return info
+
+    # Should not reach here, but return defaults as fallback
+    return info
+
+
+def get_all_disks_from_db() -> list[dict]:
+    """
+    Get all disk records from database (including deleted ones for
+    reconciliation).
+    """
+    try:
+        with get_db_cursor(readonly=True) as cur:
+            cur.execute("""
+                SELECT
+                    disk_id, disk_name, user_id, ebs_volume_id, size_gb,
+                    in_use, reservation_id, is_backing_up, is_deleted,
+                    snapshot_count, last_snapshot_at, created_at,
+                    operation_id, operation_status, last_used
+                FROM disks
+                ORDER BY created_at DESC
+            """)
+
+            results = cur.fetchall()
+            return [dict(row) for row in results]
+
+    except Exception as e:
+        logger.error(
+            f"Error fetching disks from database: {e}",
+            exc_info=True
+        )
+        return []


### PR DESCRIPTION
After analyzing, it is not possible to completely get rid of the database status for disks without some substantial rewrite on part of the logic.

So, it is more reasonable to import the information of created / available / deleted / attached / detached disks from AWS.