### PR TITLE
feat: Add `gpu-dev get-ssh-config` command for secondary users

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -2807,13 +2807,58 @@ def connect(ctx: click.Context, reservation_id: Optional[str]) -> None:
             rprint("[red]❌ No SSH command available for this node[/red]")
             return
 
+        # Auto-download SSH config if missing
+        from pathlib import Path
+        gpu_dev_dir = Path.home() / ".gpu-dev"
+        short_id = reservation_id[:8]
+        config_file = gpu_dev_dir / f"{short_id}-sshconfig"
+
+        if not config_file.exists():
+            rprint("[yellow]⚠️  SSH config not found, downloading...[/yellow]")
+
+            # Extract connection details from the connection_info
+            if is_multinode:
+                pod_name = selected_node.get("pod_name")
+                fqdn = selected_node.get("fqdn")
+                node_res_id = selected_node.get("reservation_id")
+                node_name = selected_node.get("name")
+            else:
+                pod_name = connection_info.get("pod_name")
+                fqdn = connection_info.get("fqdn")
+                node_res_id = reservation_id
+                node_name = connection_info.get("name")
+
+            if fqdn and pod_name and node_res_id:
+                from gpu_dev_cli.reservations import create_ssh_config_for_reservation
+                config_path, use_include = create_ssh_config_for_reservation(
+                    fqdn, pod_name, node_res_id, node_name
+                )
+                if config_path:
+                    rprint(f"[green]✅ SSH config created: {config_path}[/green]\n")
+                else:
+                    rprint("[yellow]⚠️  Failed to create SSH config, attempting connection anyway...[/yellow]\n")
+            else:
+                rprint("[yellow]⚠️  Missing connection details, attempting connection anyway...[/yellow]\n")
+
         # Add agent forwarding if not already present
         if "-A" not in ssh_command and "-o ForwardAgent=yes" not in ssh_command:
             ssh_command = ssh_command.replace("ssh ", "ssh -A ", 1)
 
-        # Parse and execute the command
+        # Parse and execute the command, capturing exit code for auth failures
         rprint(f"[dim]Executing: {ssh_command}[/dim]\n")
-        subprocess.run(ssh_command, shell=True)
+        result = subprocess.run(ssh_command, shell=True)
+
+        # Check for auth failure (SSH exits with code 255 for connection/auth errors)
+        if result.returncode == 255:
+            # Try to extract primary username from connection info
+            primary_user = connection_info.get("user_id", "the-primary-user")
+            current_user = user_info.get("user_id", "your-github-username")
+
+            rprint("\n[red]❌ Authentication failed. You don't have SSH access to this reservation.[/red]\n")
+            rprint(f"[cyan]Ask the primary user ([yellow]{primary_user}[/yellow]) to add you:[/cyan]")
+            rprint(f"[dim]   gpu-dev edit {reservation_id[:8]} --add-user {current_user}[/dim]\n")
+            rprint(f"[cyan]Then download your SSH config:[/cyan]")
+            rprint(f"[dim]   gpu-dev get-ssh-config {reservation_id[:8]}[/dim]\n")
 
     except KeyboardInterrupt:
         rprint("\n[yellow]Connection cancelled by user[/yellow]")

--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -2742,10 +2742,69 @@ def connect(ctx: click.Context, reservation_id: Optional[str]) -> None:
                 f"[red]❌ Reservation is not active (status: {connection_info['status']})[/red]")
             return
 
-        # Extract SSH command and execute it
-        ssh_command = connection_info.get("ssh_command", "")
+        # Check if this is a multi-node reservation
+        is_multinode = connection_info.get("is_multinode", False)
+
+        if is_multinode:
+            # Multi-node reservation - show node selection
+            nodes = connection_info.get("nodes", [])
+            if not nodes:
+                rprint("[red]❌ No nodes found for multi-node reservation[/red]")
+                return
+
+            # Check if all nodes are active
+            active_nodes = [n for n in nodes if n.get("status") == "active"]
+            if not active_nodes:
+                rprint("[red]❌ No active nodes in multi-node reservation[/red]")
+                return
+
+            # Show node selection
+            rprint(f"\n[cyan]🎯 Multi-node reservation with {len(nodes)} nodes:[/cyan]\n")
+
+            from rich.table import Table
+            table = Table(show_header=True, header_style="bold cyan", box=None)
+            table.add_column("Node", style="cyan")
+            table.add_column("Pod Name", style="green")
+            table.add_column("Status", style="yellow")
+            table.add_column("Command", style="dim")
+
+            for node in nodes:
+                status_display = "✅ Active" if node.get("status") == "active" else f"⏳ {node.get('status', 'unknown')}"
+                pod_name = node.get("pod_name", "unknown")
+                ssh_cmd_short = f"ssh {pod_name}" if pod_name != "unknown" else "N/A"
+
+                table.add_row(
+                    f"Node {node.get('node_index', 0) + 1}",
+                    pod_name,
+                    status_display,
+                    ssh_cmd_short
+                )
+
+            console.print(table)
+
+            # Interactive selection
+            from rich.prompt import Prompt
+            node_choices = [str(i+1) for i in range(len(active_nodes))]
+            node_choice = Prompt.ask(
+                "\n[cyan]Select node to connect to[/cyan]",
+                choices=node_choices + ["q"],
+                default="1"
+            )
+
+            if node_choice == "q":
+                rprint("[yellow]Connection cancelled[/yellow]")
+                return
+
+            selected_node = nodes[int(node_choice) - 1]
+            ssh_command = selected_node.get("ssh_command", "")
+            node_num = selected_node.get('node_index', 0) + 1
+            rprint(f"\n[cyan]Connecting to Node {node_num}...[/cyan]")
+        else:
+            # Single-node reservation
+            ssh_command = connection_info.get("ssh_command", "")
+
         if not ssh_command:
-            rprint("[red]❌ No SSH command available for this reservation[/red]")
+            rprint("[red]❌ No SSH command available for this node[/red]")
             return
 
         # Add agent forwarding if not already present

--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -2821,6 +2821,170 @@ def connect(ctx: click.Context, reservation_id: Optional[str]) -> None:
         rprint(f"[red]❌ Error: {str(e)}[/red]")
 
 
