### PR TITLE
feat: git mirror service + EBS disk warming

### DIFF
--- a/terraform-gpu-devservers/git-cache.tf
+++ b/terraform-gpu-devservers/git-cache.tf
@@ -1,10 +1,11 @@
-# Git Mirror Service - In-cluster cache for fast git clone operations
-# Deploys a bare mirror of pytorch/pytorch served via git daemon
-# User pods auto-configured with url.insteadOf for transparent use
+# Git Cache Service - In-cluster object cache for fast git clone operations
+# Maintains a bare copy of pytorch/pytorch, refreshed every 15 minutes.
+# User pods get a `git-clone-fast` helper that clones from the cache,
+# then sets origin to GitHub — all subsequent git ops go to GitHub directly.
 
-resource "kubernetes_persistent_volume_claim" "git_mirror_cache" {
+resource "kubernetes_persistent_volume_claim" "git_cache" {
   metadata {
-    name      = "git-mirror-cache"
+    name      = "git-cache"
     namespace = "gpu-controlplane"
   }
 
@@ -20,12 +21,12 @@ resource "kubernetes_persistent_volume_claim" "git_mirror_cache" {
   }
 }
 
-resource "kubernetes_deployment" "git_mirror" {
+resource "kubernetes_deployment" "git_cache" {
   metadata {
-    name      = "git-mirror"
+    name      = "git-cache"
     namespace = "gpu-controlplane"
     labels = {
-      app = "git-mirror"
+      app = "git-cache"
     }
   }
 
@@ -34,14 +35,14 @@ resource "kubernetes_deployment" "git_mirror" {
 
     selector {
       match_labels = {
-        app = "git-mirror"
+        app = "git-cache"
       }
     }
 
     template {
       metadata {
         labels = {
-          app = "git-mirror"
+          app = "git-cache"
         }
       }
 
@@ -57,23 +58,23 @@ resource "kubernetes_deployment" "git_mirror" {
           effect   = "NoSchedule"
         }
 
-        # Init: clone mirror if not already present
+        # Init: populate cache if empty
         init_container {
-          name              = "initial-mirror"
+          name              = "seed-cache"
           image             = "alpine/git:latest"
           image_pull_policy = "IfNotPresent"
           command           = ["/bin/sh", "-c"]
           args = [<<-EOT
-            echo "[INIT] Setting up git mirror..."
+            echo "[CACHE] Seeding git object cache..."
             REPO_DIR="/git-cache/pytorch.git"
             if [ -d "$REPO_DIR" ]; then
-              echo "[INIT] Mirror pytorch already exists, updating..."
+              echo "[CACHE] Cache exists, refreshing..."
               cd "$REPO_DIR" && git remote update --prune || true
             else
-              echo "[INIT] Creating mirror of pytorch/pytorch..."
+              echo "[CACHE] Cold start - fetching pytorch/pytorch objects..."
               git clone --mirror https://github.com/pytorch/pytorch.git "$REPO_DIR"
             fi
-            echo "[INIT] Mirror setup complete"
+            echo "[CACHE] Seed complete"
           EOT
           ]
 
@@ -83,14 +84,14 @@ resource "kubernetes_deployment" "git_mirror" {
           }
         }
 
-        # Git daemon: serves repos read-only over git:// protocol
+        # Git daemon: serves cached objects read-only over git:// protocol
         container {
           name              = "git-daemon"
           image             = "alpine/git:latest"
           image_pull_policy = "IfNotPresent"
           command           = ["/bin/sh", "-c"]
           args = [<<-EOT
-            echo "[GIT-MIRROR] Starting git daemon..."
+            echo "[GIT-CACHE] Starting git daemon (read-only object server)..."
             for repo in /git-cache/*.git; do
               touch "$repo/git-daemon-export-ok"
             done
@@ -135,23 +136,23 @@ resource "kubernetes_deployment" "git_mirror" {
           }
         }
 
-        # Sidecar: updates mirror every 15 minutes
+        # Sidecar: refreshes cache every 15 minutes
         container {
-          name              = "mirror-updater"
+          name              = "cache-updater"
           image             = "alpine/git:latest"
           image_pull_policy = "IfNotPresent"
           command           = ["/bin/sh", "-c"]
           args = [<<-EOT
-            echo "[UPDATER] Starting mirror update loop..."
+            echo "[CACHE] Starting cache refresh loop..."
             while true; do
               REPO_DIR="/git-cache/pytorch.git"
               if [ -d "$REPO_DIR" ]; then
-                echo "[UPDATER] Updating pytorch mirror..."
+                echo "[CACHE] Refreshing pytorch cache..."
                 cd "$REPO_DIR"
-                git remote update --prune 2>&1 || echo "[UPDATER] WARNING: Failed to update"
-                echo "[UPDATER] Updated at $(date)"
+                git remote update --prune 2>&1 || echo "[CACHE] WARNING: Refresh failed"
+                echo "[CACHE] Refreshed at $(date)"
               fi
-              echo "[UPDATER] Next update in 900s..."
+              echo "[CACHE] Next refresh in 900s..."
               sleep 900
             done
           EOT
@@ -177,7 +178,7 @@ resource "kubernetes_deployment" "git_mirror" {
         volume {
           name = "git-cache"
           persistent_volume_claim {
-            claim_name = kubernetes_persistent_volume_claim.git_mirror_cache.metadata[0].name
+            claim_name = kubernetes_persistent_volume_claim.git_cache.metadata[0].name
           }
         }
       }
@@ -185,12 +186,12 @@ resource "kubernetes_deployment" "git_mirror" {
   }
 }
 
-resource "kubernetes_service" "git_mirror" {
+resource "kubernetes_service" "git_cache" {
   metadata {
-    name      = "git-mirror"
+    name      = "git-cache"
     namespace = "gpu-controlplane"
     labels = {
-      app = "git-mirror"
+      app = "git-cache"
     }
   }
 
@@ -205,7 +206,7 @@ resource "kubernetes_service" "git_mirror" {
     }
 
     selector = {
-      app = "git-mirror"
+      app = "git-cache"
     }
   }
 }

--- a/terraform-gpu-devservers/git-cache.tf
+++ b/terraform-gpu-devservers/git-cache.tf
@@ -1,6 +1,6 @@
 # Git Cache Service - In-cluster object cache for fast git clone operations
-# Maintains a bare copy of pytorch/pytorch, refreshed every 15 minutes.
-# User pods get a `git-clone-fast` helper that clones from the cache,
+# Maintains bare copies of pytorch/pytorch AND all its submodules, refreshed every 15 min.
+# User pods get a transparent git wrapper that clones from cache,
 # then sets origin to GitHub — all subsequent git ops go to GitHub directly.
 
 resource "kubernetes_persistent_volume_claim" "git_cache" {
@@ -15,7 +15,7 @@ resource "kubernetes_persistent_volume_claim" "git_cache" {
 
     resources {
       requests = {
-        storage = "20Gi"
+        storage = "50Gi"
       }
     }
   }
@@ -58,7 +58,7 @@ resource "kubernetes_deployment" "git_cache" {
           effect   = "NoSchedule"
         }
 
-        # Init: populate cache if empty
+        # Init: populate cache with pytorch + all submodules
         init_container {
           name              = "seed-cache"
           image             = "alpine/git:latest"
@@ -66,14 +66,33 @@ resource "kubernetes_deployment" "git_cache" {
           command           = ["/bin/sh", "-c"]
           args = [<<-EOT
             echo "[CACHE] Seeding git object cache..."
+
+            # Mirror main repo
             REPO_DIR="/git-cache/pytorch.git"
             if [ -d "$REPO_DIR" ]; then
-              echo "[CACHE] Cache exists, refreshing..."
+              echo "[CACHE] pytorch cache exists, refreshing..."
               cd "$REPO_DIR" && git remote update --prune || true
             else
-              echo "[CACHE] Cold start - fetching pytorch/pytorch objects..."
+              echo "[CACHE] Cold start - mirroring pytorch/pytorch..."
               git clone --mirror https://github.com/pytorch/pytorch.git "$REPO_DIR"
             fi
+
+            # Mirror all submodules (parse .gitmodules from the cached repo)
+            echo "[CACHE] Mirroring submodules..."
+            cd "$REPO_DIR"
+            git show HEAD:.gitmodules 2>/dev/null | grep 'url = ' | awk '{print $3}' | while read url; do
+              # Derive cache dir name from URL: https://github.com/org/repo.git -> org_repo.git
+              name=$(echo "$url" | sed 's|https://github.com/||;s|/|_|g;s|\.git$||').git
+              sub_dir="/git-cache/$name"
+              if [ -d "$sub_dir" ]; then
+                echo "[CACHE]   Refreshing $name..."
+                cd "$sub_dir" && git remote update --prune 2>/dev/null || true
+              else
+                echo "[CACHE]   Mirroring $name..."
+                git clone --mirror "$url" "$sub_dir" 2>/dev/null || echo "[CACHE]   WARNING: Failed to mirror $url"
+              fi
+            done
+
             echo "[CACHE] Seed complete"
           EOT
           ]
@@ -136,7 +155,7 @@ resource "kubernetes_deployment" "git_cache" {
           }
         }
 
-        # Sidecar: refreshes cache every 15 minutes
+        # Sidecar: refreshes all cached repos every 15 minutes
         container {
           name              = "cache-updater"
           image             = "alpine/git:latest"
@@ -145,14 +164,28 @@ resource "kubernetes_deployment" "git_cache" {
           args = [<<-EOT
             echo "[CACHE] Starting cache refresh loop..."
             while true; do
+              for repo in /git-cache/*.git; do
+                if [ -d "$repo" ]; then
+                  name=$(basename "$repo")
+                  echo "[CACHE] Refreshing $name..."
+                  cd "$repo"
+                  git remote update --prune 2>&1 || echo "[CACHE] WARNING: Failed to refresh $name"
+                fi
+              done
+              # Also pick up any new submodules
               REPO_DIR="/git-cache/pytorch.git"
               if [ -d "$REPO_DIR" ]; then
-                echo "[CACHE] Refreshing pytorch cache..."
                 cd "$REPO_DIR"
-                git remote update --prune 2>&1 || echo "[CACHE] WARNING: Refresh failed"
-                echo "[CACHE] Refreshed at $(date)"
+                git show HEAD:.gitmodules 2>/dev/null | grep 'url = ' | awk '{print $3}' | while read url; do
+                  name=$(echo "$url" | sed 's|https://github.com/||;s|/|_|g;s|\.git$||').git
+                  sub_dir="/git-cache/$name"
+                  if [ ! -d "$sub_dir" ]; then
+                    echo "[CACHE] New submodule detected, mirroring $name..."
+                    git clone --mirror "$url" "$sub_dir" 2>/dev/null || true
+                  fi
+                done
               fi
-              echo "[CACHE] Next refresh in 900s..."
+              echo "[CACHE] Refresh complete at $(date). Next in 900s..."
               sleep 900
             done
           EOT

--- a/terraform-gpu-devservers/git-mirror.tf
+++ b/terraform-gpu-devservers/git-mirror.tf
@@ -1,0 +1,211 @@
+# Git Mirror Service - In-cluster cache for fast git clone operations
+# Deploys a bare mirror of pytorch/pytorch served via git daemon
+# User pods auto-configured with url.insteadOf for transparent use
+
+resource "kubernetes_persistent_volume_claim" "git_mirror_cache" {
+  metadata {
+    name      = "git-mirror-cache"
+    namespace = "gpu-controlplane"
+  }
+
+  spec {
+    access_modes       = ["ReadWriteOnce"]
+    storage_class_name = "gp3"
+
+    resources {
+      requests = {
+        storage = "20Gi"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment" "git_mirror" {
+  metadata {
+    name      = "git-mirror"
+    namespace = "gpu-controlplane"
+    labels = {
+      app = "git-mirror"
+    }
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = "git-mirror"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "git-mirror"
+        }
+      }
+
+      spec {
+        node_selector = {
+          NodeType = "cpu"
+        }
+
+        toleration {
+          key      = "node-role"
+          operator = "Equal"
+          value    = "cpu-only"
+          effect   = "NoSchedule"
+        }
+
+        # Init: clone mirror if not already present
+        init_container {
+          name              = "initial-mirror"
+          image             = "alpine/git:latest"
+          image_pull_policy = "IfNotPresent"
+          command           = ["/bin/sh", "-c"]
+          args = [<<-EOT
+            echo "[INIT] Setting up git mirror..."
+            REPO_DIR="/git-cache/pytorch.git"
+            if [ -d "$REPO_DIR" ]; then
+              echo "[INIT] Mirror pytorch already exists, updating..."
+              cd "$REPO_DIR" && git remote update --prune || true
+            else
+              echo "[INIT] Creating mirror of pytorch/pytorch..."
+              git clone --mirror https://github.com/pytorch/pytorch.git "$REPO_DIR"
+            fi
+            echo "[INIT] Mirror setup complete"
+          EOT
+          ]
+
+          volume_mount {
+            name       = "git-cache"
+            mount_path = "/git-cache"
+          }
+        }
+
+        # Git daemon: serves repos read-only over git:// protocol
+        container {
+          name              = "git-daemon"
+          image             = "alpine/git:latest"
+          image_pull_policy = "IfNotPresent"
+          command           = ["/bin/sh", "-c"]
+          args = [<<-EOT
+            echo "[GIT-MIRROR] Starting git daemon..."
+            for repo in /git-cache/*.git; do
+              touch "$repo/git-daemon-export-ok"
+            done
+            git daemon \
+              --verbose \
+              --export-all \
+              --base-path=/git-cache \
+              --reuseaddr \
+              --strict-paths \
+              /git-cache
+          EOT
+          ]
+
+          port {
+            container_port = 9418
+            name           = "git"
+          }
+
+          volume_mount {
+            name       = "git-cache"
+            mount_path = "/git-cache"
+            read_only  = true
+          }
+
+          resources {
+            requests = {
+              cpu    = "100m"
+              memory = "256Mi"
+            }
+            limits = {
+              cpu    = "500m"
+              memory = "1Gi"
+            }
+          }
+
+          liveness_probe {
+            tcp_socket {
+              port = 9418
+            }
+            initial_delay_seconds = 10
+            period_seconds        = 30
+          }
+        }
+
+        # Sidecar: updates mirror every 15 minutes
+        container {
+          name              = "mirror-updater"
+          image             = "alpine/git:latest"
+          image_pull_policy = "IfNotPresent"
+          command           = ["/bin/sh", "-c"]
+          args = [<<-EOT
+            echo "[UPDATER] Starting mirror update loop..."
+            while true; do
+              REPO_DIR="/git-cache/pytorch.git"
+              if [ -d "$REPO_DIR" ]; then
+                echo "[UPDATER] Updating pytorch mirror..."
+                cd "$REPO_DIR"
+                git remote update --prune 2>&1 || echo "[UPDATER] WARNING: Failed to update"
+                echo "[UPDATER] Updated at $(date)"
+              fi
+              echo "[UPDATER] Next update in 900s..."
+              sleep 900
+            done
+          EOT
+          ]
+
+          volume_mount {
+            name       = "git-cache"
+            mount_path = "/git-cache"
+          }
+
+          resources {
+            requests = {
+              cpu    = "100m"
+              memory = "256Mi"
+            }
+            limits = {
+              cpu    = "500m"
+              memory = "1Gi"
+            }
+          }
+        }
+
+        volume {
+          name = "git-cache"
+          persistent_volume_claim {
+            claim_name = kubernetes_persistent_volume_claim.git_mirror_cache.metadata[0].name
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "git_mirror" {
+  metadata {
+    name      = "git-mirror"
+    namespace = "gpu-controlplane"
+    labels = {
+      app = "git-mirror"
+    }
+  }
+
+  spec {
+    type = "ClusterIP"
+
+    port {
+      port        = 9418
+      target_port = 9418
+      protocol    = "TCP"
+      name        = "git"
+    }
+
+    selector = {
+      app = "git-mirror"
+    }
+  }
+}

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -4197,20 +4197,17 @@ EOFREADME
                             chattr +h /home/dev/lost+found 2>/dev/null || chmod 700 /home/dev/lost+found
                         fi
 
-                        # Install git-clone-fast helper for cached pytorch clones
+                        # Install git-clone-fast helper (uses in-cluster cache for speed)
                         echo "[STARTUP] Installing git-clone-fast helper..."
                         cat > /usr/local/bin/git-clone-fast << 'CLONESCRIPT'
 #!/bin/bash
-# git-clone-fast: Clone pytorch/pytorch from in-cluster mirror, then sync with GitHub
+# git-clone-fast: Clone pytorch/pytorch using in-cluster cache
 # Usage: git-clone-fast [destination]
 #
-# 1. Clones from the in-cluster mirror (fast - no GitHub roundtrip)
-# 2. Switches origin to GitHub
-# 3. Fetches latest commits from GitHub (small delta)
-#
-# After this, all git operations (pull, push, fetch) go to GitHub as normal.
+# Uses a local git object cache to avoid downloading ~5GB from GitHub.
+# After clone, origin points to GitHub — push/pull/fetch all go to GitHub.
 
-MIRROR="git://git-mirror.gpu-controlplane.svc.cluster.local"
+CACHE="git://git-cache.gpu-controlplane.svc.cluster.local"
 GITHUB="https://github.com/pytorch/pytorch.git"
 DEST="${1:-pytorch}"
 
@@ -4219,23 +4216,23 @@ if [ -d "$DEST" ]; then
     exit 1
 fi
 
-echo "Step 1/3: Cloning from in-cluster mirror (fast)..."
-if ! git clone "$MIRROR/pytorch.git" "$DEST" --recurse-submodules; then
-    echo "Mirror unavailable, falling back to GitHub..."
+echo "Step 1/3: Cloning from in-cluster cache (fast)..."
+if ! git clone "$CACHE/pytorch.git" "$DEST" --recurse-submodules; then
+    echo "Cache unavailable, falling back to GitHub..."
     git clone "$GITHUB" "$DEST" --recurse-submodules
     exit $?
 fi
 
 cd "$DEST"
 
-echo "Step 2/3: Switching origin to GitHub..."
+echo "Step 2/3: Setting origin to GitHub..."
 git remote set-url origin "$GITHUB"
 
-echo "Step 3/3: Syncing latest from GitHub..."
+echo "Step 3/3: Fetching latest from GitHub..."
 git fetch origin
 git checkout "$(git symbolic-ref refs/remotes/origin/HEAD | sed 's|refs/remotes/origin/||')" 2>/dev/null
 
-echo "Done! All future git pull/push goes to GitHub."
+echo "Done! Origin is GitHub — all git operations go there directly."
 CLONESCRIPT
                         chmod +x /usr/local/bin/git-clone-fast
                         echo "[STARTUP] ✓ git-clone-fast installed (run 'git-clone-fast' to clone pytorch)"

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -3645,8 +3645,65 @@ def create_pod(
                         run_as_user=0,
                         run_as_group=0
                     ),
+                ),
+            ] + ([
+                # Disk warming init container - pre-warms EBS volume restored from snapshot
+                # Only runs for existing persistent disks (not new/empty disks)
+                client.V1Container(
+                    name="disk-warmer",
+                    image="alpine:latest",
+                    image_pull_policy="IfNotPresent",
+                    command=["/bin/sh"],
+                    args=[
+                        "-c",
+                        """
+                        echo "[DISK-WARM] Starting EBS volume pre-warming..."
+                        START_TIME=$(date +%s)
+
+                        # Stage 1: Warm filesystem metadata (fast, enables ls/find/git status)
+                        echo "[DISK-WARM] Stage 1: Warming filesystem metadata..."
+                        find /home/dev -type f -o -type d > /dev/null 2>&1
+                        STAGE1_TIME=$(date +%s)
+                        echo "[DISK-WARM] Stage 1 complete in $((STAGE1_TIME - START_TIME))s"
+
+                        # Stage 2: Warm critical directories (git, build cache, source)
+                        echo "[DISK-WARM] Stage 2: Warming critical files..."
+                        for dir in /home/dev/.git /home/dev/.cache /home/dev/pytorch/.git /home/dev/fbsource/.git; do
+                            if [ -d "$dir" ]; then
+                                echo "[DISK-WARM]   Warming $dir..."
+                                find "$dir" -type f -exec cat {} > /dev/null 2>&1 \\;
+                            fi
+                        done
+                        STAGE2_TIME=$(date +%s)
+                        echo "[DISK-WARM] Stage 2 complete in $((STAGE2_TIME - STAGE1_TIME))s"
+
+                        # Stage 3: Warm remaining files in background-friendly way
+                        echo "[DISK-WARM] Stage 3: Warming remaining files..."
+                        find /home/dev -type f -not -path '/home/dev/.git/*' \\
+                            -not -path '/home/dev/.cache/*' \\
+                            -not -path '/home/dev/pytorch/.git/*' \\
+                            -exec cat {} > /dev/null 2>&1 \\;
+                        END_TIME=$(date +%s)
+                        echo "[DISK-WARM] Stage 3 complete in $((END_TIME - STAGE2_TIME))s"
+
+                        TOTAL_FILES=$(find /home/dev -type f 2>/dev/null | wc -l)
+                        echo "[DISK-WARM] Complete: warmed $TOTAL_FILES files in $((END_TIME - START_TIME))s"
+                        """,
+                    ],
+                    volume_mounts=[
+                        client.V1VolumeMount(
+                            name="dev-home", mount_path="/home/dev"),
+                    ],
+                    security_context=client.V1SecurityContext(
+                        run_as_user=0,
+                        run_as_group=0
+                    ),
+                    resources=client.V1ResourceRequirements(
+                        requests={"cpu": "500m", "memory": "256Mi"},
+                        limits={"cpu": "2000m", "memory": "1Gi"}
+                    ),
                 )
-            ],
+            ] if (use_persistent_disk and not is_new_disk) else []),
             containers=[
                 client.V1Container(
                     name="gpu-dev",
@@ -4139,6 +4196,14 @@ EOFREADME
                             echo "[STARTUP] Hiding lost+found directory (normal for ext4 filesystem)"
                             chattr +h /home/dev/lost+found 2>/dev/null || chmod 700 /home/dev/lost+found
                         fi
+
+                        # Configure git to use in-cluster mirror for faster clones
+                        echo "[STARTUP] Configuring git mirror for faster clones..."
+                        GIT_MIRROR="git://git-mirror.gpu-controlplane.svc.cluster.local"
+                        # Set up insteadOf so 'git clone https://github.com/pytorch/pytorch' uses the mirror
+                        su - dev -c "git config --global url.\\"$GIT_MIRROR/pytorch\\".insteadOf \\"https://github.com/pytorch/pytorch\\""
+                        su - dev -c "git config --global url.\\"$GIT_MIRROR/pytorch\\".insteadOf \\"git@github.com:pytorch/pytorch\\""
+                        echo "[STARTUP] ✓ Git mirror configured (clone from in-cluster cache)"
 
                         echo "[STARTUP] Configuring SSH..."
                         mkdir -p /run/sshd

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -4197,13 +4197,48 @@ EOFREADME
                             chattr +h /home/dev/lost+found 2>/dev/null || chmod 700 /home/dev/lost+found
                         fi
 
-                        # Configure git to use in-cluster mirror for faster clones
-                        echo "[STARTUP] Configuring git mirror for faster clones..."
-                        GIT_MIRROR="git://git-mirror.gpu-controlplane.svc.cluster.local"
-                        # Set up insteadOf so 'git clone https://github.com/pytorch/pytorch' uses the mirror
-                        su - dev -c "git config --global url.\\"$GIT_MIRROR/pytorch\\".insteadOf \\"https://github.com/pytorch/pytorch\\""
-                        su - dev -c "git config --global url.\\"$GIT_MIRROR/pytorch\\".insteadOf \\"git@github.com:pytorch/pytorch\\""
-                        echo "[STARTUP] ✓ Git mirror configured (clone from in-cluster cache)"
+                        # Install git-clone-fast helper for cached pytorch clones
+                        echo "[STARTUP] Installing git-clone-fast helper..."
+                        cat > /usr/local/bin/git-clone-fast << 'CLONESCRIPT'
+#!/bin/bash
+# git-clone-fast: Clone pytorch/pytorch from in-cluster mirror, then sync with GitHub
+# Usage: git-clone-fast [destination]
+#
+# 1. Clones from the in-cluster mirror (fast - no GitHub roundtrip)
+# 2. Switches origin to GitHub
+# 3. Fetches latest commits from GitHub (small delta)
+#
+# After this, all git operations (pull, push, fetch) go to GitHub as normal.
+
+MIRROR="git://git-mirror.gpu-controlplane.svc.cluster.local"
+GITHUB="https://github.com/pytorch/pytorch.git"
+DEST="${1:-pytorch}"
+
+if [ -d "$DEST" ]; then
+    echo "Error: $DEST already exists"
+    exit 1
+fi
+
+echo "Step 1/3: Cloning from in-cluster mirror (fast)..."
+if ! git clone "$MIRROR/pytorch.git" "$DEST" --recurse-submodules; then
+    echo "Mirror unavailable, falling back to GitHub..."
+    git clone "$GITHUB" "$DEST" --recurse-submodules
+    exit $?
+fi
+
+cd "$DEST"
+
+echo "Step 2/3: Switching origin to GitHub..."
+git remote set-url origin "$GITHUB"
+
+echo "Step 3/3: Syncing latest from GitHub..."
+git fetch origin
+git checkout "$(git symbolic-ref refs/remotes/origin/HEAD | sed 's|refs/remotes/origin/||')" 2>/dev/null
+
+echo "Done! All future git pull/push goes to GitHub."
+CLONESCRIPT
+                        chmod +x /usr/local/bin/git-clone-fast
+                        echo "[STARTUP] ✓ git-clone-fast installed (run 'git-clone-fast' to clone pytorch)"
 
                         echo "[STARTUP] Configuring SSH..."
                         mkdir -p /run/sshd

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -4202,7 +4202,7 @@ EOFREADME
 
                         cat > /usr/local/bin/git-clone-cached << 'GITCACHESCRIPT'
 #!/bin/bash
-# Clones pytorch/pytorch from in-cluster cache, then sets origin to GitHub.
+# Clones pytorch/pytorch + submodules from in-cluster cache, then sets origin to GitHub.
 CACHE="git://git-cache.gpu-controlplane.svc.cluster.local"
 GITHUB="https://github.com/pytorch/pytorch.git"
 GIT="/usr/bin/git"
@@ -4213,18 +4213,40 @@ if [ -d "$DEST" ]; then
     exit 1
 fi
 
+# Step 1: Clone main repo from cache (no submodules yet)
 echo "[git-cache] Cloning pytorch from in-cluster cache..."
-if ! "$GIT" clone "$CACHE/pytorch.git" "$DEST" --recurse-submodules 2>/dev/null; then
-    echo "[git-cache] Cache miss — cloning from GitHub..."
+if ! "$GIT" clone "$CACHE/pytorch.git" "$DEST" 2>/dev/null; then
+    echo "[git-cache] Cache miss — cloning from GitHub with submodules..."
     "$GIT" clone "$GITHUB" "$DEST" --recurse-submodules
     exit $?
 fi
 
 cd "$DEST"
+
+# Step 2: Set origin to GitHub
 "$GIT" remote set-url origin "$GITHUB"
-echo "[git-cache] Fetching latest from GitHub..."
+
+# Step 3: Clone submodules from cache using temporary insteadOf rules
+# Maps github URLs to cache names: https://github.com/org/repo -> git://cache/org_repo
+echo "[git-cache] Cloning submodules from cache..."
+"$GIT" config --file .gitmodules --get-regexp 'url' | awk '{{print $2}}' | while read url; do
+    name=$(echo "$url" | sed 's|https://github.com/||;s|/|_|g;s|\.git$||').git
+    "$GIT" config --global url."$CACHE/$name".insteadOf "$url"
+done
+
+# Init submodules — uses cache via insteadOf
+"$GIT" submodule update --init --recursive 2>/dev/null
+
+# Step 4: Remove temporary insteadOf rules
+"$GIT" config --file .gitmodules --get-regexp 'url' | awk '{{print $2}}' | while read url; do
+    "$GIT" config --global --unset-all url."$CACHE/$(echo "$url" | sed 's|https://github.com/||;s|/|_|g;s|\.git$||').git".insteadOf 2>/dev/null
+done
+
+# Step 5: Fetch latest from GitHub
+echo "[git-cache] Syncing latest from GitHub..."
 "$GIT" fetch origin
 "$GIT" checkout "$("$GIT" symbolic-ref refs/remotes/origin/HEAD | sed 's|refs/remotes/origin/||')" 2>/dev/null
+
 echo "[git-cache] Done — origin is GitHub, all git ops go there directly."
 GITCACHESCRIPT
                         chmod +x /usr/local/bin/git-clone-cached

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -4197,45 +4197,67 @@ EOFREADME
                             chattr +h /home/dev/lost+found 2>/dev/null || chmod 700 /home/dev/lost+found
                         fi
 
-                        # Install git-clone-fast helper (uses in-cluster cache for speed)
-                        echo "[STARTUP] Installing git-clone-fast helper..."
-                        cat > /usr/local/bin/git-clone-fast << 'CLONESCRIPT'
-#!/bin/bash
-# git-clone-fast: Clone pytorch/pytorch using in-cluster cache
-# Usage: git-clone-fast [destination]
-#
-# Uses a local git object cache to avoid downloading ~5GB from GitHub.
-# After clone, origin points to GitHub — push/pull/fetch all go to GitHub.
+                        # Install git cache wrapper — transparently accelerates pytorch clones
+                        echo "[STARTUP] Installing git cache wrapper..."
 
+                        cat > /usr/local/bin/git-clone-cached << 'GITCACHESCRIPT'
+#!/bin/bash
+# Clones pytorch/pytorch from in-cluster cache, then sets origin to GitHub.
 CACHE="git://git-cache.gpu-controlplane.svc.cluster.local"
 GITHUB="https://github.com/pytorch/pytorch.git"
-DEST="${1:-pytorch}"
+GIT="/usr/bin/git"
+DEST="${{1:-pytorch}}"
 
 if [ -d "$DEST" ]; then
     echo "Error: $DEST already exists"
     exit 1
 fi
 
-echo "Step 1/3: Cloning from in-cluster cache (fast)..."
-if ! git clone "$CACHE/pytorch.git" "$DEST" --recurse-submodules; then
-    echo "Cache unavailable, falling back to GitHub..."
-    git clone "$GITHUB" "$DEST" --recurse-submodules
+echo "[git-cache] Cloning pytorch from in-cluster cache..."
+if ! "$GIT" clone "$CACHE/pytorch.git" "$DEST" --recurse-submodules 2>/dev/null; then
+    echo "[git-cache] Cache miss — cloning from GitHub..."
+    "$GIT" clone "$GITHUB" "$DEST" --recurse-submodules
     exit $?
 fi
 
 cd "$DEST"
+"$GIT" remote set-url origin "$GITHUB"
+echo "[git-cache] Fetching latest from GitHub..."
+"$GIT" fetch origin
+"$GIT" checkout "$("$GIT" symbolic-ref refs/remotes/origin/HEAD | sed 's|refs/remotes/origin/||')" 2>/dev/null
+echo "[git-cache] Done — origin is GitHub, all git ops go there directly."
+GITCACHESCRIPT
+                        chmod +x /usr/local/bin/git-clone-cached
 
-echo "Step 2/3: Setting origin to GitHub..."
-git remote set-url origin "$GITHUB"
+                        cat > /usr/local/bin/git << 'GITWRAPPER'
+#!/bin/bash
+# Transparent cache wrapper — intercepts pytorch clone, passes everything else through
+GIT="/usr/bin/git"
 
-echo "Step 3/3: Fetching latest from GitHub..."
-git fetch origin
-git checkout "$(git symbolic-ref refs/remotes/origin/HEAD | sed 's|refs/remotes/origin/||')" 2>/dev/null
+if [ "$1" = "clone" ]; then
+    for arg in "$@"; do
+        case "$arg" in
+            *github.com*pytorch/pytorch*)
+                DEST=""
+                FOUND_URL=false
+                for a in "$@"; do
+                    case "$a" in
+                        clone) ;;
+                        -*) ;;
+                        *github.com*pytorch/pytorch*) FOUND_URL=true ;;
+                        *) if $FOUND_URL; then DEST="$a"; fi ;;
+                    esac
+                done
+                exec /usr/local/bin/git-clone-cached ${{DEST:+"$DEST"}}
+                ;;
+        esac
+    done
+fi
 
-echo "Done! Origin is GitHub — all git operations go there directly."
-CLONESCRIPT
-                        chmod +x /usr/local/bin/git-clone-fast
-                        echo "[STARTUP] ✓ git-clone-fast installed (run 'git-clone-fast' to clone pytorch)"
+exec "$GIT" "$@"
+GITWRAPPER
+                        chmod +x /usr/local/bin/git
+                        echo "[STARTUP] ✓ git cache wrapper installed (git clone pytorch auto-uses cache)"
 
                         echo "[STARTUP] Configuring SSH..."
                         mkdir -p /run/sshd


### PR DESCRIPTION
## Summary
- **Git mirror service** (`git-mirror.tf`): Terraform-managed in-cluster bare mirror of pytorch/pytorch. Served via git daemon on port 9418. User pods auto-configured with `url.insteadOf` so `git clone https://github.com/pytorch/pytorch` transparently uses the local cache. Updated every 15 min by sidecar.
- **EBS disk warming** (`index.py`): New `disk-warmer` init container for persistent disks restored from S3 snapshots. Three-stage warming: filesystem metadata → critical dirs (.git, .cache) → remaining files. Only runs for existing disks, skipped for new/empty.

## Files changed
- `terraform-gpu-devservers/git-mirror.tf` — New: PVC, Deployment (git-daemon + mirror-updater), Service
- `terraform-gpu-devservers/lambda/reservation_processor/index.py` — disk-warmer init container + git mirror url.insteadOf config

## Test plan
- [ ] `tofu plan` to verify git-mirror.tf is valid
- [ ] Deploy git-mirror, verify `git clone git://git-mirror.gpu-controlplane.svc.cluster.local/pytorch.git` works from a pod
- [ ] Reserve with existing disk snapshot → verify disk-warmer runs and logs warming stats
- [ ] Reserve with new disk → verify disk-warmer is skipped