### PR TITLE
refactor: rename GPU type g7e to rtxpro6000 (v0.5.1)

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -498,9 +498,9 @@ def main(ctx: click.Context) -> None:
     "--gpu-type",
     "-t",
     type=click.Choice(
-        ["b200", "h200", "h100", "a100", "g7e", "a10g", "t4", "l4", "t4-small", "cpu-arm", "cpu-x86"], case_sensitive=False
+        ["b200", "h200", "h100", "a100", "rtxpro6000", "a10g", "t4", "l4", "t4-small", "cpu-arm", "cpu-x86"], case_sensitive=False
     ),
-    help="GPU type to reserve (b200/h200/h100/a100/g7e/a10g/t4/l4/t4-small/cpu-arm/cpu-x86)",
+    help="GPU type to reserve (b200/h200/h100/a100/rtxpro6000/a10g/t4/l4/t4-small/cpu-arm/cpu-x86)",
 )
 @click.option(
     "--hours",
@@ -652,7 +652,7 @@ def reserve(
             "t4": {"max_gpus": 4, "instance_type": "g4dn.12xlarge"},
             "l4": {"max_gpus": 4, "instance_type": "g6.12xlarge"},
             "a10g": {"max_gpus": 4, "instance_type": "g5.12xlarge"},
-            "g7e": {"max_gpus": 4, "instance_type": "g7e.24xlarge"},
+            "rtxpro6000": {"max_gpus": 4, "instance_type": "g7e.24xlarge"},
             "t4-small": {"max_gpus": 1, "instance_type": "g4dn.xlarge"},
             "a100": {"max_gpus": 8, "instance_type": "p4d.24xlarge"},
             "h100": {"max_gpus": 8, "instance_type": "p5.48xlarge"},
@@ -2398,7 +2398,7 @@ def _show_availability() -> None:
                 "a100": "Ampere (sm80)",
                 "a10g": "Ampere (sm80)",
                 "l4": "Ada Lovelace (sm89)",
-                "g7e": "Blackwell (sm120)",
+                "rtxpro6000": "Blackwell (sm120)",
                 "t4": "Turing (sm75)",
                 "cpu-x86": "CPU (x86_64)",
                 "cpu-arm": "CPU (arm64)",
@@ -2547,7 +2547,7 @@ def _show_availability_watch(interval: int) -> None:
                             "a100": "Ampere (sm80)",
                             "a10g": "Ampere (sm80)",
                             "l4": "Ada Lovelace (sm89)",
-                            "g7e": "Blackwell (sm120)",
+                            "rtxpro6000": "Blackwell (sm120)",
                             "t4": "Turing (sm75)",
                             "cpu-x86": "CPU (x86_64)",
                             "cpu-arm": "CPU (arm64)",

--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/interactive.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/interactive.py
@@ -153,7 +153,7 @@ def select_gpu_count_interactive(gpu_type: str, max_gpus: int) -> Optional[int]:
         # CPU instances don't have GPUs, but we still need a "count" for nodes
         valid_counts = [0]  # 0 GPUs for CPU-only instances
         multinode_counts = []  # No multinode for CPU instances
-    elif gpu_type in ["t4", "l4", "a10g", "g7e"]:
+    elif gpu_type in ["t4", "l4", "a10g", "rtxpro6000"]:
         valid_counts = [1, 2, 4]
         # Add multinode options
         multinode_counts = [8, 12, 16, 20, 24]  # multiples of 4

--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
@@ -535,7 +535,7 @@ class ReservationManager:
                 "t4": {"max_gpus": 4},
                 "l4": {"max_gpus": 4},
                 "a10g": {"max_gpus": 4},
-                "g7e": {"max_gpus": 4},
+                "rtxpro6000": {"max_gpus": 4},
                 "t4-small": {"max_gpus": 1},
                 "g5g": {"max_gpus": 2},
                 "a100": {"max_gpus": 8},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.5.0"
+version = "0.5.1"
 description = "CLI tool for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"

--- a/terraform-gpu-devservers/eks.tf
+++ b/terraform-gpu-devservers/eks.tf
@@ -184,8 +184,8 @@ locals {
     "t4"       = "t4"
     "t4-az2"   = "t4" # Both t4 and t4-az2 should be labeled as "t4" in Kubernetes
     "l4"       = "l4"
-    "a10g"     = "a10g"
-    "g7e"      = "g7e"
+    "a10g"       = "a10g"
+    "rtxpro6000" = "rtxpro6000"
     "h100"     = "h100"
     "h200"     = "h200"
     "b200"     = "b200"

--- a/terraform-gpu-devservers/lambda.tf
+++ b/terraform-gpu-devservers/lambda.tf
@@ -180,8 +180,8 @@ resource "aws_lambda_function" "reservation_processor" {
       HOSTED_ZONE_ID                     = local.effective_domain_name != "" ? local.hosted_zone_id : ""
       SSH_DOMAIN_MAPPINGS_TABLE          = local.effective_domain_name != "" ? aws_dynamodb_table.ssh_domain_mappings.name : ""
       SSL_CERTIFICATE_ARN                = local.effective_domain_name != "" ? aws_acm_certificate.wildcard[0].arn : ""
-      LAMBDA_VERSION                     = "0.5.0"
-      MIN_CLI_VERSION                    = "0.5.0"
+      LAMBDA_VERSION                     = "0.5.1"
+      MIN_CLI_VERSION                    = "0.5.1"
       DISK_CONTENTS_BUCKET               = aws_s3_bucket.disk_contents.bucket
       OPERATIONS_TABLE                   = aws_dynamodb_table.operations.name
     }, local.alb_env_vars)

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -66,7 +66,7 @@ GPU_CONFIG = {
     "t4": {"instance_type": "g4dn.12xlarge", "max_gpus": 4, "cpus": 48, "memory_gb": 192, "efa_count": 0},
     "l4": {"instance_type": "g6.12xlarge", "max_gpus": 4, "cpus": 48, "memory_gb": 192, "efa_count": 1},
     "a10g": {"instance_type": "g5.12xlarge", "max_gpus": 4, "cpus": 48, "memory_gb": 192, "efa_count": 1},
-    "g7e": {"instance_type": "g7e.24xlarge", "max_gpus": 4, "cpus": 96, "memory_gb": 1024, "efa_count": 2},
+    "rtxpro6000": {"instance_type": "g7e.24xlarge", "max_gpus": 4, "cpus": 96, "memory_gb": 1024, "efa_count": 2},
     "t4-small": {"instance_type": "g4dn.2xlarge", "max_gpus": 1, "cpus": 8, "memory_gb": 32, "efa_count": 0},
     "g5g": {"instance_type": "g5g.2xlarge", "max_gpus": 2, "cpus": 8, "memory_gb": 32, "efa_count": 0},
     "a100": {"instance_type": "p4d.24xlarge", "max_gpus": 8, "cpus": 96, "memory_gb": 1152, "efa_count": 4},
@@ -2151,7 +2151,7 @@ def validate_reservation_request(request: dict[str, Any]) -> tuple[bool, str]:
     gpu_type = request.get("gpu_type", "")
 
     # Validate GPU type
-    valid_gpu_types = ["t4", "l4", "a10g", "g7e", "t4-small", "a100",
+    valid_gpu_types = ["t4", "l4", "a10g", "rtxpro6000", "t4-small", "a100",
                        "h100", "h200", "b200", "cpu-arm", "cpu-x86"]
     if gpu_type not in valid_gpu_types:
         error_msg = f"Invalid GPU type: {gpu_type}. Must be one of: {', '.join(valid_gpu_types)}"
@@ -2382,7 +2382,7 @@ def update_gpu_availability_table(
             "t4": {"gpus_per_instance": 4},
             "l4": {"gpus_per_instance": 4},
             "a10g": {"gpus_per_instance": 4},
-            "g7e": {"gpus_per_instance": 4},
+            "rtxpro6000": {"gpus_per_instance": 4},
             "a100": {"gpus_per_instance": 8},
             "h100": {"gpus_per_instance": 8},
             "h200": {"gpus_per_instance": 8},

--- a/terraform-gpu-devservers/main.tf
+++ b/terraform-gpu-devservers/main.tf
@@ -207,7 +207,7 @@ locals {
           architecture        = "x86_64"
           efa_network_cards   = 1
         }
-        "g7e" = {
+        "rtxpro6000" = {
           instance_type       = "g7e.24xlarge"
           instance_types      = null
           instance_count      = 2
@@ -302,8 +302,8 @@ locals {
       a100      = "primary"
       t4        = "primary"
       l4        = "secondary"
-      a10g      = "secondary"
-      g7e       = "secondary"
+      a10g       = "secondary"
+      rtxpro6000 = "secondary"
       "cpu-arm" = "primary"
       "cpu-x86" = "primary"
     }


### PR DESCRIPTION
## Summary
- Rename GPU type `g7e` → `rtxpro6000` (uses the GPU name, not the AWS instance family — matches the convention of t4/l4/a10g/h100/etc)
- The instance type itself remains `g7e.24xlarge` (correct AWS identifier)
- Bumps versions to 0.5.1 (pyproject + LAMBDA_VERSION + MIN_CLI_VERSION)

## Why
v0.5.0 (just published) used `g7e`, which is the AWS instance family code, not the GPU model. Existing supported types use the GPU name (`l4` not `g6`, `t4` not `g4dn`, `a10g` not `g5`). Renaming to `rtxpro6000` (NVIDIA RTX PRO 6000 Blackwell, server edition) matches that convention.

## Files changed
- `terraform-gpu-devservers/main.tf` — `supported_gpu_types` key + subnet assignment
- `terraform-gpu-devservers/eks.tf` — `gpu_type_kubernetes_labels`
- `terraform-gpu-devservers/lambda/reservation_processor/index.py` — `GPU_CONFIG`, `valid_gpu_types`, per-type map
- `cli-tools/gpu-dev-cli/gpu_dev_cli/{cli,interactive,reservations}.py` — Choice, configs, architecture display
- `pyproject.toml`, `terraform-gpu-devservers/lambda.tf` — version bump 0.5.0 → 0.5.1

## Test plan
- [ ] After `tf apply`: `gpu-dev reserve --gpu-type rtxpro6000 --gpus 1` succeeds
- [ ] `gpu-dev availability` lists `rtxpro6000` (not `g7e`)
- [ ] After tag `v0.5.1` push: PyPI release publishes; users running 0.5.0 get prompted to upgrade by MIN_CLI_VERSION

## Notes
v0.5.0 was published moments before this rename — minimal user impact since `tf apply` for the new GPU type hasn't run yet, so no one is using `g7e` in practice.
