### PR TITLE
feat: use Karpenter for CPU node autoscaling (industry standard)

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -2441,14 +2441,17 @@ def _show_availability() -> None:
                 available = info.get("available", 0)
                 max_reservable = info.get("max_reservable", 0)
                 total = info.get("total", 0)
+                scalable_total = info.get("scalable_total", 0)
                 full_nodes_available = info.get("full_nodes_available", 0)
                 gpus_per_instance = info.get("gpus_per_instance", 0)
                 queue_length = info.get("queue_length", 0)
                 est_wait = info.get("estimated_wait_minutes", 0)
 
-                # Format wait time
+                # Format wait time — for Karpenter types, show scale-up estimate
                 if available > 0:
                     wait_display = "Available now"
+                elif scalable_total > 0 and available == 0:
+                    wait_display = "~1min (scaling up)"
                 elif est_wait == 0:
                     wait_display = "Unknown"
                 elif est_wait < 60:
@@ -2461,10 +2464,13 @@ def _show_availability() -> None:
                     else:
                         wait_display = f"{hours}h {minutes}min"
 
+                # Show total as "current / scalable" for Karpenter types
+                if scalable_total > 0:
+                    total_display = f"{total} / {scalable_total}"
+                else:
+                    total_display = str(total)
+
                 # Color code availability based on full nodes available
-                # Red: 0 GPUs available
-                # Yellow: Some GPUs available but no full node
-                # Green: At least one full node available
                 if available == 0:
                     available_display = f"[red]{available}[/red]"
                 elif full_nodes_available > 0:
@@ -2476,7 +2482,7 @@ def _show_availability() -> None:
                     gpu_type.upper(),
                     available_display,
                     str(max_reservable),
-                    str(total),
+                    total_display,
                     str(queue_length),
                     arch,
                     wait_display,
@@ -2583,12 +2589,15 @@ def _show_availability_watch(interval: int) -> None:
                             last_arch = arch
                             available = info.get("available", 0)
                             total = info.get("total", 0)
+                            scalable_total = info.get("scalable_total", 0)
                             queue_length = info.get("queue_length", 0)
                             est_wait = info.get("estimated_wait_minutes", 0)
 
                             # Format wait time
                             if available > 0:
                                 wait_display = "Available now"
+                            elif scalable_total > 0 and available == 0:
+                                wait_display = "~1min (scaling up)"
                             elif est_wait == 0:
                                 wait_display = "Unknown"
                             elif est_wait < 60:
@@ -2601,6 +2610,12 @@ def _show_availability_watch(interval: int) -> None:
                                 else:
                                     wait_display = f"{hours}h {minutes}min"
 
+                            # Show total as "current / scalable" for Karpenter types
+                            if scalable_total > 0:
+                                total_display = f"{total} / {scalable_total}"
+                            else:
+                                total_display = str(total)
+
                             # Color code availability
                             if available > 0:
                                 available_display = f"[green]{available}[/green]"
@@ -2610,7 +2625,7 @@ def _show_availability_watch(interval: int) -> None:
                             table.add_row(
                                 gpu_type.upper(),
                                 available_display,
-                                str(total),
+                                total_display,
                                 str(queue_length),
                                 arch,
                                 wait_display,

--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
@@ -959,6 +959,7 @@ class ReservationManager:
                 availability_info[gpu_type] = {
                     "available": int(item.get("available_gpus", 0)),
                     "total": int(item.get("total_gpus", 0)),
+                    "scalable_total": int(item.get("scalable_total", 0)),
                     "max_reservable": int(item.get("max_reservable", 0)),
                     "full_nodes_available": int(item.get("full_nodes_available", 0)),
                     "gpus_per_instance": int(item.get("gpus_per_instance", 0)),

--- a/terraform-gpu-devservers/eks.tf
+++ b/terraform-gpu-devservers/eks.tf
@@ -191,6 +191,7 @@ locals {
         instance_count = cr_config != null ? cr_config.instance_count : gpu_config.instance_count
       }
     ]
+    if !try(gpu_config.karpenter_managed, false) # Skip types managed by Karpenter
   ])
 
   # Convert to map for for_each

