### PR TITLE
fix: queue reservations when no single node has enough GPUs + bin-pack pods

### DIFF
--- a/terraform-gpu-devservers/eks.tf
+++ b/terraform-gpu-devservers/eks.tf
@@ -362,7 +362,10 @@ resource "aws_launch_template" "gpu_dev_launch_template" {
     }
   }
 
-  # Add capacity reservation specification for instances that have reservations configured
+  # Capacity reservation specification:
+  # - With CR: target the specific reservation
+  # - Without CR (on-demand): explicitly set "none" so AWS doesn't auto-match
+  #   on-demand instances to targeted CRs in the same AZ (steals CR slots)
   dynamic "capacity_reservation_specification" {
     for_each = each.value.capacity_reservation_id != null ? [1] : []
     content {
@@ -370,6 +373,13 @@ resource "aws_launch_template" "gpu_dev_launch_template" {
       capacity_reservation_target {
         capacity_reservation_id = each.value.capacity_reservation_id
       }
+    }
+  }
+
+  dynamic "capacity_reservation_specification" {
+    for_each = each.value.capacity_reservation_id == null ? [1] : []
+    content {
+      capacity_reservation_preference = "none"
     }
   }
 

--- a/terraform-gpu-devservers/main.tf
+++ b/terraform-gpu-devservers/main.tf
@@ -270,9 +270,8 @@ locals {
         { key = "cr2", id = null, instance_count = 2 },                   # H200 on-demand (2 instances)
       ]
       b200 = [
-        { key = "cr0", id = "cr-0c366fb8339a10f69", instance_count = 1 }, # B200 reservation (1 instance)
-        { key = "cr1", id = "cr-08e7fee0b8dc3de5e", instance_count = 3 }, # B200 reservation (3 instances)
-        { key = "cr2", id = null, instance_count = 2 },                   # B200 on-demand (2 instances)
+        { key = "cr0", id = "cr-0c366fb8339a10f69", instance_count = 1 }, # B200 reservation (1 instance, us-east-2a)
+        { key = "cr1", id = "cr-08e7fee0b8dc3de5e", instance_count = 2 }, # B200 reservation (2 of 3 CR slots, 1 freed for other team)
       ]
       # T4 and L4 don't have capacity reservations - managed via supported_gpu_types fallback
     }


### PR DESCRIPTION
## Summary

- **Fix GPU fragmentation scheduling bug**: The availability check was summing GPUs across all nodes, so requesting 8 GPUs would see "12 available" (spread across 3 nodes as 4+3+5) and immediately try to create the pod. Since k8s requires all GPUs on a single node, the pod would get stuck `Pending` for 600s then fail. Now `check_gpu_availability` returns `(total, max_per_node)` and scheduling decisions use `max_per_node`. When no single node can fulfill the request, the reservation **queues properly** instead of creating an unschedulable pod.

- **Add pod affinity for bin-packing**: Adds a soft pod affinity (weight 50) that prefers nodes already running gpu-dev pods. This packs smaller reservations onto the same nodes, keeping whole nodes free for large (8-GPU) requests. The profiling node preference (weight 100) still takes priority.

- **Better queue messages**: When queued due to fragmentation, the message now says `"Need 8 B200 GPUs on one node, max 5 available on any single node"` instead of the misleading `"only 12 available"`.

## What was happening

```
User requests 8x B200 GPUs
→ Lambda checks: 4+3+5 = 12 B200 GPUs available ✓
→ Creates pod requesting 8 GPUs
→ k8s can't schedule: no single node has 8 free
→ Pod stuck Pending for 600s
→ Lambda times out → reservation marked "failed"
```

## What happens now

```
User requests 8x B200 GPUs
→ Lambda checks: max on single node = 5, need 8
→ Queues reservation (position #1)
→ Scheduled Lambda retries when a node frees up
```

## Test plan

- [ ] Verify 8-GPU B200 reservation queues when no single node has 8 free (instead of failing after 600s timeout)
- [ ] Verify small reservations (1-4 GPUs) still schedule immediately when capacity exists
- [ ] Verify bin-packing: new 1-GPU reservation lands on a node that already has pods (not an empty node)
- [ ] Verify queued reservations are picked up when a node fully frees up

🤖 Generated with [Claude Code](https://claude.com/claude-code)