### PR TITLE
Increase pod ready timeout from 10min to 14min for Docker pull

### DIFF
--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -5031,8 +5031,13 @@ def create_jupyter_service(k8s_client, pod_name: str, jupyter_port: int):
         raise
 
 
-def wait_for_pod_ready(k8s_client, pod_name: str, timeout_seconds: int = 600):
-    """Wait for pod to be ready - simplified since background monitoring handles status updates"""
+def wait_for_pod_ready(k8s_client, pod_name: str, timeout_seconds: int = 840):
+    """Wait for pod to be ready.
+
+    Default timeout is 840s (14 min) to accommodate large Docker image pulls
+    while staying within the Lambda's 900s (15 min) execution limit.
+    The remaining 60s buffer allows for Lambda overhead and cleanup.
+    """
     try:
         v1 = client.CoreV1Api(k8s_client)
         start_time = time.time()


### PR DESCRIPTION
## Summary

`wait_for_pod_ready()` had a default timeout of 600s (10 min), but the Lambda has a 900s (15 min) timeout. Large custom Docker images (`--dockerimage`) can take 10-15 min to pull on K8s, causing the pod ready check to give up before the Lambda would.

Increases the default to 840s (14 min) with a 60s buffer for Lambda overhead.

## Why this is safe

- **Normal reservations**: Default image is pre-pulled on nodes → pod ready in <60s. No change in behavior.
- **SQS**: Visibility timeout (1000s) already exceeds Lambda timeout (900s) → no duplicate processing risk.
- **Expiry Lambda**: Separate function, separate timeout, unaffected.
- **BuildKit builds**: Separate code path (`wait_for_buildkit_job` at line 2421), has its own 900s timeout. Unaffected.
- **Worst case**: A genuinely stuck pod takes 14 min instead of 10 min to fail. Acceptable tradeoff — users with slow pulls succeed instead of getting false failures.

## What this fixes

Docker pull timeouts reported by users with large custom images. The image pull happens at the K8s level (kubelet), and our Lambda-side wait was too short to accommodate it.