### PR TITLE
fix: resolve silent timeout when extending reservations

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
@@ -900,14 +900,17 @@ class ReservationManager:
             ]
 
             initial_expires_at = None
+            full_reservation_id = reservation_id
             if matching_reservations:
                 initial_expires_at = matching_reservations[0].get("expires_at", "")
+                full_reservation_id = matching_reservations[0].get("reservation_id", reservation_id)
 
             # Send message to Lambda to extend reservation
             # Lambda will handle both the expiration timestamp update and any necessary pod updates
             message = {
                 "action": "extend_reservation",
-                "reservation_id": reservation_id,
+                "reservation_id": full_reservation_id,
+                "user_id": user_id,
                 "extension_hours": extension_hours,
                 "version": get_version(),
             }

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -1148,18 +1148,31 @@ def handler(event, context):
                         validate_cli_version(message_body)
                     except ValueError as version_error:
                         error_str = str(version_error)
-                        # Write error to operations table (for CLI polling)
-                        operation_id = message_body.get("operation_id")
-                        write_operation_result(operation_id, "failed", error_str)
-                        # Also update reservation status if applicable
+                        action = message_body.get("action")
                         reservation_id = message_body.get("reservation_id")
-                        if reservation_id:
-                            update_reservation_status(
-                                reservation_id=reservation_id,
-                                status="failed",
-                                detailed_status="CLI version validation failed",
-                                failure_reason=error_str
-                            )
+
+                        # For extend actions, write to extension_error so CLI polling detects it
+                        if action == "extend_reservation" and reservation_id:
+                            try:
+                                reservation = find_reservation_by_prefix(
+                                    reservation_id, message_body.get("user_id"))
+                                update_reservation_error(
+                                    reservation["reservation_id"], error_str, "extension_error")
+                            except Exception as lookup_err:
+                                logger.error(
+                                    f"Could not write extension_error for {reservation_id}: {lookup_err}")
+                        else:
+                            # Write error to operations table (for CLI polling)
+                            operation_id = message_body.get("operation_id")
+                            write_operation_result(operation_id, "failed", error_str)
+                            # Also update reservation status if applicable
+                            if reservation_id:
+                                update_reservation_status(
+                                    reservation_id=reservation_id,
+                                    status="failed",
+                                    detailed_status="CLI version validation failed",
+                                    failure_reason=error_str
+                                )
                         logger.error(f"Version validation failed: {error_str}")
                         delete_sqs_message(record)
                         continue
@@ -7952,6 +7965,7 @@ def process_extend_reservation_action(record: dict[str, Any]) -> bool:
         message = json.loads(record["body"])
         reservation_id = message.get("reservation_id")
         extension_hours = message.get("extension_hours")
+        user_id = message.get("user_id")
 
         if not all([reservation_id, extension_hours]):
             logger.error(
@@ -7962,7 +7976,7 @@ def process_extend_reservation_action(record: dict[str, Any]) -> bool:
             f"Processing extend reservation: {reservation_id} by {extension_hours} hours")
 
         try:
-            reservation = find_reservation_by_prefix(reservation_id)
+            reservation = find_reservation_by_prefix(reservation_id, user_id)
             full_reservation_id = reservation["reservation_id"]
             logger.info(
                 f"Found reservation {full_reservation_id} (prefix: {reservation_id})")


### PR DESCRIPTION
## Summary
- Extend reservation requests silently timed out after 3 minutes because errors were never communicated back to the CLI polling loop
- Two root causes: (1) CLI sent short prefix ID in SQS message, so Lambda version check errors wrote to phantom DynamoDB records instead of the real reservation; (2) version check error handler wrote to `failure_reason`/`status` fields but CLI only checks `extension_error` and `expires_at`
- CLI now sends full reservation_id + user_id in extend SQS message
- Lambda version check handler now properly writes to `extension_error` for extend actions
- Lambda extend processor now uses `user_id` for efficient UserIndex query instead of full table scan

## Test plan
- [ ] Run `gpu-dev edit <id>` and extend a reservation - verify it completes successfully
- [ ] Test with an old CLI version (< MIN_CLI_VERSION) - verify CLI shows version error instead of silent timeout
- [ ] Verify extend still respects 48h max duration limit