+@main.command(name="get-ssh-config")
+@click.argument("reservation_id", required=False)
+@click.pass_context
+def get_ssh_config_cmd(ctx: click.Context, reservation_id: Optional[str]) -> None:
+    """Download SSH config for a reservation (useful for added users)
+
+    Generates SSH config file for a reservation. Particularly useful for secondary
+    users added via --add-user who don't have the SSH config automatically created.
+
+    If no reservation ID is provided, shows your active reservations and lets you select one.
+
+    \b
+    Examples:
+        gpu-dev get-ssh-config                  # Interactive mode - select reservation
+        gpu-dev get-ssh-config abc12345         # Get config for reservation abc12345
+        gpu-dev get-ssh-config abc1             # Short form works too
+
+    This creates ~/.gpu-dev/<id>-sshconfig file for the reservation.
+
+    \b
+    For added users:
+    1. Original user: gpu-dev edit abc123 --add-user friend-username
+    2. Added user: gpu-dev get-ssh-config abc123
+    3. Added user: ssh gpu-dev-abc123 (or gpu-dev connect abc123)
+    """
+    try:
+        with Live(
+            Spinner("dots", text="📡 Fetching reservation details..."), console=console
+        ) as live:
+            config = load_config()
+
+            # Authenticate
+            try:
+                user_info = authenticate_user(config)
+                reservation_mgr = ReservationManager(config)
+            except RuntimeError as e:
+                live.stop()
+                rprint(f"[red]❌ {str(e)}[/red]")
+                return
+
+            # If no reservation ID provided, show interactive selection
+            if reservation_id is None:
+                reservations = reservation_mgr.list_reservations(
+                    user_filter=user_info["user_id"],
+                    statuses_to_include=["active"]
+                )
+
+                live.stop()
+
+                if not reservations:
+                    rprint("[yellow]📋 No active reservations found[/yellow]")
+                    return
+
+                if len(reservations) == 1:
+                    # Auto-select if only one active reservation
+                    reservation_id = reservations[0].get("reservation_id")
+                    rprint(
+                        f"[cyan]Getting SSH config for reservation {reservation_id[:8]}...[/cyan]\n")
+                else:
+                    # Interactive selection
+                    rprint("[cyan]🎯 Select reservation to get SSH config for:[/cyan]")
+                    selected_id = select_reservation_interactive(
+                        reservations, "get SSH config")
+                    if selected_id is None or selected_id == "__QUIT__":
+                        rprint("[yellow]Cancelled.[/yellow]")
+                        return
+                    reservation_id = selected_id
+                    rprint(
+                        f"\n[cyan]Getting SSH config for reservation {reservation_id[:8]}...[/cyan]\n")
+
+                live.start()
+
+            # Get connection info
+            connection_info = reservation_mgr.get_connection_info(
+                reservation_id, user_info["user_id"]
+            )
+
+        live.stop()
+
+        if not connection_info:
+            rprint(
+                f"[red]❌ Could not get connection info for {reservation_id}[/red]")
+            return
+
+        if connection_info["status"] != "active":
+            rprint(
+                f"[red]❌ Reservation is not active (status: {connection_info['status']})[/red]")
+            return
+
+        # Check if multi-node
+        is_multinode = connection_info.get("is_multinode", False)
+
+        if is_multinode:
+            # Multi-node - create configs for all nodes
+            nodes = connection_info.get("nodes", [])
+            if not nodes:
+                rprint("[red]❌ No nodes found for multi-node reservation[/red]")
+                return
+
+            rprint(f"[cyan]📁 Creating SSH configs for {len(nodes)} nodes...[/cyan]\n")
+
+            for node in nodes:
+                node_res_id = node.get("reservation_id")
+                pod_name = node.get("pod_name")
+                fqdn = node.get("fqdn")
+                node_name = node.get("name")
+                node_idx = node.get("node_index", 0)
+
+                if not fqdn or not pod_name or not node_res_id:
+                    rprint(f"[yellow]⚠️  Skipping Node {node_idx + 1}: Missing connection details[/yellow]")
+                    continue
+
+                config_path, use_include = create_ssh_config_for_reservation(
+                    fqdn, pod_name, node_res_id, node_name
+                )
+
+                if config_path:
+                    if use_include:
+                        rprint(f"[green]✅ Node {node_idx + 1}:[/green] [cyan]ssh {pod_name}[/cyan]")
+                    else:
+                        rprint(f"[green]✅ Node {node_idx + 1}:[/green] [cyan]ssh -F {config_path} {pod_name}[/cyan]")
+                else:
+                    rprint(f"[yellow]⚠️  Node {node_idx + 1}: Failed to create SSH config[/yellow]")
+
+            rprint(f"\n[green]✅ SSH configs created for all {len(nodes)} nodes[/green]")
+        else:
+            # Single-node - create one config
+            pod_name = connection_info.get("pod_name")
+            fqdn = connection_info.get("fqdn")
+            res_name = connection_info.get("name")
+
+            if not fqdn:
+                # Try to extract from ssh_command
+                ssh_command = connection_info.get("ssh_command", "")
+                import re
+                match = re.search(r'ssh.*?@([^\s]+)', ssh_command)
+                if match:
+                    fqdn = match.group(1)
+
+            if not fqdn or not pod_name:
+                rprint("[red]❌ Missing connection details (fqdn or pod_name)[/red]")
+                return
+
+            config_path, use_include = create_ssh_config_for_reservation(
+                fqdn, pod_name, reservation_id, res_name
+            )
+
+            if config_path:
+                rprint(f"[green]✅ SSH config created:[/green] [cyan]{config_path}[/cyan]\n")
+                if use_include:
+                    rprint(f"[green]🎉 You can now connect with:[/green] [cyan]ssh {pod_name}[/cyan]")
+                    rprint(f"[dim]   or:[/dim] [cyan]gpu-dev connect {reservation_id[:8]}[/cyan]")
+                else:
+                    rprint(f"[green]🎉 You can now connect with:[/green] [cyan]ssh -F {config_path} {pod_name}[/cyan]")
+                    rprint(f"[dim]   or:[/dim] [cyan]gpu-dev connect {reservation_id[:8]}[/cyan]")
+            else:
+                rprint("[red]❌ Failed to create SSH config[/red]")
+
+    except KeyboardInterrupt:
+        rprint("\n[yellow]Cancelled by user[/yellow]")
+    except Exception as e:
+        rprint(f"[red]❌ Error: {str(e)}[/red]")
+
+
 @main.command()
 @click.pass_context
 def help(ctx: click.Context) -> None:
@@ -3349,6 +3513,9 @@ def edit(
                 )
                 rprint(
                     f"[blue]💡 {add_user} can now SSH to the server using their GitHub SSH keys[/blue]"
+                )
+                rprint(
+                    f"[blue]💡 Tell {add_user} to run:[/blue] [cyan]gpu-dev get-ssh-config {reservation_id[:8]}[/cyan]"
                 )
             else:
                 rprint(f"[red]❌ Failed to add user {add_user}[/red]")

--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
@@ -900,14 +900,17 @@ class ReservationManager:
             ]
 
             initial_expires_at = None
+            full_reservation_id = reservation_id
             if matching_reservations:
                 initial_expires_at = matching_reservations[0].get("expires_at", "")
+                full_reservation_id = matching_reservations[0].get("reservation_id", reservation_id)
 
             # Send message to Lambda to extend reservation
             # Lambda will handle both the expiration timestamp update and any necessary pod updates
             message = {
                 "action": "extend_reservation",
-                "reservation_id": reservation_id,
+                "reservation_id": full_reservation_id,
+                "user_id": user_id,
                 "extension_hours": extension_hours,
                 "version": get_version(),
             }

--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
@@ -768,6 +768,7 @@ class ReservationManager:
                 "secondary_users": reservation.get("secondary_users", []),
                 "warning": reservation.get("warning", ""),
                 "is_multinode": is_multinode,
+                "fqdn": reservation.get("fqdn", ""),
             }
 
             # If multi-node, fetch all nodes in the group

--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
@@ -701,7 +701,10 @@ class ReservationManager:
     def get_connection_info(
         self, reservation_id: str, user_id: str
     ) -> Optional[Dict[str, Any]]:
