### PR TITLE
fix: pin websockets<13.0 to fix non-interactive SSH commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "rich>=13.7.0",
     "pyyaml>=6.0.1",
     "questionary>=2.1.1",
-    "websockets>=12.0",
+    "websockets>=12.0,<13.0",
     "certifi>=2023.7.22",
     "mcp>=1.0.0",
 ]

--- a/terraform-gpu-devservers/ssh-proxy/requirements.txt
+++ b/terraform-gpu-devservers/ssh-proxy/requirements.txt
@@ -1,2 +1,2 @@
 boto3>=1.26.0
-websockets>=12.0
+websockets>=12.0,<13.0


### PR DESCRIPTION
## Summary

- Pin `websockets` to `>=12.0,<13.0` in both the server-side ECS proxy (`terraform-gpu-devservers/ssh-proxy/requirements.txt`) and the client-side CLI (`pyproject.toml`)
- Fixes non-interactive SSH commands (`ssh host command`) being broken while interactive SSH still works

## Root Cause

websockets 13.x introduced breaking changes:
- **Server handler signature change**: The `path` parameter was removed from the server handler in 13.x, breaking the proxy server's connection handler
- **Connection close behavior change**: 13.x changed how connection close is sequenced, breaking non-interactive SSH commands that rely on clean stdin EOF -> close ordering

The SSH tunnel architecture (`User SSH -> ProxyCommand (gpu-dev-ssh-proxy, WebSocket client) -> ALB -> ECS Fargate proxy.py (WebSocket server) -> Pod SSH`) depends on both sides using compatible websockets behavior. Non-interactive commands send their input and then close stdin, expecting the WebSocket to cleanly propagate the close -- this sequencing broke in 13.x.

## Why `>=12.0,<13.0` instead of `==12.0`

Using a range pin allows minor/patch updates within the 12.x series (e.g., security fixes) while blocking the breaking 13.x+ changes.

## Test plan

- [ ] Verify interactive SSH still works: `ssh -F ~/.devgpu/<id>-sshconfig <pod>`
- [ ] Verify non-interactive SSH works: `ssh -F ~/.devgpu/<id>-sshconfig <pod> nvidia-smi`
- [ ] Verify CLI install picks up websockets 12.x: `pip show websockets`
- [ ] Redeploy ECS proxy service to pick up pinned server-side dependency