### PR TITLE
fix: persist disk fields in DynamoDB for queued reservations

### DIFF
--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -1850,6 +1850,14 @@ def process_reservation_request(record: dict[str, Any]) -> bool:
                 if reservation_request.get("dockerimage"):
                     initial_record["dockerimage"] = reservation_request["dockerimage"]
 
+                # Store disk preferences so queued reservations retain them
+                if reservation_request.get("disk_name"):
+                    initial_record["disk_name"] = reservation_request["disk_name"]
+                if "no_persistent_disk" in reservation_request:
+                    initial_record["no_persistent_disk"] = reservation_request["no_persistent_disk"]
+                if "recreate_env" in reservation_request:
+                    initial_record["recreate_env"] = reservation_request["recreate_env"]
+
                 # Store initial record
                 reservations_table = dynamodb.Table(RESERVATIONS_TABLE)
                 reservations_table.put_item(Item=initial_record)
@@ -2260,6 +2268,13 @@ def create_reservation(request: dict[str, Any]) -> str:
             reservation["cli_version"] = request["version"]
         if "preserve_entrypoint" in request:
             reservation["preserve_entrypoint"] = request["preserve_entrypoint"]
+        # Store disk preferences so queued reservations retain them
+        if "disk_name" in request:
+            reservation["disk_name"] = request["disk_name"]
+        if "no_persistent_disk" in request:
+            reservation["no_persistent_disk"] = request["no_persistent_disk"]
+        if "recreate_env" in request:
+            reservation["recreate_env"] = request["recreate_env"]
         # Store Lambda version that processed this reservation
         reservation["lambda_version"] = LAMBDA_VERSION
 


### PR DESCRIPTION
## Summary

- Stores `disk_name`, `no_persistent_disk`, and `recreate_env` fields in DynamoDB when reservations are created, so they survive the queued-to-processing transition

## Problem

When a user requests a GPU reservation with a persistent disk (or explicitly opts out via `--no-persistent-disk`), the CLI sends `disk_name`, `no_persistent_disk`, and `recreate_env` fields in the SQS message. The Lambda has two processing paths:

1. **Immediate allocation** (GPUs available): `process_reservation_request()` calls `create_reservation()` then `allocate_gpu_resources()` directly with the original SQS message data -- all fields are present and disk preferences work correctly.

2. **Queued allocation** (GPUs not available): `process_reservation_request()` creates an initial DynamoDB record and sets status to `"queued"`. Later, the scheduled queue processor reads the reservation back from DynamoDB and calls `allocate_gpu_resources()` with the DynamoDB record as the request dict.

The bug: neither the initial record creation (line ~1826) nor `create_reservation()` (line ~2236) stored the disk-related fields. When the queue processor later read the reservation from DynamoDB and passed it to `allocate_gpu_resources()`, the fields were missing, causing `disk_name` to be `None`, `no_persistent_disk` to default to `False`, and `recreate_env` to default to `False` -- effectively ignoring the user's disk preferences.

## Fix

Added `disk_name`, `no_persistent_disk`, and `recreate_env` to both:
- The initial DynamoDB record in `process_reservation_request()` (persists fields when reservation is first created)
- The reservation dict in `create_reservation()` (persists fields when reservation transitions to preparing)

## Test plan

- [ ] Reserve with `--disk-name myproject` when GPUs are fully occupied -- verify the queued reservation gets a persistent disk named `myproject` once GPUs free up
- [ ] Reserve with `--no-persistent-disk` when GPUs are fully occupied -- verify the queued reservation gets temporary storage (EmptyDir) once GPUs free up
- [ ] Reserve with `--recreate-env` when GPUs are fully occupied -- verify the environment is recreated from scratch once GPUs free up
- [ ] Reserve when GPUs are immediately available (no queuing) -- verify existing behavior is unchanged