### PR TITLE
Add gpu-dev disk clear command + fix stale lock cleanup

### DIFF
--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -1138,6 +1138,8 @@ def handler(event, context):
                         success = process_add_user_action(record)
                     elif message_body.get("action") == "extend_reservation":
                         success = process_extend_reservation_action(record)
+                    elif message_body.get("action") == "clear_disk_lock":
+                        success = process_clear_disk_lock_action(record)
                     elif message_body.get("action") == "delete_disk":
                         success = process_delete_disk_action(record)
                     elif message_body.get("action") == "create_disk":
@@ -7486,6 +7488,50 @@ def process_add_user_action(record: dict[str, Any]) -> bool:
     except Exception as e:
         logger.error(f"Error processing add user action: {str(e)}")
         return False  # Retry on processing errors
+
+
+def process_clear_disk_lock_action(record: dict[str, Any]) -> bool:
+    """Clear a stale in_use lock on a disk after verifying no active reservation."""
+    message = json.loads(record["body"])
+    user_id = message.get("user_id")
+    disk_name = message.get("disk_name")
+
+    if not all([user_id, disk_name]):
+        logger.error(f"Missing required fields in clear_disk_lock action: {message}")
+        return True
+
+    logger.info(f"Processing clear_disk_lock for disk '{disk_name}' (user: {user_id})")
+
+    reservations_table = dynamodb.Table(
+        os.environ.get('RESERVATIONS_TABLE_NAME', 'pytorch-gpu-dev-reservations')
+    )
+    active_statuses = {"active", "preparing", "queued", "pending"}
+
+    response = reservations_table.query(
+        IndexName="UserIndex",
+        KeyConditionExpression="user_id = :user_id",
+        FilterExpression="disk_name = :disk_name AND #status IN (:active, :preparing, :queued, :pending)",
+        ExpressionAttributeNames={"#status": "status"},
+        ExpressionAttributeValues={
+            ":user_id": user_id,
+            ":disk_name": disk_name,
+            ":active": "active",
+            ":preparing": "preparing",
+            ":queued": "queued",
+            ":pending": "pending"
+        }
+    )
+
+    if response.get("Items"):
+        res_id = response["Items"][0]["reservation_id"]
+        logger.warning(
+            f"Disk '{disk_name}' is attached to active reservation {res_id}, refusing to clear lock"
+        )
+        return True
+
+    mark_disk_in_use(user_id, disk_name, False)
+    logger.info(f"Cleared stale lock on disk '{disk_name}' for user '{user_id}'")
+    return True
 
 
 def process_delete_disk_action(record: dict[str, Any]) -> bool:


### PR DESCRIPTION
## Summary

- **`gpu-dev disk clear <name>`** — new user-facing command to clear stale disk locks. When a reservation expires or is cancelled but Lambda cleanup fails to clear the `in_use` flag, users get permanently stuck with "[IN USE]" on their disk. Previously the only fix was an admin script with elevated AWS permissions.
- **Fix cancellation cleanup** — moved `mark_disk_in_use(False)` outside the try block during reservation cancellation so the lock is cleared even if pod cleanup or snapshot creation fails.
- **Fix `--version`** — `@click.version_option()` now passes `package_name="gpu-dev"` so `gpu-dev --version` works (completes the fix from #32).

### How disk clear works

Users don't have `dynamodb:UpdateItem` permission, so the CLI sends a `clear_disk_lock` action through SQS. The Lambda handler verifies no active reservation is using the disk before clearing the flag.

```
gpu-dev disk clear default
```

## Test plan

- [ ] `gpu-dev --version` returns version without error
- [ ] `gpu-dev disk clear --help` shows usage
- [ ] `gpu-dev disk clear <name>` on a stale-locked disk sends SQS message and Lambda clears the lock
- [ ] `gpu-dev disk clear <name>` on a disk with an active reservation is refused by Lambda
- [ ] `gpu-dev disk clear <name>` on an unlocked disk prints "not locked" and exits
- [ ] Cancelling a reservation clears the disk lock even if pod cleanup fails