### PR TITLE
feat: add g7e (Blackwell RTX PRO 6000) GPU type to prod

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -498,9 +498,9 @@ def main(ctx: click.Context) -> None:
     "--gpu-type",
     "-t",
     type=click.Choice(
-        ["b200", "h200", "h100", "a100", "a10g", "t4", "l4", "t4-small", "cpu-arm", "cpu-x86"], case_sensitive=False
+        ["b200", "h200", "h100", "a100", "g7e", "a10g", "t4", "l4", "t4-small", "cpu-arm", "cpu-x86"], case_sensitive=False
     ),
-    help="GPU type to reserve (b200/h200/h100/a100/a10g/t4/l4/t4-small/cpu-arm/cpu-x86)",
+    help="GPU type to reserve (b200/h200/h100/a100/g7e/a10g/t4/l4/t4-small/cpu-arm/cpu-x86)",
 )
 @click.option(
     "--hours",
@@ -652,6 +652,7 @@ def reserve(
             "t4": {"max_gpus": 4, "instance_type": "g4dn.12xlarge"},
             "l4": {"max_gpus": 4, "instance_type": "g6.12xlarge"},
             "a10g": {"max_gpus": 4, "instance_type": "g5.12xlarge"},
+            "g7e": {"max_gpus": 4, "instance_type": "g7e.24xlarge"},
             "t4-small": {"max_gpus": 1, "instance_type": "g4dn.xlarge"},
             "a100": {"max_gpus": 8, "instance_type": "p4d.24xlarge"},
             "h100": {"max_gpus": 8, "instance_type": "p5.48xlarge"},
@@ -2397,6 +2398,7 @@ def _show_availability() -> None:
                 "a100": "Ampere (sm80)",
                 "a10g": "Ampere (sm80)",
                 "l4": "Ada Lovelace (sm89)",
+                "g7e": "Blackwell (sm120)",
                 "t4": "Turing (sm75)",
                 "cpu-x86": "CPU (x86_64)",
                 "cpu-arm": "CPU (arm64)",
@@ -2405,6 +2407,7 @@ def _show_availability() -> None:
             # Sort order: newest GPU architectures first, then CPUs at the bottom
             arch_priority = {
                 "Blackwell (sm100)": 0,
+                "Blackwell (sm120)": 0,
                 "Hopper (sm90)": 1,
                 "Ada Lovelace (sm89)": 2,
                 "Ampere (sm80)": 3,
@@ -2544,6 +2547,7 @@ def _show_availability_watch(interval: int) -> None:
                             "a100": "Ampere (sm80)",
                             "a10g": "Ampere (sm80)",
                             "l4": "Ada Lovelace (sm89)",
+                            "g7e": "Blackwell (sm120)",
                             "t4": "Turing (sm75)",
                             "cpu-x86": "CPU (x86_64)",
                             "cpu-arm": "CPU (arm64)",
@@ -2552,6 +2556,7 @@ def _show_availability_watch(interval: int) -> None:
                         # Sort order: newest GPU architectures first, then CPUs at the bottom
                         arch_priority = {
                             "Blackwell (sm100)": 0,
+                            "Blackwell (sm120)": 0,
                             "Hopper (sm90)": 1,
                             "Ada Lovelace (sm89)": 2,
                             "Ampere (sm80)": 3,

--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/interactive.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/interactive.py
@@ -153,7 +153,7 @@ def select_gpu_count_interactive(gpu_type: str, max_gpus: int) -> Optional[int]:
         # CPU instances don't have GPUs, but we still need a "count" for nodes
         valid_counts = [0]  # 0 GPUs for CPU-only instances
         multinode_counts = []  # No multinode for CPU instances
-    elif gpu_type in ["t4", "l4", "a10g"]:
+    elif gpu_type in ["t4", "l4", "a10g", "g7e"]:
         valid_counts = [1, 2, 4]
         # Add multinode options
         multinode_counts = [8, 12, 16, 20, 24]  # multiples of 4

--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
@@ -535,6 +535,7 @@ class ReservationManager:
                 "t4": {"max_gpus": 4},
                 "l4": {"max_gpus": 4},
                 "a10g": {"max_gpus": 4},
+                "g7e": {"max_gpus": 4},
                 "t4-small": {"max_gpus": 1},
                 "g5g": {"max_gpus": 2},
                 "a100": {"max_gpus": 8},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.4.1"
+version = "0.5.0"
 description = "CLI tool for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"

--- a/terraform-gpu-devservers/eks.tf
+++ b/terraform-gpu-devservers/eks.tf
@@ -185,6 +185,7 @@ locals {
     "t4-az2"   = "t4" # Both t4 and t4-az2 should be labeled as "t4" in Kubernetes
     "l4"       = "l4"
     "a10g"     = "a10g"
+    "g7e"      = "g7e"
     "h100"     = "h100"
     "h200"     = "h200"
     "b200"     = "b200"

--- a/terraform-gpu-devservers/lambda.tf
+++ b/terraform-gpu-devservers/lambda.tf
@@ -180,8 +180,8 @@ resource "aws_lambda_function" "reservation_processor" {
       HOSTED_ZONE_ID                     = local.effective_domain_name != "" ? local.hosted_zone_id : ""
       SSH_DOMAIN_MAPPINGS_TABLE          = local.effective_domain_name != "" ? aws_dynamodb_table.ssh_domain_mappings.name : ""
       SSL_CERTIFICATE_ARN                = local.effective_domain_name != "" ? aws_acm_certificate.wildcard[0].arn : ""
-      LAMBDA_VERSION                     = "0.4.1"
-      MIN_CLI_VERSION                    = "0.4.0"
+      LAMBDA_VERSION                     = "0.5.0"
+      MIN_CLI_VERSION                    = "0.5.0"
       DISK_CONTENTS_BUCKET               = aws_s3_bucket.disk_contents.bucket
       OPERATIONS_TABLE                   = aws_dynamodb_table.operations.name
     }, local.alb_env_vars)

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -66,6 +66,7 @@ GPU_CONFIG = {
     "t4": {"instance_type": "g4dn.12xlarge", "max_gpus": 4, "cpus": 48, "memory_gb": 192, "efa_count": 0},
     "l4": {"instance_type": "g6.12xlarge", "max_gpus": 4, "cpus": 48, "memory_gb": 192, "efa_count": 1},
     "a10g": {"instance_type": "g5.12xlarge", "max_gpus": 4, "cpus": 48, "memory_gb": 192, "efa_count": 1},
+    "g7e": {"instance_type": "g7e.24xlarge", "max_gpus": 4, "cpus": 96, "memory_gb": 1024, "efa_count": 2},
     "t4-small": {"instance_type": "g4dn.2xlarge", "max_gpus": 1, "cpus": 8, "memory_gb": 32, "efa_count": 0},
     "g5g": {"instance_type": "g5g.2xlarge", "max_gpus": 2, "cpus": 8, "memory_gb": 32, "efa_count": 0},
     "a100": {"instance_type": "p4d.24xlarge", "max_gpus": 8, "cpus": 96, "memory_gb": 1152, "efa_count": 4},
@@ -2150,7 +2151,7 @@ def validate_reservation_request(request: dict[str, Any]) -> tuple[bool, str]:
     gpu_type = request.get("gpu_type", "")
 
     # Validate GPU type
-    valid_gpu_types = ["t4", "l4", "a10g", "t4-small", "a100",
+    valid_gpu_types = ["t4", "l4", "a10g", "g7e", "t4-small", "a100",
                        "h100", "h200", "b200", "cpu-arm", "cpu-x86"]
     if gpu_type not in valid_gpu_types:
         error_msg = f"Invalid GPU type: {gpu_type}. Must be one of: {', '.join(valid_gpu_types)}"
@@ -2381,6 +2382,7 @@ def update_gpu_availability_table(
             "t4": {"gpus_per_instance": 4},
             "l4": {"gpus_per_instance": 4},
             "a10g": {"gpus_per_instance": 4},
+            "g7e": {"gpus_per_instance": 4},
             "a100": {"gpus_per_instance": 8},
             "h100": {"gpus_per_instance": 8},
             "h200": {"gpus_per_instance": 8},

--- a/terraform-gpu-devservers/main.tf
+++ b/terraform-gpu-devservers/main.tf
@@ -207,6 +207,15 @@ locals {
           architecture        = "x86_64"
           efa_network_cards   = 1
         }
+        "g7e" = {
+          instance_type       = "g7e.24xlarge"
+          instance_types      = null
+          instance_count      = 2
+          gpus_per_instance   = 4 # 4x RTX PRO 6000 Blackwell GPUs
+          use_placement_group = false
+          architecture        = "x86_64"
+          efa_network_cards   = 2
+        }
         "cpu-arm" = {
           instance_type       = "c7g.8xlarge"
           instance_types      = null
@@ -294,6 +303,7 @@ locals {
       t4        = "primary"
       l4        = "secondary"
       a10g      = "secondary"
+      g7e       = "secondary"
       "cpu-arm" = "primary"
       "cpu-x86" = "primary"
     }


### PR DESCRIPTION
## Summary
- Adds **g7e** (`g7e.24xlarge`, RTX PRO 6000 Blackwell) as a new GPU type in prod, modeled on l4/a10g
- 4 GPUs/instance, 2-instance fallback, single-AZ (us-east-2b / `secondary` subnet), non-multinode (matches l4/a10g)
- Provides a cheaper Blackwell-class GPU option alongside b200

## Why g7e.24xlarge
- Same 4-GPU shape as l4 (g6.12xlarge) and a10g (g5.12xlarge), so it slots into existing per-pod GPU-count logic without needing new branches in interactive count selection or scheduling
- 96 vCPU / 1024 GiB / 2x EFA / 96 GiB GPU memory per card
- Available in us-east-2a and us-east-2b on-demand (verified via `describe-instance-type-offerings`)

## Files changed
- `terraform-gpu-devservers/main.tf` — prod `supported_gpu_types["g7e"]` + subnet assignment (`secondary`)
- `terraform-gpu-devservers/eks.tf` — `gpu_type_kubernetes_labels` mapping
- `terraform-gpu-devservers/lambda/reservation_processor/index.py` — `GPU_CONFIG`, `valid_gpu_types`, per-type `gpus_per_instance`
- `cli-tools/gpu-dev-cli/gpu_dev_cli/{cli,interactive,reservations}.py` — `--gpu-type` choice, validation map, architecture display, multinode config

## Test plan
- [ ] `tofu plan -var-file=...` in prod workspace shows new ASG `gpu-nodes-g7e` (2x g7e.24xlarge in `secondary` subnet) and no diffs to existing ASGs
- [ ] `tf apply` completes; new ASG comes up healthy
- [ ] After ASG ready: `kubectl get nodes -l gpu-type=g7e` shows 2 nodes with `nvidia.com/gpu: 4`
- [ ] `gpu-dev availability` lists g7e under "Blackwell (sm120)"
- [ ] `gpu-dev reserve --gpu-type g7e --gpus 1 --hours 0.25` succeeds and pod schedules
- [ ] `nvidia-smi` inside pod shows RTX PRO 6000 Blackwell

## Notes / follow-ups
- Architecture string set to `Blackwell (sm120)` — confirm against actual `nvidia-smi` output once a node is up; adjust the CLI map if it should be sm100 or different
- No capacity reservation entry added — uses on-demand fallback like l4/a10g. Add to `local.capacity_reservations.prod.g7e` if a reservation is later attached
- Not added to `multinode_gpu_types` in `availability_updater` (mirrors l4/a10g behavior)