--- a/terraform-gpu-devservers/karpenter.tf
+++ b/terraform-gpu-devservers/karpenter.tf
@@ -1,0 +1,459 @@
+# Karpenter - Node autoscaler for CPU dev nodes
+# Karpenter provisions nodes on-demand when pods are pending, and consolidates when idle.
+
+locals {
+  karpenter_namespace = "kube-system"
+
+  # Extract Karpenter-managed GPU types
+  karpenter_managed_types = {
+    for gpu_type, config in local.current_config.supported_gpu_types : gpu_type => config
+    if try(config.karpenter_managed, false)
+  }
+}
+
+# --- IAM Role for Karpenter Controller (IRSA) ---
+
+resource "aws_iam_role" "karpenter_controller" {
+  name = "${local.workspace_prefix}-karpenter-controller"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.eks.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${replace(aws_eks_cluster.gpu_dev_cluster.identity[0].oidc[0].issuer, "https://", "")}:aud" = "sts.amazonaws.com"
+            "${replace(aws_eks_cluster.gpu_dev_cluster.identity[0].oidc[0].issuer, "https://", "")}:sub" = "system:serviceaccount:${local.karpenter_namespace}:karpenter"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "${var.prefix}-karpenter-controller"
+    Environment = local.current_config.environment
+  }
+}
+
+resource "aws_iam_role_policy" "karpenter_controller" {
+  name = "${local.workspace_prefix}-karpenter-controller-policy"
+  role = aws_iam_role.karpenter_controller.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:CreateFleet",
+          "ec2:CreateLaunchTemplate",
+          "ec2:CreateTags",
+          "ec2:DeleteLaunchTemplate",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeImages",
+          "ec2:DescribeInstances",
+          "ec2:DescribeInstanceTypeOfferings",
+          "ec2:DescribeInstanceTypes",
+          "ec2:DescribeLaunchTemplates",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSpotPriceHistory",
+          "ec2:DescribeSubnets",
+          "ec2:RunInstances",
+          "ec2:TerminateInstances",
+        ]
+        Resource = "*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = "iam:PassRole"
+        Resource = aws_iam_role.eks_node_role.arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "eks:DescribeCluster",
+        ]
+        Resource = aws_eks_cluster.gpu_dev_cluster.arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParameter",
+        ]
+        Resource = "arn:aws:ssm:${local.current_config.aws_region}::parameter/aws/service/eks/optimized-ami/*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "pricing:GetProducts",
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+          "sqs:GetQueueUrl",
+          "sqs:ReceiveMessage",
+        ]
+        Resource = aws_sqs_queue.karpenter_interruption.arn
+      },
+    ]
+  })
+}
+
+# --- SQS Queue for node interruption/spot events ---
+
+resource "aws_sqs_queue" "karpenter_interruption" {
+  name                      = "${var.prefix}-karpenter-interruption"
+  message_retention_seconds = 300
+  sqs_managed_sse_enabled   = true
+
+  tags = {
+    Name        = "${var.prefix}-karpenter-interruption"
+    Environment = local.current_config.environment
+  }
+}
+
+resource "aws_sqs_queue_policy" "karpenter_interruption" {
+  queue_url = aws_sqs_queue.karpenter_interruption.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = ["events.amazonaws.com", "sqs.amazonaws.com"] }
+        Action    = "sqs:SendMessage"
+        Resource  = aws_sqs_queue.karpenter_interruption.arn
+      }
+    ]
+  })
+}
+
+# EventBridge rules to forward EC2 events to Karpenter's SQS queue
+resource "aws_cloudwatch_event_rule" "karpenter_instance_state_change" {
+  name = "${var.prefix}-karpenter-instance-state"
+  event_pattern = jsonencode({
+    source      = ["aws.ec2"]
+    detail-type = ["EC2 Instance State-change Notification"]
+  })
+}
+
+resource "aws_cloudwatch_event_target" "karpenter_instance_state_change" {
+  rule = aws_cloudwatch_event_rule.karpenter_instance_state_change.name
+  arn  = aws_sqs_queue.karpenter_interruption.arn
+}
+
+resource "aws_cloudwatch_event_rule" "karpenter_spot_interruption" {
+  name = "${var.prefix}-karpenter-spot-interruption"
+  event_pattern = jsonencode({
+    source      = ["aws.ec2"]
+    detail-type = ["EC2 Spot Instance Interruption Warning"]
+  })
+}
+
+resource "aws_cloudwatch_event_target" "karpenter_spot_interruption" {
+  rule = aws_cloudwatch_event_rule.karpenter_spot_interruption.name
+  arn  = aws_sqs_queue.karpenter_interruption.arn
+}
+
+# --- Helm Release ---
+
+resource "helm_release" "karpenter" {
+  name       = "karpenter"
+  repository = "oci://public.ecr.aws/karpenter"
+  chart      = "karpenter"
+  version    = "1.1.1"
+  namespace  = local.karpenter_namespace
+
+  wait    = true
+  timeout = 600
+
+  set {
+    name  = "settings.clusterName"
+    value = aws_eks_cluster.gpu_dev_cluster.name
+  }
+
+  set {
+    name  = "settings.clusterEndpoint"
+    value = aws_eks_cluster.gpu_dev_cluster.endpoint
+  }
+
+  set {
+    name  = "settings.interruptionQueue"
+    value = aws_sqs_queue.karpenter_interruption.name
+  }
+
+  set {
+    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+    value = aws_iam_role.karpenter_controller.arn
+  }
+
+  # Run Karpenter controller on the management CPU nodes (not Karpenter-managed nodes)
+  set {
+    name  = "nodeSelector.NodeType"
+    value = "cpu-management"
+  }
+
+  set {
+    name  = "tolerations[0].operator"
+    value = "Exists"
+  }
+
+  depends_on = [
+    aws_eks_cluster.gpu_dev_cluster,
+    aws_iam_role_policy.karpenter_controller,
+    aws_autoscaling_group.cpu_nodes, # Management CPU nodes must exist first
+  ]
+}
+
+# --- EC2NodeClass per architecture ---
+
+resource "kubernetes_manifest" "karpenter_node_class_cpu_x86" {
+  manifest = {
+    apiVersion = "karpenter.k8s.aws/v1"
+    kind       = "EC2NodeClass"
+    metadata = {
+      name = "cpu-x86"
+    }
+    spec = {
+      role = aws_iam_role.eks_node_role.name
+
+      amiSelectorTerms = [
+        { alias = "al2023@latest" }
+      ]
+
+      subnetSelectorTerms = [
+        {
+          tags = {
+            "kubernetes.io/cluster/${aws_eks_cluster.gpu_dev_cluster.name}" = "shared"
+          }
+        }
+      ]
+
+      securityGroupSelectorTerms = [
+        {
+          tags = {
+            Name = "${var.prefix}-gpu-dev-sg"
+          }
+        }
+      ]
+
+      blockDeviceMappings = [
+        {
+          deviceName = "/dev/xvda"
+          ebs = {
+            volumeSize          = "500Gi"
+            volumeType          = "gp3"
+            deleteOnTermination = true
+            encrypted           = true
+          }
+        }
+      ]
+
+      # Extra user data (runs before nodeadm init — Karpenter handles cluster join)
+      userData = <<-EOT
+        #!/bin/bash
+        yum install -y htop wget
+        cat >/etc/sysctl.d/99-net.conf <<'SYSCTL'
+        net.core.rmem_default=262144000
+        net.core.rmem_max=262144000
+        net.core.wmem_default=262144000
+        net.core.wmem_max=262144000
+        SYSCTL
+        sysctl --system
+      EOT
+    }
+  }
+
+  depends_on = [helm_release.karpenter]
+}
+
+resource "kubernetes_manifest" "karpenter_node_class_cpu_arm" {
+  manifest = {
+    apiVersion = "karpenter.k8s.aws/v1"
+    kind       = "EC2NodeClass"
+    metadata = {
+      name = "cpu-arm"
+    }
+    spec = {
+      role = aws_iam_role.eks_node_role.name
+
+      amiSelectorTerms = [
+        { alias = "al2023@latest" }
+      ]
+
+      subnetSelectorTerms = [
+        {
+          tags = {
+            "kubernetes.io/cluster/${aws_eks_cluster.gpu_dev_cluster.name}" = "shared"
+          }
+        }
+      ]
+
+      securityGroupSelectorTerms = [
+        {
+          tags = {
+            Name = "${var.prefix}-gpu-dev-sg"
+          }
+        }
+      ]
+
+      blockDeviceMappings = [
+        {
+          deviceName = "/dev/xvda"
+          ebs = {
+            volumeSize          = "500Gi"
+            volumeType          = "gp3"
+            deleteOnTermination = true
+            encrypted           = true
+          }
+        }
+      ]
+
+      userData = <<-EOT
+        #!/bin/bash
+        yum install -y htop wget
+        cat >/etc/sysctl.d/99-net.conf <<'SYSCTL'
+        net.core.rmem_default=262144000
+        net.core.rmem_max=262144000
+        net.core.wmem_default=262144000
+        net.core.wmem_max=262144000
+        SYSCTL
+        sysctl --system
+      EOT
+    }
+  }
+
+  depends_on = [helm_release.karpenter]
+}
+
+# --- NodePool per CPU type ---
+
+resource "kubernetes_manifest" "karpenter_node_pool_cpu_x86" {
+  manifest = {
+    apiVersion = "karpenter.sh/v1"
+    kind       = "NodePool"
+    metadata = {
+      name = "cpu-x86"
+    }
+    spec = {
+      template = {
+        metadata = {
+          labels = {
+            NodeType = "gpu"
+            GpuType  = "cpu-x86"
+          }
+        }
+        spec = {
+          nodeClassRef = {
+            group = "karpenter.k8s.aws"
+            kind  = "EC2NodeClass"
+            name  = "cpu-x86"
+          }
+          requirements = [
+            {
+              key      = "kubernetes.io/arch"
+              operator = "In"
+              values   = ["amd64"]
+            },
+            {
+              key      = "karpenter.sh/capacity-type"
+              operator = "In"
+              values   = ["on-demand"]
+            },
+            {
+              key      = "node.kubernetes.io/instance-type"
+              operator = "In"
+              values   = [local.current_config.supported_gpu_types["cpu-x86"].instance_type]
+            },
+          ]
+
+          # Consolidate idle nodes after 30 seconds (fast scale-down)
+          expireAfter = "Never"
+        }
+      }
+
+      limits = {
+        # Max 30 nodes worth of CPU (matches previous ASG max)
+        cpu = tostring(30 * (local.current_config.environment == "prod" ? 32 : 16))
+      }
+
+      disruption = {
+        consolidationPolicy = "WhenEmptyOrUnderutilized"
+        consolidateAfter    = "60s"
+      }
+    }
+  }
+
+  depends_on = [
+    kubernetes_manifest.karpenter_node_class_cpu_x86,
+  ]
+}
+
+resource "kubernetes_manifest" "karpenter_node_pool_cpu_arm" {
+  manifest = {
+    apiVersion = "karpenter.sh/v1"
+    kind       = "NodePool"
+    metadata = {
+      name = "cpu-arm"
+    }
+    spec = {
+      template = {
+        metadata = {
+          labels = {
+            NodeType = "gpu"
+            GpuType  = "cpu-arm"
+          }
+        }
+        spec = {
+          nodeClassRef = {
+            group = "karpenter.k8s.aws"
+            kind  = "EC2NodeClass"
+            name  = "cpu-arm"
+          }
+          requirements = [
+            {
+              key      = "kubernetes.io/arch"
+              operator = "In"
+              values   = ["arm64"]
+            },
+            {
+              key      = "karpenter.sh/capacity-type"
+              operator = "In"
+              values   = ["on-demand"]
+            },
+            {
+              key      = "node.kubernetes.io/instance-type"
+              operator = "In"
+              values   = [local.current_config.supported_gpu_types["cpu-arm"].instance_type]
+            },
+          ]
+
+          expireAfter = "Never"
+        }
+      }
+
+      limits = {
+        cpu = tostring(30 * (local.current_config.environment == "prod" ? 32 : 16))
+      }
+
+      disruption = {
+        consolidationPolicy = "WhenEmptyOrUnderutilized"
+        consolidateAfter    = "60s"
+      }
+    }
+  }
+
+  depends_on = [
+    kubernetes_manifest.karpenter_node_class_cpu_arm,
+  ]
+}