-        """Get SSH connection information for a reservation"""
+        """Get SSH connection information for a reservation
+
+        For multi-node reservations, returns info for all nodes in the group.
+        """
         try:
             # Query by user first (efficient), then filter by reservation_id prefix
             response = self.reservations_table.query(
@@ -734,7 +737,12 @@ class ReservationManager:
 
             reservation = matching_reservations[0]
 
-            return {
+            # Check if this is part of a multi-node group
+            is_multinode = reservation.get("is_multinode", False)
+            master_reservation_id = reservation.get("master_reservation_id")
+
+            # Build base connection info
+            connection_info = {
                 "ssh_command": reservation.get("ssh_command", "ssh user@pending"),
                 "pod_name": reservation.get("pod_name", "pending"),
                 "namespace": reservation.get("namespace", "default"),
@@ -759,7 +767,37 @@ class ReservationManager:
                 "ebs_volume_id": reservation.get("ebs_volume_id", ""),
                 "secondary_users": reservation.get("secondary_users", []),
                 "warning": reservation.get("warning", ""),
+                "is_multinode": is_multinode,
             }
+
+            # If multi-node, fetch all nodes in the group
+            if is_multinode and master_reservation_id:
+                # Find all reservations with the same master_reservation_id
+                multinode_reservations = [
+                    res for res in all_reservations
+                    if res.get("master_reservation_id") == master_reservation_id
+                ]
+
+                # Sort by node_index
+                multinode_reservations.sort(key=lambda r: r.get("node_index", 0))
+
+                # Add multi-node specific info
+                connection_info["total_nodes"] = len(multinode_reservations)
+                connection_info["nodes"] = []
+
+                for node_res in multinode_reservations:
+                    node_info = {
+                        "reservation_id": node_res.get("reservation_id"),
+                        "pod_name": node_res.get("pod_name"),
+                        "ssh_command": node_res.get("ssh_command", "ssh user@pending"),
+                        "node_index": node_res.get("node_index", 0),
+                        "status": node_res.get("status"),
+                        "name": node_res.get("name"),
+                        "fqdn": node_res.get("fqdn"),
+                    }
+                    connection_info["nodes"].append(node_info)
+
+            return connection_info
 
         except Exception as e:
             console.print(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "rich>=13.7.0",
     "pyyaml>=6.0.1",
     "questionary>=2.1.1",
-    "websockets>=12.0",
+    "websockets>=12.0,<13.0",
     "certifi>=2023.7.22",
     "mcp>=1.0.0",
 ]

--- a/terraform-gpu-devservers/docker/Dockerfile
+++ b/terraform-gpu-devservers/docker/Dockerfile
@@ -59,6 +59,63 @@ ENV CUDA_13_PATH=/usr/local/cuda-13.0
 ENV PATH=/usr/local/cuda-12.8/bin:/usr/local/cuda-13.0/bin:${PATH}
 ENV LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64:/usr/local/cuda-13.0/lib64:${LD_LIBRARY_PATH}
 
+# Install EFA support for multi-node GPU communication
+# Build dependencies for AWS OFI-NCCL plugin
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        autoconf \
+        automake \
+        libtool \
+        pkg-config \
+        libhwloc-dev \
+        pciutils \
+        kmod \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install AWS EFA installer (includes libfabric, EFA tools, and OpenMPI with EFA support)
+# Version 1.47.0 is the latest stable release as of Jan 2025
+RUN cd /tmp && \
+    curl -O https://efa-installer.amazonaws.com/aws-efa-installer-1.47.0.tar.gz && \
+    tar -xf aws-efa-installer-1.47.0.tar.gz && \
+    cd aws-efa-installer && \
+    ./efa_installer.sh -y --skip-kmod --skip-limit-conf --no-verify --mpi=openmpi4 && \
+    cd / && \
+    rm -rf /tmp/aws-efa-installer*
+
+# Build and install AWS OFI-NCCL plugin (bridges NCCL to libfabric/EFA)
+# This is the critical component that allows NCCL to use EFA for inter-node communication
+# Using master branch (verified working with NCCL 2.25.1)
+RUN cd /tmp && \
+    git clone https://github.com/aws/aws-ofi-nccl.git && \
+    cd aws-ofi-nccl && \
+    ./autogen.sh && \
+    ./configure --prefix=/opt/aws-ofi-nccl \
+                --with-libfabric=/opt/amazon/efa \
+                --with-cuda=/usr/local/cuda \
+                --with-mpi=/opt/amazon/openmpi && \
+    make -j$(nproc) && \
+    make install && \
+    cd / && \
+    rm -rf /tmp/aws-ofi-nccl
+
+# Clone NCCL tests for performance benchmarking (not building yet, will build at runtime if needed)
+RUN cd /opt && \
+    git clone https://github.com/NVIDIA/nccl-tests.git && \
+    cd nccl-tests && \
+    echo "NCCL tests cloned, build with: make MPI=1 MPI_HOME=/opt/amazon/openmpi CUDA_HOME=/usr/local/cuda"
+
+# Set environment variables for EFA and NCCL
+ENV PATH=/opt/amazon/openmpi/bin:/opt/amazon/efa/bin:${PATH}
+ENV LD_LIBRARY_PATH=/opt/aws-ofi-nccl/lib:/opt/amazon/openmpi/lib:/opt/amazon/efa/lib:${LD_LIBRARY_PATH}
+ENV FI_PROVIDER=efa
+ENV FI_EFA_USE_DEVICE_RDMA=1
+ENV NCCL_DEBUG=INFO
+ENV NCCL_NET_PLUGIN=/opt/aws-ofi-nccl/lib/libnccl-net.so
+ENV NCCL_ALGO=ring,tree
+ENV NCCL_IB_HCA=^mlx
+ENV SUPPORTS_EFA=true
+
 # Install Python packages (Jupyter and common ML packages)
 RUN pip install --no-cache-dir \
         jupyterlab \

--- a/terraform-gpu-devservers/docker/shell_env
+++ b/terraform-gpu-devservers/docker/shell_env
@@ -6,6 +6,18 @@ export CUDA_HOME=/usr/local/cuda
 export PATH="/usr/local/cuda/bin:$PATH"
 export LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-}"
 
+# EFA and OpenMPI environment for multi-node GPU communication
+export PATH="/opt/amazon/openmpi/bin:/opt/amazon/efa/bin:$PATH"
+export LD_LIBRARY_PATH="/opt/aws-ofi-nccl/lib:/opt/amazon/openmpi/lib:/opt/amazon/efa/lib:${LD_LIBRARY_PATH:-}"
+
+# NCCL settings for EFA
+export FI_PROVIDER=efa
+export FI_EFA_USE_DEVICE_RDMA=1
+export NCCL_DEBUG=INFO
+export NCCL_NET_PLUGIN=/opt/aws-ofi-nccl/lib/libnccl-net.so
+export NCCL_ALGO=ring,tree
+export NCCL_IB_HCA=^mlx
+
 # Node.js user global packages (for Claude CLI)
 export PATH="$HOME/.npm-global/bin:$PATH"
 

--- a/terraform-gpu-devservers/lambda/reservation_expiry/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_expiry/index.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import Any
 
 import boto3
+from boto3.dynamodb.conditions import Attr
 from kubernetes import client, stream
 
 from shared import setup_kubernetes_client
@@ -424,262 +425,10 @@ def handler(event, context):
                         f"Failed to expire stuck preparing reservation {reservation_id}: {e}"
                     )
 
