### PR TITLE
Update BuildKit image to v0.27.1 to fix CVE-2026-22709

### DIFF
--- a/terraform-gpu-devservers/lambda/reservation_processor/buildkit_job.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/buildkit_job.py
@@ -104,11 +104,13 @@ def create_buildkit_job(
 
     logger.info(f"Creating BuildKit job {job_name} to build {full_image_uri}")
 
-    # BuildKit container - pinned by digest for security (tags can be moved)
-    # v0.27.0 (2026-01-21)
+    # BuildKit container - using tag until digest is pinned
+    # v0.27.1 (2026-01-29) - fixes CVE-2026-22709 (vm2 sandbox escape)
+    # TODO: pin by digest after verifying with:
+    #   docker buildx imagetools inspect moby/buildkit:v0.27.1
     buildkit_container = client.V1Container(
         name="buildkit",
-        image="moby/buildkit@sha256:054d632d0d7e94b11cdc6048674773499a5170cf7d8ce0c326daaff6be43c8e0",
+        image="moby/buildkit:v0.27.1",
         command=["/bin/sh"],
         args=[
             "-c",


### PR DESCRIPTION
The buildkitd container was flagged for CVE-2026-22709 (vm2 sandbox escape, critical). Updates from v0.27.0 to v0.27.1 to redeploy with patched packages.

Using tag temporarily; digest should be pinned after verification.