--- a/terraform-gpu-devservers/lambda/availability_updater/index.py
+++ b/terraform-gpu-devservers/lambda/availability_updater/index.py
@@ -94,25 +94,31 @@ def update_gpu_availability(gpu_type: str, k8s_client=None) -> None:
             if asg["AutoScalingGroupName"].startswith(asg_name_prefix)
         ]
 
-        if not matching_asgs:
-            logger.warning(f"No ASGs found matching pattern: {asg_name_prefix}*")
-            return
-
-        asg_names = [asg["AutoScalingGroupName"] for asg in matching_asgs]
-        logger.info(f"Found {len(matching_asgs)} ASGs: {asg_names}")
-
-        # Calculate total availability metrics across all matching ASGs
-        desired_capacity = sum(asg["DesiredCapacity"] for asg in matching_asgs)
-        running_instances = sum(
-            len([
-                instance for instance in asg["Instances"]
-                if instance["LifecycleState"] == "InService"
-            ]) for asg in matching_asgs
-        )
-
         # Get GPU configuration for this type
         gpu_config = SUPPORTED_GPU_TYPES.get(gpu_type, {})
         gpus_per_instance = gpu_config.get("gpus_per_instance", 8)
+        is_karpenter_managed = gpu_config.get("karpenter_managed", False)
+
+        if not matching_asgs and not is_karpenter_managed:
+            logger.warning(f"No ASGs found matching pattern: {asg_name_prefix}* and not Karpenter-managed")
+            return
+
+        if is_karpenter_managed:
+            logger.info(f"{gpu_type} is Karpenter-managed, skipping ASG checks")
+            desired_capacity = 0
+            running_instances = 0
+        else:
+            asg_names = [asg["AutoScalingGroupName"] for asg in matching_asgs]
+            logger.info(f"Found {len(matching_asgs)} ASGs: {asg_names}")
+
+            # Calculate total availability metrics across all matching ASGs
+            desired_capacity = sum(asg["DesiredCapacity"] for asg in matching_asgs)
+            running_instances = sum(
+                len([
+                    instance for instance in asg["Instances"]
+                    if instance["LifecycleState"] == "InService"
+                ]) for asg in matching_asgs
+            )
 
         # Handle CPU-only nodes differently (they don't have GPUs)
         is_cpu_type = gpus_per_instance == 0