-        # Clean up failed reservations that might have orphaned pods
-        try:
-            failed_response = reservations_table.query(
-                IndexName="StatusIndex",
-                KeyConditionExpression="#status = :status",
-                ExpressionAttributeNames={"#status": "status"},
-                ExpressionAttributeValues={":status": "failed"},
-            )
-            failed_reservations = failed_response.get("Items", [])
-            logger.info(f"Found {len(failed_reservations)} failed reservations")
-
-            # Clean up failed reservations that have pods (created in the last 24 hours to avoid processing old ones)
-            FAILED_CLEANUP_WINDOW = 24 * 3600  # 24 hours
-            failed_cleanup_threshold = current_time - FAILED_CLEANUP_WINDOW
-
-            for reservation in failed_reservations:
-                reservation_id = reservation["reservation_id"]
-                pod_name = reservation.get("pod_name")
-
-                if not pod_name:
-                    continue  # No pod to clean up
-
-                # Check if failed recently (within cleanup window)
-                failed_at = reservation.get(
-                    "failed_at", reservation.get("created_at", "")
-                )
-                try:
-                    if isinstance(failed_at, str):
-                        failed_timestamp = int(
-                            datetime.fromisoformat(
-                                failed_at.replace("Z", "+00:00")
-                            ).timestamp()
-                        )
-                    else:
-                        failed_timestamp = int(failed_at)
-
-                    if failed_timestamp < failed_cleanup_threshold:
-                        continue  # Too old, skip cleanup
-
-                except (ValueError, AttributeError):
-                    continue  # Can't parse timestamp, skip
-
-                # Check if pod actually exists before trying to clean it up
-                if not check_pod_exists(pod_name):
-                    logger.debug(f"Pod {pod_name} for failed reservation {reservation_id[:8]} already deleted")
-                    # Pod gone but disk might still be marked in_use - clean it up
-                    user_id = reservation.get("user_id")
-                    disk_name = reservation.get("disk_name")
-
-                    # Fallback: if disk_name not in reservation, look it up from disks table
-                    if user_id and not disk_name:
-                        disk_name = find_disk_by_reservation(user_id, reservation_id)
-
-                    if user_id and disk_name:
-                        try:
-                            mark_disk_not_in_use(user_id, disk_name)
-                            logger.info(f"Cleared disk '{disk_name}' in_use flag for failed reservation {reservation_id[:8]} (pod already deleted)")
-                        except Exception as disk_error:
-                            logger.warning(f"Failed to clear disk in_use flag for {reservation_id[:8]}: {disk_error}")
-                    continue
-
-                logger.info(
-                    f"Cleaning up failed reservation {reservation_id[:8]} with pod {pod_name}"
-                )
-                try:
-                    cleanup_pod(pod_name, reservation_data=reservation)
-                    logger.info(
-                        f"Successfully cleaned up failed reservation {reservation_id[:8]}"
-                    )
-                except Exception as e:
-                    logger.error(
-                        f"Failed to cleanup failed reservation {reservation_id[:8]}: {e}"
-                    )
-
-        except Exception as e:
-            logger.error(f"Error processing failed reservations: {e}")
-
-        # Pod-centric cleanup: Check all running pods and clean up those with failed/cancelled/expired reservations
-        try:
-            logger.info("Starting pod-centric cleanup - checking all running gpu-dev pods")
-
-            # Get Kubernetes client
-            k8s_client = get_k8s_client()
-            v1 = client.CoreV1Api(k8s_client)
-
-            # List all pods in gpu-dev namespace with gpu-dev- prefix
-            pod_list = v1.list_namespaced_pod(
-                namespace="gpu-dev",
-                label_selector=""  # Get all pods, we'll filter by name
-            )
-
-            gpu_dev_pods = [pod for pod in pod_list.items if pod.metadata.name.startswith("gpu-dev-")]
-            logger.info(f"Found {len(gpu_dev_pods)} gpu-dev pods to check")
-
-            pods_cleaned = 0
-            for pod in gpu_dev_pods:
-                pod_name = pod.metadata.name
-
-                # Extract reservation ID from pod name (format: gpu-dev-{reservation_id})
-                if not pod_name.startswith("gpu-dev-"):
-                    continue
-
-                reservation_id_prefix = pod_name[8:]  # Remove "gpu-dev-" prefix (this is truncated)
-
-                try:
-                    # Look up reservation by prefix using paginated scan (pod names are truncated)
-                    items = []
-                    last_evaluated_key = None
-
-                    # Scan all pages to find the reservation
-                    while True:
-                        if last_evaluated_key:
-                            scan_response = reservations_table.scan(
-                                FilterExpression="begins_with(reservation_id, :prefix)",
-                                ExpressionAttributeValues={":prefix": reservation_id_prefix},
-                                ExclusiveStartKey=last_evaluated_key
-                            )
-                        else:
-                            scan_response = reservations_table.scan(
-                                FilterExpression="begins_with(reservation_id, :prefix)",
-                                ExpressionAttributeValues={":prefix": reservation_id_prefix}
-                            )
-
-                        items.extend(scan_response.get("Items", []))
-
-                        # Check if there are more pages
-                        last_evaluated_key = scan_response.get("LastEvaluatedKey")
-                        if not last_evaluated_key or items:  # Stop if we found items or no more pages
-                            break
-
-                    if not items:
-                        logger.warning(f"Pod {pod_name} has no corresponding reservation in DynamoDB (searched prefix: {reservation_id_prefix}) - keeping pod")
-                        continue
-
-                    # Use the first matching reservation (there should only be one with this prefix)
-                    reservation = items[0]
-                    reservation_id = reservation.get("reservation_id", "")
-                    reservation_status = reservation.get("status", "")
-
-                    # Clean up pod if reservation is in a terminal state
-                    if reservation_status in ["failed", "cancelled", "expired"]:
-                        logger.info(f"Cleaning up pod {pod_name} - reservation status: {reservation_status}")
-                        try:
-                            cleanup_pod(pod_name, reservation_data=reservation)
-                            pods_cleaned += 1
-                            logger.info(f"Successfully cleaned up pod {pod_name} with {reservation_status} reservation")
-                        except Exception as cleanup_error:
-                            logger.error(f"Failed to cleanup pod {pod_name} with {reservation_status} reservation: {cleanup_error}")
-                    else:
-                        logger.debug(f"Pod {pod_name} has active reservation status: {reservation_status}")
-
-                except Exception as e:
-                    logger.error(f"Error checking reservation status for pod {pod_name}: {e}")
-                    continue
-
-            logger.info(f"Pod-centric cleanup completed - cleaned up {pods_cleaned} pods")
-
-        except Exception as e:
-            logger.error(f"Error in pod-centric cleanup: {e}")
-
-        # Also keep the original expired/cancelled reservation cleanup for redundancy
-        try:
-            expired_statuses = ["expired", "cancelled"]
-            expired_cancelled_reservations = []
-
-            for status in expired_statuses:
-                response = reservations_table.query(
-                    IndexName="StatusIndex",
-                    KeyConditionExpression="#status = :status",
-                    ExpressionAttributeNames={"#status": "status"},
-                    ExpressionAttributeValues={":status": status},
-                )
-                expired_cancelled_reservations.extend(response.get("Items", []))
-
-            logger.info(f"Found {len(expired_cancelled_reservations)} expired/cancelled reservations for redundant cleanup")
-
-            # Clean up pods from expired/cancelled reservations (within last 7 days to avoid processing very old ones)
-            EXPIRED_CLEANUP_WINDOW = 7 * 24 * 3600  # 7 days
-            expired_cleanup_threshold = current_time - EXPIRED_CLEANUP_WINDOW
-
-            for reservation in expired_cancelled_reservations:
-                reservation_id = reservation["reservation_id"]
-                pod_name = reservation.get("pod_name")
-
-                if not pod_name:
-                    continue  # No pod to clean up
-
-                # Check if expired/cancelled recently (within cleanup window)
-                expired_at = reservation.get("expired_at", reservation.get("cancelled_at", ""))
-                if not expired_at:
-                    continue  # No expiry/cancel timestamp
-
-                try:
-                    if isinstance(expired_at, str):
-                        expired_timestamp = int(
-                            datetime.fromisoformat(
-                                expired_at.replace("Z", "+00:00")
-                            ).timestamp()
-                        )
-                    else:
-                        expired_timestamp = int(expired_at)
-
-                    if expired_timestamp < expired_cleanup_threshold:
-                        continue  # Too old, skip cleanup
-
-                except (ValueError, AttributeError):
-                    continue  # Can't parse timestamp, skip
-
-                # Check if pod actually exists before trying to clean it up
-                if not check_pod_exists(pod_name):
-                    logger.debug(f"Pod {pod_name} for {reservation.get('status', 'unknown')} reservation {reservation_id[:8]} already deleted")
-                    # Pod gone but disk might still be marked in_use - clean it up
-                    user_id = reservation.get("user_id")
-                    disk_name = reservation.get("disk_name")
-
-                    # Fallback: if disk_name not in reservation, look it up from disks table
-                    if user_id and not disk_name:
-                        disk_name = find_disk_by_reservation(user_id, reservation_id)
-
-                    if user_id and disk_name:
-                        try:
-                            mark_disk_not_in_use(user_id, disk_name)
-                            logger.info(f"Cleared disk '{disk_name}' in_use flag for {reservation.get('status', 'unknown')} reservation {reservation_id[:8]} (pod already deleted)")
-                        except Exception as disk_error:
-                            logger.warning(f"Failed to clear disk in_use flag for {reservation_id[:8]}: {disk_error}")
-                    continue
-
-                logger.info(
-                    f"Redundant cleanup: {reservation.get('status', 'unknown')} reservation {reservation_id[:8]} with pod {pod_name}"
-                )
-                try:
-                    cleanup_pod(pod_name, reservation_data=reservation)
-                    logger.info(
-                        f"Successfully cleaned up {reservation.get('status', 'unknown')} reservation {reservation_id[:8]}"
-                    )
-                except Exception as e:
-                    logger.error(
-                        f"Failed to cleanup {reservation.get('status', 'unknown')} reservation {reservation_id[:8]}: {e}"
-                    )
-
-        except Exception as e:
-            logger.error(f"Error processing expired/cancelled reservations: {e}")
-
-        # Also check for stale queued/pending reservations
-        stale_statuses = ["queued", "pending"]
-        stale_reservations = []
-        for status in stale_statuses:
-            response = reservations_table.query(
-                IndexName="StatusIndex",
-                KeyConditionExpression="#status = :status",
-                ExpressionAttributeNames={"#status": "status"},
-                ExpressionAttributeValues={":status": status},
-            )
-            stale_reservations.extend(response.get("Items", []))
-
-        logger.info(f"Found {len(stale_reservations)} queued/pending reservations")
+        # =====================================================================
+        # CRITICAL PATH: Process expiry and warnings FIRST (lightweight)
+        # These must run before heavy cleanup to avoid Lambda timeout
+        # =====================================================================
 
         warning_threshold = current_time + (WARNING_MINUTES * 60)
         stale_threshold = current_time - (
@@ -807,6 +556,20 @@ def handler(event, context):
                     except Exception as e:
                         logger.warning(f"Error checking OOM status for reservation {reservation_id[:8]}: {e}")
 
+        # Check for stale queued/pending reservations
+        stale_statuses = ["queued", "pending"]
+        stale_reservations = []
+        for status in stale_statuses:
+            response = reservations_table.query(
+                IndexName="StatusIndex",
+                KeyConditionExpression="#status = :status",
+                ExpressionAttributeNames={"#status": "status"},
+                ExpressionAttributeValues={":status": status},
+            )
+            stale_reservations.extend(response.get("Items", []))
+
+        logger.info(f"Found {len(stale_reservations)} queued/pending reservations")
+
         # Process stale queued/pending reservations
         for reservation in stale_reservations:
             created_at = reservation.get("created_at", "")
@@ -829,13 +592,281 @@ def handler(event, context):
                 )
                 continue
 
