### PR TITLE
fix: use stable keys for ASG for_each to prevent index-shift disasters

### DIFF
--- a/terraform-gpu-devservers/main.tf
+++ b/terraform-gpu-devservers/main.tf
@@ -254,27 +254,27 @@ locals {
     }
     prod = {
       # Production environment capacity reservations
+      # NOTE: 'key' must match existing ASG suffix to avoid destroy/recreate.
+      # When removing a CR, delete the entry entirely - keys are stable, not index-based.
       a100 = [
-        { id = "cr-01cc0f00f28b095af", instance_count = 1 }, # A100 reservation (1 instance)
-        { id = null, instance_count = 1 }                    # A100 on-demand (1 instance)
+        { key = "cr0", id = "cr-01cc0f00f28b095af", instance_count = 1 }, # A100 reservation (1 instance)
+        { key = "cr1", id = null, instance_count = 1 },                   # A100 on-demand (1 instance)
       ]
       h100 = [
-        { id = "cr-0a7caa7414866615a", instance_count = 4 }, # H100 reservation us-east-2c (p5.48xlarge)
-        { id = null, instance_count = 2 }                    # H100 on-demand (2 instances)
+        { key = "cr0", id = "cr-0a7caa7414866615a", instance_count = 4 }, # H100 reservation us-east-2c (p5.48xlarge)
+        { key = "cr1", id = null, instance_count = 2 },                   # H100 on-demand (2 instances)
       ]
       h200 = [
-        { id = "cr-0f6d0766f5d3339e6", instance_count = 2 }, # H200 reservation us-east-2c (p5e.48xlarge)
-        { id = "cr-06c9c978dea756a26", instance_count = 3 }, # H200 reservation (3 instances)
-        { id = null, instance_count = 2 }                    # H200 on-demand (2 instances)
+        { key = "cr0", id = "cr-0f6d0766f5d3339e6", instance_count = 2 }, # H200 reservation us-east-2c (p5e.48xlarge)
+        { key = "cr1", id = "cr-06c9c978dea756a26", instance_count = 3 }, # H200 reservation (3 instances)
+        { key = "cr2", id = null, instance_count = 2 },                   # H200 on-demand (2 instances)
       ]
       b200 = [
-        { id = "cr-0c366fb8339a10f69", instance_count = 1 }, # B200 reservation (1 instance)
-        # cr-0122dff5e01d566dc removed (2 B200) - 0 instances running, CR freed for other use
-        { id = "cr-08e7fee0b8dc3de5e", instance_count = 2 }, # B200 reservation (2 of 3 - 1 freed for other use)
-        { id = null, instance_count = 1 }                    # B200 on-demand (1 instance)
+        { key = "cr0", id = "cr-0c366fb8339a10f69", instance_count = 1 }, # B200 reservation (1 instance)
+        { key = "cr1", id = "cr-08e7fee0b8dc3de5e", instance_count = 3 }, # B200 reservation (3 instances)
+        { key = "cr2", id = null, instance_count = 2 },                   # B200 on-demand (2 instances)
       ]
       # T4 and L4 don't have capacity reservations - managed via supported_gpu_types fallback
-      # This avoids destroying/recreating existing ASGs
     }
   }
 


### PR DESCRIPTION
## Summary

- Add explicit `key` field to each capacity reservation entry so the `for_each` key is derived from the entry itself, not its list index
- Removing a CR entry now only destroys that specific ASG — no more cascading index shifts that reconfigure neighboring ASGs
- Reconciles B200 instance counts with current deployed state (1+3+2=6, down from original 7)

## Context

Removing `cr-0122dff5e01d566dc` from the middle of the B200 list caused `cr2` to become `cr1` and the on-demand slot to become `cr2`. Terraform updated the ASGs in-place: `b200-cr2` went from 3 instances in us-east-2b to 1 on-demand in us-east-2a, terminating 2 nodes instantly. This killed nshulga's pod (reservation dd732f18) with no graceful shutdown or snapshot.

## Verification

`tofu plan` confirms **no changes** — the new key-based approach produces identical ASG names to the current deployed state.

## Test plan

- [x] `tofu plan` shows no changes against current infrastructure
- [ ] Future CR removal: delete one entry from the list and verify only that ASG is affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)