@@ -120,15 +126,24 @@ def update_gpu_availability(gpu_type: str, k8s_client=None) -> None:
         if is_cpu_type:
             # For CPU nodes, report instance slots (assuming 3 users per node)
             max_users_per_node = 3
+
+            # For Karpenter-managed nodes, get actual running count from K8s (not ASG)
+            if is_karpenter_managed and k8s_client is not None:
+                from kubernetes import client
+                v1 = client.CoreV1Api(k8s_client)
+                nodes = v1.list_node(label_selector=f"GpuType={gpu_type}")
+                running_instances = len([n for n in nodes.items if is_node_ready_and_schedulable(n)])
+                logger.info(f"Karpenter-managed {gpu_type}: {running_instances} nodes from K8s API")
+
             total_gpus = running_instances * max_users_per_node
             logger.info(
-                f"CPU ASG calculation: {running_instances} instances * {max_users_per_node} slots = {total_gpus} total slots")
+                f"CPU calculation: {running_instances} instances * {max_users_per_node} slots = {total_gpus} total slots")
 
             # Check actual pod usage on CPU nodes
             if k8s_client is not None:
                 try:
                     logger.info(f"Checking CPU node availability for {gpu_type}")
-                    # Count available slots by checking pod count on each node
+                    from kubernetes import client
                     v1 = client.CoreV1Api(k8s_client)
                     nodes = v1.list_node(label_selector=f"GpuType={gpu_type}")
 