-            # Cancel if stale (>5 minutes in queued/pending state)
+            # Cancel if stale (>48 hours in queued/pending state)
             if created_timestamp < stale_threshold:
                 logger.info(
                     f"Cancelling stale {reservation['status']} reservation {reservation_id}"
                 )
                 cancel_stale_reservation(reservation)
                 stale_cancelled_count += 1
+
+        # Sweep stale disk locks (orphaned by terminated reservations)
+        sweep_stale_disk_locks()
+
+        # =====================================================================
+        # HEAVY CLEANUP: These operations can be slow and may not complete
+        # =====================================================================
+
+        # Clean up failed reservations that might have orphaned pods
+        try:
+            failed_response = reservations_table.query(
+                IndexName="StatusIndex",
+                KeyConditionExpression="#status = :status",
+                ExpressionAttributeNames={"#status": "status"},
+                ExpressionAttributeValues={":status": "failed"},
+            )
+            failed_reservations = failed_response.get("Items", [])
+            logger.info(f"Found {len(failed_reservations)} failed reservations")
+
+            # Clean up failed reservations that have pods (created in the last 24 hours to avoid processing old ones)
+            FAILED_CLEANUP_WINDOW = 24 * 3600  # 24 hours
+            failed_cleanup_threshold = current_time - FAILED_CLEANUP_WINDOW
+
+            for reservation in failed_reservations:
+                reservation_id = reservation["reservation_id"]
+                pod_name = reservation.get("pod_name")
+
+                if not pod_name:
+                    continue  # No pod to clean up
+
+                # Check if failed recently (within cleanup window)
+                failed_at = reservation.get(
+                    "failed_at", reservation.get("created_at", "")
+                )
+                try:
+                    if isinstance(failed_at, str):
+                        failed_timestamp = int(
+                            datetime.fromisoformat(
+                                failed_at.replace("Z", "+00:00")
+                            ).timestamp()
+                        )
+                    else:
+                        failed_timestamp = int(failed_at)
+
+                    if failed_timestamp < failed_cleanup_threshold:
+                        continue  # Too old, skip cleanup
+
+                except (ValueError, AttributeError):
+                    continue  # Can't parse timestamp, skip
+
+                # Check if pod actually exists before trying to clean it up
+                if not check_pod_exists(pod_name):
+                    logger.debug(f"Pod {pod_name} for failed reservation {reservation_id[:8]} already deleted")
+                    # Pod gone but disk might still be marked in_use - clean it up
+                    user_id = reservation.get("user_id")
+                    disk_name = reservation.get("disk_name")
+
+                    # Fallback: if disk_name not in reservation, look it up from disks table
+                    if user_id and not disk_name:
+                        disk_name = find_disk_by_reservation(user_id, reservation_id)
+
+                    if user_id and disk_name:
+                        try:
+                            mark_disk_not_in_use(user_id, disk_name)
+                            logger.info(f"Cleared disk '{disk_name}' in_use flag for failed reservation {reservation_id[:8]} (pod already deleted)")
+                        except Exception as disk_error:
+                            logger.warning(f"Failed to clear disk in_use flag for {reservation_id[:8]}: {disk_error}")
+                    continue
+
+                logger.info(
+                    f"Cleaning up failed reservation {reservation_id[:8]} with pod {pod_name}"
+                )
+                try:
+                    cleanup_pod(pod_name, reservation_data=reservation)
+                    logger.info(
+                        f"Successfully cleaned up failed reservation {reservation_id[:8]}"
+                    )
+                except Exception as e:
+                    logger.error(
+                        f"Failed to cleanup failed reservation {reservation_id[:8]}: {e}"
+                    )
+
+        except Exception as e:
+            logger.error(f"Error processing failed reservations: {e}")
+
+        # Pod-centric cleanup: Check all running pods and clean up those with failed/cancelled/expired reservations
+        try:
+            logger.info("Starting pod-centric cleanup - checking all running gpu-dev pods")
+
+            # Get Kubernetes client
+            k8s_client = get_k8s_client()
+            v1 = client.CoreV1Api(k8s_client)
+
+            # List all pods in gpu-dev namespace with gpu-dev- prefix
+            pod_list = v1.list_namespaced_pod(
+                namespace="gpu-dev",
+                label_selector=""  # Get all pods, we'll filter by name
+            )
+
+            gpu_dev_pods = [pod for pod in pod_list.items if pod.metadata.name.startswith("gpu-dev-")]
+            logger.info(f"Found {len(gpu_dev_pods)} gpu-dev pods to check")
+
+            pods_cleaned = 0
+            for pod in gpu_dev_pods:
+                # Time budget: stop cleanup if less than 2 minutes remaining
+                remaining_ms = context.get_remaining_time_in_millis()
+                if remaining_ms < 120_000:
+                    logger.warning(
+                        f"Time budget exhausted ({remaining_ms}ms remaining) - "
+                        f"stopping pod-centric cleanup after {pods_cleaned} pods cleaned"
+                    )
+                    break
+
+                pod_name = pod.metadata.name
+
+                # Extract reservation ID from pod name (format: gpu-dev-{reservation_id})
+                if not pod_name.startswith("gpu-dev-"):
+                    continue
+
+                reservation_id_prefix = pod_name[8:]  # Remove "gpu-dev-" prefix (this is truncated)
+
+                try:
+                    # Look up reservation by prefix using paginated scan (pod names are truncated)
+                    items = []
+                    last_evaluated_key = None
+
+                    # Scan all pages to find the reservation
+                    while True:
+                        if last_evaluated_key:
+                            scan_response = reservations_table.scan(
+                                FilterExpression="begins_with(reservation_id, :prefix)",
+                                ExpressionAttributeValues={":prefix": reservation_id_prefix},
+                                ExclusiveStartKey=last_evaluated_key
+                            )
+                        else:
+                            scan_response = reservations_table.scan(
+                                FilterExpression="begins_with(reservation_id, :prefix)",
+                                ExpressionAttributeValues={":prefix": reservation_id_prefix}
+                            )
+
+                        items.extend(scan_response.get("Items", []))
+
+                        # Check if there are more pages
+                        last_evaluated_key = scan_response.get("LastEvaluatedKey")
+                        if not last_evaluated_key or items:  # Stop if we found items or no more pages
+                            break
+
+                    if not items:
+                        logger.warning(f"Pod {pod_name} has no corresponding reservation in DynamoDB (searched prefix: {reservation_id_prefix}) - keeping pod")
+                        continue
+
+                    # Use the first matching reservation (there should only be one with this prefix)
+                    reservation = items[0]
+                    reservation_id = reservation.get("reservation_id", "")
+                    reservation_status = reservation.get("status", "")
+
+                    # Clean up pod if reservation is in a terminal state
+                    if reservation_status in ["failed", "cancelled", "expired"]:
+                        logger.info(f"Cleaning up pod {pod_name} - reservation status: {reservation_status}")
+                        try:
+                            cleanup_pod(pod_name, reservation_data=reservation)
+                            pods_cleaned += 1
+                            logger.info(f"Successfully cleaned up pod {pod_name} with {reservation_status} reservation")
+                        except Exception as cleanup_error:
+                            logger.error(f"Failed to cleanup pod {pod_name} with {reservation_status} reservation: {cleanup_error}")
+                    else:
+                        logger.debug(f"Pod {pod_name} has active reservation status: {reservation_status}")
+
+                except Exception as e:
+                    logger.error(f"Error checking reservation status for pod {pod_name}: {e}")
+                    continue
+
+            logger.info(f"Pod-centric cleanup completed - cleaned up {pods_cleaned} pods")
+
+        except Exception as e:
+            logger.error(f"Error in pod-centric cleanup: {e}")
+
+        # Also keep the original expired/cancelled reservation cleanup for redundancy
+        try:
+            expired_statuses = ["expired", "cancelled"]
+            expired_cancelled_reservations = []
+
+            for status in expired_statuses:
+                response = reservations_table.query(
+                    IndexName="StatusIndex",
+                    KeyConditionExpression="#status = :status",
+                    ExpressionAttributeNames={"#status": "status"},
+                    ExpressionAttributeValues={":status": status},
+                )
+                expired_cancelled_reservations.extend(response.get("Items", []))
+
+            logger.info(f"Found {len(expired_cancelled_reservations)} expired/cancelled reservations for redundant cleanup")
+
+            # Clean up pods from expired/cancelled reservations (within last 7 days to avoid processing very old ones)
+            EXPIRED_CLEANUP_WINDOW = 7 * 24 * 3600  # 7 days
+            expired_cleanup_threshold = current_time - EXPIRED_CLEANUP_WINDOW
+
+            for reservation in expired_cancelled_reservations:
+                # Time budget: stop if less than 2 minutes remaining
+                remaining_ms = context.get_remaining_time_in_millis()
+                if remaining_ms < 120_000:
+                    logger.warning(
+                        f"Time budget exhausted ({remaining_ms}ms remaining) - "
+                        f"stopping redundant cleanup"
+                    )
+                    break
+
+                reservation_id = reservation["reservation_id"]
+                pod_name = reservation.get("pod_name")
+
+                if not pod_name:
+                    continue  # No pod to clean up
+
+                # Check if expired/cancelled recently (within cleanup window)
+                expired_at = reservation.get("expired_at", reservation.get("cancelled_at", ""))
+                if not expired_at:
+                    continue  # No expiry/cancel timestamp
+
+                try:
+                    if isinstance(expired_at, str):
+                        expired_timestamp = int(
+                            datetime.fromisoformat(
+                                expired_at.replace("Z", "+00:00")
+                            ).timestamp()
+                        )
+                    else:
+                        expired_timestamp = int(expired_at)
+
+                    if expired_timestamp < expired_cleanup_threshold:
+                        continue  # Too old, skip cleanup
+
+                except (ValueError, AttributeError):
+                    continue  # Can't parse timestamp, skip
+
+                # Check if pod actually exists before trying to clean it up
+                if not check_pod_exists(pod_name):
+                    logger.debug(f"Pod {pod_name} for {reservation.get('status', 'unknown')} reservation {reservation_id[:8]} already deleted")
+                    # Pod gone but disk might still be marked in_use - clean it up
+                    user_id = reservation.get("user_id")
+                    disk_name = reservation.get("disk_name")
+
+                    # Fallback: if disk_name not in reservation, look it up from disks table
+                    if user_id and not disk_name:
+                        disk_name = find_disk_by_reservation(user_id, reservation_id)
+
+                    if user_id and disk_name:
+                        try:
+                            mark_disk_not_in_use(user_id, disk_name)
+                            logger.info(f"Cleared disk '{disk_name}' in_use flag for {reservation.get('status', 'unknown')} reservation {reservation_id[:8]} (pod already deleted)")
+                        except Exception as disk_error:
+                            logger.warning(f"Failed to clear disk in_use flag for {reservation_id[:8]}: {disk_error}")
+                    continue
+
+                logger.info(
+                    f"Redundant cleanup: {reservation.get('status', 'unknown')} reservation {reservation_id[:8]} with pod {pod_name}"
+                )
+                try:
+                    cleanup_pod(pod_name, reservation_data=reservation)
+                    logger.info(
+                        f"Successfully cleaned up {reservation.get('status', 'unknown')} reservation {reservation_id[:8]}"
+                    )
+                except Exception as e:
+                    logger.error(
+                        f"Failed to cleanup {reservation.get('status', 'unknown')} reservation {reservation_id[:8]}: {e}"
+                    )
+
+        except Exception as e:
+            logger.error(f"Error processing expired/cancelled reservations: {e}")
 
         # Sync disk deletion status from DynamoDB to EC2 snapshots
         try:
