### PR TITLE
fix: show upgrade message when backend resources don't exist

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/auth.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/auth.py
@@ -3,7 +3,7 @@
 import subprocess
 import re
 from typing import Dict, Any
-from .config import Config
+from .config import Config, CLI_UPGRADE_MESSAGE
 from rich.spinner import Spinner
 
 
@@ -34,6 +34,9 @@ def authenticate_user(config: Config) -> Dict[str, Any]:
         }
 
     except Exception as e:
+        # Let upgrade messages pass through without re-wrapping
+        if CLI_UPGRADE_MESSAGE in str(e):
+            raise
         raise RuntimeError(f"AWS authentication failed: {e}")
 
 

--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
@@ -16,7 +16,7 @@ from rich.console import Console
 from rich.live import Live
 from rich.spinner import Spinner
 
-from .config import Config
+from .config import Config, CLI_UPGRADE_MESSAGE
 from .name_generator import sanitize_name
 from . import __version__
 
@@ -971,6 +971,13 @@ class ReservationManager:
 
             return availability_info
 
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code == "ResourceNotFoundException":
+                raise RuntimeError(CLI_UPGRADE_MESSAGE)
+            console.print(
+                f"[red]❌ Error getting GPU availability: {str(e)}[/red]")
+            return None
         except Exception as e:
             console.print(
                 f"[red]❌ Error getting GPU availability: {str(e)}[/red]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev-cli"
-version = "0.3.5"
+version = "0.3.6"
 description = "CLI tool for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"

--- a/terraform-gpu-devservers/lambda.tf
+++ b/terraform-gpu-devservers/lambda.tf
@@ -179,8 +179,8 @@ resource "aws_lambda_function" "reservation_processor" {
       HOSTED_ZONE_ID                     = local.effective_domain_name != "" ? local.hosted_zone_id : ""
       SSH_DOMAIN_MAPPINGS_TABLE          = local.effective_domain_name != "" ? aws_dynamodb_table.ssh_domain_mappings.name : ""
       SSL_CERTIFICATE_ARN                = local.effective_domain_name != "" ? aws_acm_certificate.wildcard[0].arn : ""
-      LAMBDA_VERSION                     = "0.3.5"
-      MIN_CLI_VERSION                    = "0.3.5"
+      LAMBDA_VERSION                     = "0.3.6"
+      MIN_CLI_VERSION                    = "0.3.6"
       DISK_CONTENTS_BUCKET               = aws_s3_bucket.disk_contents.bucket
     }, local.alb_env_vars)
   }


### PR DESCRIPTION
## Summary
- When SQS queue or DynamoDB tables don't exist (e.g., after infrastructure changes in test environment), show a friendly upgrade message instead of confusing AWS errors
- Bumps CLI version to 0.3.6 and MIN_CLI_VERSION to 0.3.6

## Changes
- `config.py`: Add `CLI_UPGRADE_MESSAGE` constant, catch `NonExistentQueue` error
- `auth.py`: Let upgrade messages pass through without "AWS authentication failed:" prefix
- `reservations.py`: Catch `ResourceNotFoundException` for availability table
- `pyproject.toml`: Bump version to 0.3.6
- `lambda.tf`: Bump `LAMBDA_VERSION` and `MIN_CLI_VERSION` to 0.3.6

## Test plan
- [ ] Point CLI to test environment (us-west-1) where SQS queue doesn't exist
- [ ] Run `gpu-dev avail` and verify friendly upgrade message is shown
- [ ] Verify prod environment still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)