@@ -223,6 +238,14 @@ def update_gpu_availability(gpu_type: str, k8s_client=None) -> None:
             full_nodes_available = available_gpus  # Each "GPU" represents one CPU node slot
             max_reservable = 1 if available_gpus > 0 else 0  # Max 1 CPU node per reservation
 
+        # For Karpenter-managed CPU types, report scalable total based on max node limit
+        scalable_total = 0
+        if is_cpu_type and is_karpenter_managed:
+            karpenter_max = gpu_config.get("karpenter_max_nodes", 0)
+            if karpenter_max > 0:
+                scalable_total = karpenter_max * max_users_per_node
+                logger.info(f"Karpenter-managed {gpu_type}: scalable_total = {karpenter_max} nodes * {max_users_per_node} = {scalable_total}")
+
         # Update DynamoDB table
         table = dynamodb.Table(AVAILABILITY_TABLE)
 
@@ -231,15 +254,13 @@ def update_gpu_availability(gpu_type: str, k8s_client=None) -> None:
                 "gpu_type": gpu_type,
                 "total_gpus": total_gpus,
                 "available_gpus": available_gpus,
+                "scalable_total": scalable_total,
                 "max_reservable": max_reservable,
                 "full_nodes_available": full_nodes_available,
                 "running_instances": running_instances,
                 "desired_capacity": desired_capacity,
                 "gpus_per_instance": gpus_per_instance,