@@ -1015,6 +1046,60 @@ def find_disk_by_reservation(user_id: str, reservation_id: str) -> str | None:
     except Exception as e:
         logger.warning(f"Error looking up disk by reservation: {e}")
         return None
+
+
+def sweep_stale_disk_locks():
+    """Sweep disks table for locks orphaned by terminated reservations"""
+    try:
+        disks_table = dynamodb.Table(DISKS_TABLE)
+        response = disks_table.scan(
+            FilterExpression=Attr('in_use').eq(True)
+        )
+        locked_disks = response.get('Items', [])
+
+        while 'LastEvaluatedKey' in response:
+            response = disks_table.scan(
+                FilterExpression=Attr('in_use').eq(True),
+                ExclusiveStartKey=response['LastEvaluatedKey']
+            )
+            locked_disks.extend(response.get('Items', []))
+
+        logger.info(f"Found {len(locked_disks)} locked disks to check")
+        cleaned = 0
+
+        reservations_table = dynamodb.Table(RESERVATIONS_TABLE)
+
+        for disk in locked_disks:
+            attached_reservation = disk.get('attached_to_reservation')
+            user_id = disk.get('user_id')
+            disk_name = disk.get('disk_name')
+
+            if not attached_reservation or not user_id or not disk_name:
+                continue
+
+            try:
+                res_response = reservations_table.get_item(
+                    Key={'reservation_id': attached_reservation}
+                )
+                reservation = res_response.get('Item')
+
+                if not reservation:
+                    mark_disk_not_in_use(user_id, disk_name)
+                    cleaned += 1
+                    logger.info(f"Cleared orphaned disk lock: '{disk_name}' for user {user_id} (reservation {attached_reservation[:8]} not found)")
+                    continue
+
+                status = reservation.get('status', '')
+                if status in ('expired', 'cancelled', 'failed'):
+                    mark_disk_not_in_use(user_id, disk_name)
+                    cleaned += 1
+                    logger.info(f"Cleared stale disk lock: '{disk_name}' for user {user_id} (reservation {attached_reservation[:8]} is {status})")
+            except Exception as e:
+                logger.warning(f"Error checking reservation for disk '{disk_name}': {e}")
+
+        logger.info(f"Stale disk lock sweep complete: cleaned {cleaned}/{len(locked_disks)} locks")
+    except Exception as e:
+        logger.error(f"Error in stale disk lock sweep: {e}")
 
 
 def handle_oom_event(reservation: dict, oom_info: dict) -> bool:
