### PR TITLE
fix: fail reservation when named persistent disk setup fails

### DIFF
--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -2712,9 +2712,22 @@ def allocate_gpu_resources(reservation_id: str, request: dict[str, Any], trace_d
             except Exception as disk_error:
                 logger.error(f"Failed to set up persistent disk: {disk_error}")
 
-                # Check if this is a "disk in use" error - these should fail the reservation
                 error_msg = str(disk_error)
-                if "is currently in use" in error_msg or "already in use" in error_msg:
+
+                # If user explicitly requested a named disk, NEVER silently fall back to temporary.
+                # Any disk error (in use, timeout, creation failure) should fail the reservation
+                # so the user knows what happened instead of getting surprise temporary storage.
+                if disk_name:
+                    logger.error(f"Named disk '{disk_name}' was explicitly requested but setup failed - failing reservation")
+                    update_reservation_status(
+                        reservation_id,
+                        "failed",
+                        failure_reason=f"Persistent disk '{disk_name}' setup failed: {error_msg}"
+                    )
+                    raise RuntimeError(f"Cannot create reservation: disk '{disk_name}' setup failed: {error_msg}")
+
+                # Check if this is a "disk in use" error - these should fail the reservation
+                if "in use" in error_msg.lower():
                     # Don't fall back - fail the reservation with clear error
                     update_reservation_status(
                         reservation_id,
@@ -2723,7 +2736,7 @@ def allocate_gpu_resources(reservation_id: str, request: dict[str, Any], trace_d
                     )
                     raise RuntimeError(f"Cannot create reservation: {error_msg}")
 
-                # For other errors, continue without persistent disk (backwards compatibility)
+                # For other errors without explicit disk_name, continue without persistent disk (backwards compatibility)
                 logger.warning(f"Falling back to non-persistent storage due to disk error: {disk_error}")
                 use_persistent_disk = False
                 persistent_volume_id = None  # Clear any volume that was set before the error


### PR DESCRIPTION
## Summary
- When a user selects a named disk (e.g., "default"), disk setup errors were silently falling back to temporary storage
- User saw "Storage: Temporary" with no indication their disk wasn't attached
- Root cause: timeout error message "still in use" didn't match the check for "is currently in use" / "already in use"
- Fix: When `disk_name` is explicitly set, ALL disk errors now fail the reservation with a clear error message
- Silent fallback to temporary is only used when no specific disk was requested (legacy behavior)

## Evidence from Lambda logs
```
Named disk 'default' requested → Setting up persistent disk 'default'
→ Waiting for disk 'default' to be released from previous reservation
→ (2 min timeout) → "Persistent disk setup failed - continuing without persistent storage"
```
The "still in use" error fell through the pattern match and hit the generic fallback.

## Test plan
- [ ] Reserve with `--disk default` when disk is available → should get persistent storage
- [ ] Reserve with `--disk default` when disk is in use → should FAIL with clear error (not silent temporary)
- [ ] Reserve without disk selection → should still work with legacy fallback behavior