-                "last_updated": context.aws_request_id
-                if "context" in locals()
-                else "unknown",
-                "last_updated_timestamp": int(time.time()) if "time" in dir() else 0,
+                "last_updated_timestamp": int(time.time()),
             }
         )
 

--- a/terraform-gpu-devservers/main.tf
+++ b/terraform-gpu-devservers/main.tf
@@ -95,18 +95,22 @@ locals {
         "cpu-arm" = {
           instance_type       = "c7g.4xlarge"
           instance_types      = null
-          instance_count      = 30
+          instance_count      = 0
           gpus_per_instance   = 0
           use_placement_group = false
           architecture        = "arm64"
+          karpenter_managed   = true
+          karpenter_max_nodes = 30
         }
         "cpu-x86" = {
           instance_type       = "c7i.4xlarge"
           instance_types      = null
-          instance_count      = 30
+          instance_count      = 0
           gpus_per_instance   = 0
           use_placement_group = false
           architecture        = "x86_64"
+          karpenter_managed   = true
+          karpenter_max_nodes = 30
         }
         "t4" = {
           instance_type       = "g4dn.12xlarge"
@@ -221,18 +225,22 @@ locals {
         "cpu-arm" = {
           instance_type       = "c7g.8xlarge"
           instance_types      = null
-          instance_count      = 30
+          instance_count      = 0
           gpus_per_instance   = 0
           use_placement_group = false
           architecture        = "arm64"
+          karpenter_managed   = true
+          karpenter_max_nodes = 30
         }
         "cpu-x86" = {
           instance_type       = "c7i.8xlarge"
           instance_types      = null
-          instance_count      = 30
+          instance_count      = 0
           gpus_per_instance   = 0
           use_placement_group = false
           architecture        = "x86_64"
+          karpenter_managed   = true
+          karpenter_max_nodes = 30
         }
       }
     }


### PR DESCRIPTION
## Summary

Replace fixed 60 CPU nodes with **Karpenter-managed** dynamic scaling (0-30 nodes per type). This is an alternative to PR #37's custom Lambda approach, using the **industry-standard** EKS autoscaling solution.

## Comparison: Karpenter vs Custom Lambda

| Feature | Karpenter (this PR) | Custom Lambda (PR #37) |
|---------|---------------------|------------------------|
| Scale-up speed | **~60 seconds** (event-driven) | ~3 minutes (polling) |
| Scale-down logic | Built-in consolidation with PDB | Custom instance protection code |
| Code to maintain | **~0 lines** (declarative CRDs) | ~100 lines of Python |
| Industry adoption | **AWS recommended**, battle-tested | Custom implementation |
| Reaction trigger | **Pod pending event** (immediate) | ASG lifecycle hook (delayed) |

## Architecture

**Karpenter controller:**
- Runs on management CPU nodes (2x c5.4xlarge, managed by ASG)
- Watches for pending pods with specific node selectors
- Provisions nodes in ~60s when needed
- Consolidates idle nodes after 60s

**NodePools (2):**
- `cpu-x86`: c7i.8xlarge (prod) / c7i.4xlarge (default), max 30 nodes
- `cpu-arm`: c7g.8xlarge (prod) / c7g.4xlarge (default), max 30 nodes
- Each pool: 500GB gp3 root, AL2023, on-demand only

**Interruption handling:**
- EventBridge rules forward EC2 state-change events to SQS
- Karpenter drains nodes gracefully on spot interruption

## Files changed

| File | Change |
|------|--------|
| `main.tf` | CPU types: `karpenter_managed=true`, `instance_count=0` |
| `eks.tf` | Filter Karpenter types from ASG creation (1 line: `if !try(gpu_config.karpenter_managed, false)`) |
| `karpenter.tf` | **New**: 459 lines (IAM, SQS, EventBridge, Helm, NodePools, EC2NodeClasses) |
| `availability_updater/index.py` | Handle Karpenter types (query K8s API for node count, not ASG) |
| `cli.py` + `reservations.py` | Show `"0 / 90"` scalable capacity and `"~1min (scaling up)"` |

## Test plan

- [ ] `terraform plan` — CPU ASGs removed, Karpenter resources created
- [ ] After `tf apply`: 0 CPU nodes initially, management nodes running Karpenter
- [ ] Scale-up test: reserve CPU slot → pod pending → Karpenter provisions node in ~60s → pod schedules
- [ ] Scale-down test: cancel reservation → pod deleted → Karpenter consolidates idle node in ~60s
- [ ] `gpu-dev avail` shows `0 / 90` and `~1min (scaling up)` for CPU types
- [ ] GPU ASGs completely unaffected (no `karpenter_managed` field)

## Why Karpenter?

This is the **AWS-recommended** approach for EKS autoscaling. It's:
- **Faster**: 60s vs 3min (no polling delay)
- **Event-driven**: Reacts to pod pending events immediately
- **Less code**: Replaces custom autoscaling logic with declarative CRDs
- **Battle-tested**: Used by thousands of EKS clusters in production
- **Simpler**: No custom instance protection, no ASG polling, no scale-up/down thresholds

The tradeoff is a bigger infrastructure change (Karpenter install, new IAM roles, EventBridge setup) vs the quick Lambda approach in PR #37. But for production, Karpenter is the right choice.