### PR TITLE
fix: persistent disk cleanup and fallback behavior (⚠️ UNTESTED)

### DIFF
--- a/terraform-gpu-devservers/lambda/reservation_expiry/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_expiry/index.py
@@ -1576,9 +1576,22 @@ def cleanup_pod(pod_name: str, namespace: str = "gpu-dev", reservation_data: dic
                                 logger.warning(f"Error updating DynamoDB for snapshot completion: {update_error}")
                                 # Don't fail cleanup if DynamoDB update fails
 
-                        # Step 4: Delete the EBS volume after snapshot completes
+                        # Step 4: Detach and delete the EBS volume after snapshot completes
                         try:
                             logger.info(f"Deleting EBS volume {volume_id} after successful snapshot")
+                            # Detach first if still attached (prevents VolumeInUse errors)
+                            try:
+                                vol_desc = ec2_client.describe_volumes(VolumeIds=[volume_id])
+                                attachments = vol_desc['Volumes'][0].get('Attachments', [])
+                                if attachments:
+                                    logger.info(f"Volume {volume_id} still attached to {attachments[0].get('InstanceId')} - detaching first")
+                                    ec2_client.detach_volume(VolumeId=volume_id, Force=True)
+                                    waiter = ec2_client.get_waiter('volume_available')
+                                    waiter.wait(VolumeIds=[volume_id], WaiterConfig={'Delay': 5, 'MaxAttempts': 24})
+                                    logger.info(f"Volume {volume_id} detached successfully")
+                            except Exception as detach_error:
+                                logger.warning(f"Error detaching volume {volume_id}: {detach_error}")
+
                             ec2_client.delete_volume(VolumeId=volume_id)
                             logger.info(f"Successfully deleted volume {volume_id}")
 

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -2504,23 +2504,23 @@ def allocate_gpu_resources(reservation_id: str, request: dict[str, Any]) -> None
                     logger.warning(f"Stored warning for reservation {reservation_id}: {disk_warning}")
             except Exception as disk_error:
                 logger.error(f"Failed to set up persistent disk: {disk_error}")
-
-                # Check if this is a "disk in use" error - these should fail the reservation
                 error_msg = str(disk_error)
-                if "is currently in use" in error_msg or "already in use" in error_msg:
-                    # Don't fall back - fail the reservation with clear error
+
+                # If user explicitly requested a disk (disk_name set), never silently fall back
+                # Also fail for "disk in use" errors regardless
+                if disk_name or "is currently in use" in error_msg or "already in use" in error_msg:
                     update_reservation_status(
                         reservation_id,
                         "failed",
-                        failure_reason=error_msg
+                        failure_reason=f"Persistent disk setup failed: {error_msg}"
                     )
                     raise RuntimeError(f"Cannot create reservation: {error_msg}")
 
-                # For other errors, continue without persistent disk (backwards compatibility)
+                # Only fall back to non-persistent for old-style reservations without explicit disk_name
                 logger.warning(f"Falling back to non-persistent storage due to disk error: {disk_error}")
                 use_persistent_disk = False
-                persistent_volume_id = None  # Clear any volume that was set before the error
-                is_new_disk = True  # EmptyDir volume will need shell environment setup
+                persistent_volume_id = None
+                is_new_disk = True
                 update_reservation_status(
                     reservation_id,
                     "preparing",


### PR DESCRIPTION
# ⚠️ WARNING: UNTESTED CHANGES

These changes fix real bugs but have **NOT been tested in production**. Review carefully and test before merging.

---

## Fix 1: Force-detach EBS volumes before deletion

**File**: `lambda/reservation_expiry/index.py` (+15 lines)

**Problem**: When cleaning up expired reservations with persistent disks, volume deletion fails with `VolumeInUse` error if the volume is still attached to an instance.

**Solution**: 
- Force-detach the volume before deletion
- Wait for volume to reach "available" state (up to 2 minutes)
- Then delete the volume

**Impact**: Prevents orphaned volumes that accumulate costs when cleanup fails.

---

## Fix 2: Don't silently fall back to EmptyDir when user requests persistent disk

**File**: `lambda/reservation_processor/index.py` (±8 lines)

**Problem**: When a user explicitly requests a persistent disk via `disk_name` parameter, if that disk setup fails (e.g., disk doesn't exist, disk in use), the code would silently fall back to EmptyDir instead of failing the reservation.

**Solution**:
- If `disk_name` is set by user → **fail the reservation** with clear error message
- If error is "disk in use" → **fail the reservation** (regardless of disk_name)
- Only fall back to EmptyDir for old-style reservations without explicit disk_name (backward compatibility)

**Impact**: Users get clear error messages when their disk request fails, instead of silently getting EmptyDir when they expected persistent storage.

---

## Test Plan (REQUIRED before merge)

- [ ] **Test volume cleanup**: Create reservation with persistent disk, let it expire, verify volume is detached and deleted successfully
- [ ] **Test snapshot flow**: Create reservation with persistent disk, let it expire with snapshot requested, verify snapshot completes and volume is cleaned up
- [ ] **Test explicit disk_name**: Request reservation with `disk_name` for non-existent disk, verify reservation fails with clear error (not EmptyDir fallback)
- [ ] **Test disk in use**: Request reservation with disk that's already attached, verify reservation fails with clear error
- [ ] **Test backward compatibility**: Old-style reservation without `disk_name` parameter should still fall back to EmptyDir on disk errors
- [ ] **Monitor for orphaned volumes**: Check AWS console for any EBS volumes not cleaned up properly

---

## Files Changed

- `terraform-gpu-devservers/lambda/reservation_expiry/index.py`: Add detach-before-delete logic
- `terraform-gpu-devservers/lambda/reservation_processor/index.py`: Check disk_name before fallback

**Do NOT merge until tested!**