### PR TITLE
fix: pin buildkit image to stable v0.27.0 for security

### DIFF
--- a/terraform-gpu-devservers/lambda/reservation_processor/buildkit_job.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/buildkit_job.py
@@ -104,10 +104,11 @@ def create_buildkit_job(
 
     logger.info(f"Creating BuildKit job {job_name} to build {full_image_uri}")
 
-    # BuildKit container - back to working approach
+    # BuildKit container - pinned by digest for security (tags can be moved)
+    # v0.27.0 (2026-01-21)
     buildkit_container = client.V1Container(
         name="buildkit",
-        image="moby/buildkit:master",
+        image="moby/buildkit@sha256:054d632d0d7e94b11cdc6048674773499a5170cf7d8ce0c326daaff6be43c8e0",
         command=["/bin/sh"],
         args=[
             "-c",


### PR DESCRIPTION
## Summary
- Replace `moby/buildkit:master` with `moby/buildkit@sha256:054d632d0d7e94b11cdc6048674773499a5170cf7d8ce0c326daaff6be43c8e0` (v0.27.0)
- Pin by SHA256 digest for immutability (tags can be moved/overwritten)
- Addresses vm2 sandbox escape vulnerability

## Test plan
- [ ] Verify buildkit jobs still work with pinned image
- [ ] Confirm image builds complete successfully