@@ -1220,6 +1305,18 @@ def expire_reservation_due_to_missing_pod(reservation: dict[str, Any]) -> None:
             f"Successfully marked reservation {reservation_id} as expired due to missing pod"
         )
 
+        # Clear disk lock so persistent disk can be reused
+        user_id = reservation.get("user_id")
+        disk_name = reservation.get("disk_name")
+        if user_id and not disk_name:
+            disk_name = find_disk_by_reservation(user_id, reservation_id)
+        if user_id and disk_name:
+            try:
+                mark_disk_not_in_use(user_id, disk_name)
+                logger.info(f"Cleared disk lock for '{disk_name}' after missing pod expiry of {reservation_id[:8]}")
+            except Exception as e:
+                logger.warning(f"Failed to clear disk lock during missing pod expiry: {e}")
+
     except Exception as e:
         logger.error(
             f"Error marking reservation {reservation.get('reservation_id')} as expired: {str(e)}"
@@ -1381,6 +1478,17 @@ def cancel_stale_reservation(reservation: dict[str, Any]) -> None:
         )
 
         logger.info(f"Successfully cancelled stale reservation {reservation_id}")
+
+        # Clear disk lock so persistent disk can be reused
+        disk_name = reservation.get("disk_name")
+        if user_id and user_id != "unknown" and not disk_name:
+            disk_name = find_disk_by_reservation(user_id, reservation_id)
+        if user_id and user_id != "unknown" and disk_name:
+            try:
+                mark_disk_not_in_use(user_id, disk_name)
+                logger.info(f"Cleared disk lock for '{disk_name}' after stale cancellation of {reservation_id[:8]}")
+            except Exception as e:
+                logger.warning(f"Failed to clear disk lock during stale cancellation: {e}")
 
     except Exception as e:
         logger.error(

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -1850,6 +1850,14 @@ def process_reservation_request(record: dict[str, Any]) -> bool:
                 if reservation_request.get("dockerimage"):
                     initial_record["dockerimage"] = reservation_request["dockerimage"]
 
+                # Store disk preferences so queued reservations retain them
+                if reservation_request.get("disk_name"):
+                    initial_record["disk_name"] = reservation_request["disk_name"]
+                if "no_persistent_disk" in reservation_request:
+                    initial_record["no_persistent_disk"] = reservation_request["no_persistent_disk"]
+                if "recreate_env" in reservation_request:
+                    initial_record["recreate_env"] = reservation_request["recreate_env"]
+
                 # Store initial record
                 reservations_table = dynamodb.Table(RESERVATIONS_TABLE)
                 reservations_table.put_item(Item=initial_record)
@@ -2260,6 +2268,13 @@ def create_reservation(request: dict[str, Any]) -> str:
             reservation["cli_version"] = request["version"]
         if "preserve_entrypoint" in request:
             reservation["preserve_entrypoint"] = request["preserve_entrypoint"]
+        # Store disk preferences so queued reservations retain them
+        if "disk_name" in request:
+            reservation["disk_name"] = request["disk_name"]
+        if "no_persistent_disk" in request:
+            reservation["no_persistent_disk"] = request["no_persistent_disk"]
+        if "recreate_env" in request:
+            reservation["recreate_env"] = request["recreate_env"]
         # Store Lambda version that processed this reservation
         reservation["lambda_version"] = LAMBDA_VERSION
 

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -1148,18 +1148,31 @@ def handler(event, context):
                         validate_cli_version(message_body)
                     except ValueError as version_error:
                         error_str = str(version_error)
-                        # Write error to operations table (for CLI polling)
-                        operation_id = message_body.get("operation_id")
-                        write_operation_result(operation_id, "failed", error_str)
-                        # Also update reservation status if applicable
+                        action = message_body.get("action")
                         reservation_id = message_body.get("reservation_id")
-                        if reservation_id:
-                            update_reservation_status(
-                                reservation_id=reservation_id,
-                                status="failed",
-                                detailed_status="CLI version validation failed",
-                                failure_reason=error_str
-                            )
+
+                        # For extend actions, write to extension_error so CLI polling detects it
+                        if action == "extend_reservation" and reservation_id:
+                            try:
+                                reservation = find_reservation_by_prefix(
+                                    reservation_id, message_body.get("user_id"))
+                                update_reservation_error(
+                                    reservation["reservation_id"], error_str, "extension_error")
+                            except Exception as lookup_err:
+                                logger.error(
+                                    f"Could not write extension_error for {reservation_id}: {lookup_err}")
+                        else:
+                            # Write error to operations table (for CLI polling)
+                            operation_id = message_body.get("operation_id")
+                            write_operation_result(operation_id, "failed", error_str)
+                            # Also update reservation status if applicable
+                            if reservation_id:
+                                update_reservation_status(
+                                    reservation_id=reservation_id,
+                                    status="failed",
+                                    detailed_status="CLI version validation failed",
+                                    failure_reason=error_str
+                                )
                         logger.error(f"Version validation failed: {error_str}")
                         delete_sqs_message(record)
                         continue
@@ -7952,6 +7965,7 @@ def process_extend_reservation_action(record: dict[str, Any]) -> bool:
         message = json.loads(record["body"])
         reservation_id = message.get("reservation_id")
         extension_hours = message.get("extension_hours")
+        user_id = message.get("user_id")
 
         if not all([reservation_id, extension_hours]):
             logger.error(
@@ -7962,7 +7976,7 @@ def process_extend_reservation_action(record: dict[str, Any]) -> bool:
             f"Processing extend reservation: {reservation_id} by {extension_hours} hours")
 
         try:
-            reservation = find_reservation_by_prefix(reservation_id)
+            reservation = find_reservation_by_prefix(reservation_id, user_id)
             full_reservation_id = reservation["reservation_id"]
             logger.info(
                 f"Found reservation {full_reservation_id} (prefix: {reservation_id})")

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -4616,7 +4616,9 @@ EOF
                     security_context=client.V1SecurityContext(
                         capabilities=client.V1Capabilities(
                             # SYS_ADMIN required for NVIDIA GPU profiling (ncu, nsys)
-                            add=["IPC_LOCK", "SYS_ADMIN"]
+                            # SYS_RESOURCE required for EFA RDMA memory registration
+                            # IPC_LOCK required for pinning memory for RDMA operations
+                            add=["IPC_LOCK", "SYS_ADMIN", "SYS_RESOURCE"]
                         ),
                         # Run as root when using custom Docker images to allow SSH setup
                         run_as_user=0 if dockerimage else None,

--- a/terraform-gpu-devservers/ssh-proxy/requirements.txt
+++ b/terraform-gpu-devservers/ssh-proxy/requirements.txt
@@ -1,2 +1,2 @@
 boto3>=1.26.0
-websockets>=12.0
+websockets>=12.0,<13.0


### PR DESCRIPTION
## Summary

Enables **secondary users** (added via `--add-user`) to download SSH config files, solving the problem where added users couldn't connect because SSH configs were only created on the original user's machine.

## Problem

When a user shares a reservation using `gpu-dev edit --add-user friend`, the added user gets SSH key access to the pod, but **no SSH config file**. SSH configs are only created on the original user's machine at `~/.gpu-dev/<id>-sshconfig`.

Without the config file, the added user can't easily connect:
- ❌ `ssh gpu-dev-abc12345` fails (no config)
- ❌ `gpu-dev connect abc12345` fails (can't find config)
- ✅ Can technically connect with full manual SSH command (complex, not user-friendly)

## Solution

### New Command: `gpu-dev get-ssh-config`

A self-service command for any user with reservation access to download SSH configs.

**Features:**
- Works for both original users and secondary users
- Interactive mode: select from active reservations
- Multi-node support: creates configs for all nodes
- Creates `~/.gpu-dev/<id>-sshconfig` file
- Handles SSH Include automatically

### Updated Add-User Message

When adding a user, show them what to run:

```bash
$ gpu-dev edit abc12345 --add-user bob
✅ User bob added to reservation abc12345...
💡 bob can now SSH to the server using their GitHub SSH keys
💡 Tell bob to run: gpu-dev get-ssh-config abc12345
```

## User Experience

### Original User Flow:
```bash
# Share reservation
$ gpu-dev edit abc12345 --add-user bob
✅ User bob added to reservation abc12345...
💡 Tell bob to run: gpu-dev get-ssh-config abc12345
```

### Secondary User Flow:
```bash
# Download SSH config
$ gpu-dev get-ssh-config abc12345
📁 Getting SSH config for reservation abc12345...
✅ SSH config created: ~/.gpu-dev/abc12345-sshconfig
🎉 You can now connect with: ssh gpu-dev-abc12345
   or: gpu-dev connect abc12345

# Connect normally
$ gpu-dev connect abc12345
Connecting to reservation abc12345...
[SSH session starts]
```

### Multi-Node Support:
```bash
$ gpu-dev get-ssh-config 54ba2244
📁 Creating SSH configs for 2 nodes...

✅ Node 1: ssh gpu-dev-54ba2244
✅ Node 2: ssh gpu-dev-6648439c

✅ SSH configs created for all 2 nodes
```

## Technical Details

**File:** `cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py`
- Added `get-ssh-config` command (line ~2823)
- Interactive mode with reservation selection
- Multi-node detection and handling
- Uses existing `create_ssh_config_for_reservation()` function

**File:** `cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py`
- Added `fqdn` field to `get_connection_info()` return dict
- Required for SSH config generation

## Benefits

✅ **Self-service**: Secondary users can download configs themselves
✅ **No manual sharing**: No need to copy config files between users
✅ **Multi-node support**: Works seamlessly with multi-node reservations
✅ **Consistent UX**: All users have the same connection experience
✅ **Simple onboarding**: Added users just run one command to get started

## Testing

- ✅ Backward compatible: Doesn't affect existing workflows
- ✅ Single-node: Creates config for single reservation
- ✅ Multi-node: Creates configs for all nodes
- ⏳ Live testing: Needs verification with actual add-user scenario

## Alternative Approaches Considered

1. **Store configs in DynamoDB/S3**: More complex, adds infrastructure
2. **Copy configs automatically**: Requires push mechanism, harder to implement
3. **In-pod config storage**: Users can't access before first connection

**Chosen approach (download on-demand)** is simplest and most flexible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)