### PR TITLE
fix: per-CR efa_network_cards override (h200 cr3 p5en limit)

### DIFF
--- a/terraform-gpu-devservers/eks.tf
+++ b/terraform-gpu-devservers/eks.tf
@@ -212,8 +212,10 @@ locals {
           ? lookup(local.capacity_reservation_azs[terraform.workspace], cr_config.id, local.gpu_subnet_assignments[terraform.workspace][gpu_type])
           : local.gpu_subnet_assignments[terraform.workspace][gpu_type]
         )
+        # Per-CR override for efa_network_cards (e.g. p5en.48xlarge caps at 16 vs p5e at 32)
+        efa_network_cards = cr_config != null ? try(cr_config.efa_network_cards, gpu_config.efa_network_cards) : gpu_config.efa_network_cards
         # Multi-EFA instances (>1 network card) must use private subnets (no public IP in launch template)
-        use_private_subnet = try(gpu_config.efa_network_cards, 0) > 1
+        use_private_subnet = (cr_config != null ? try(cr_config.efa_network_cards, try(gpu_config.efa_network_cards, 0)) : try(gpu_config.efa_network_cards, 0)) > 1
       }
     ]
   ])
@@ -363,7 +365,7 @@ resource "aws_launch_template" "gpu_dev_launch_template" {
       associate_public_ip_address = true
       security_groups             = [aws_security_group.gpu_dev_sg.id]
       subnet_id                   = each.value.gpu_config.use_placement_group ? null : local.public_subnet_map[each.value.subnet_az]
-      interface_type              = try(each.value.gpu_config.efa_network_cards, 0) > 0 ? "efa" : "interface"
+      interface_type              = try(each.value.efa_network_cards, 0) > 0 ? "efa" : "interface"
       delete_on_termination       = true
     }
   }
@@ -386,7 +388,7 @@ resource "aws_launch_template" "gpu_dev_launch_template" {
   # Each network card supports 2 device indices (0 and 1); device_index must be 0
   # since this is the only interface on each card
   dynamic "network_interfaces" {
-    for_each = each.value.use_private_subnet ? range(1, try(each.value.gpu_config.efa_network_cards, 1)) : []
+    for_each = each.value.use_private_subnet ? range(1, try(each.value.efa_network_cards, 1)) : []
     content {
       device_index          = 0
       interface_type        = "efa-only"

--- a/terraform-gpu-devservers/main.tf
+++ b/terraform-gpu-devservers/main.tf
@@ -272,7 +272,7 @@ locals {
         { key = "cr0", id = "cr-0f6d0766f5d3339e6", instance_count = 2 }, # H200 capacity block (may be expired - keep to prevent ASG destroy)
         { key = "cr1", id = "cr-06c9c978dea756a26", instance_count = 3 }, # H200 reservation (3 instances)
         { key = "cr2", id = null, instance_count = 2 },                   # H200 on-demand (2 instances)
-        { key = "cr3", id = "cr-02949f61f1a761b54", instance_count = 1 }, # H200 reservation us-east-2a (1 instance, 8 GPUs)
+        { key = "cr3", id = "cr-02949f61f1a761b54", instance_count = 1, efa_network_cards = 16 }, # H200 reservation us-east-2a (1 instance, 8 GPUs, p5en.48xlarge max 16 EFA)
       ]
       b200 = [
         { key = "cr0", id = "cr-0c366fb8339a10f69", instance_count = 0 }, # B200 reservation us-east-2a (disabled - CR freed)


### PR DESCRIPTION
## Summary
`tf apply` fails creating ASG `gpu-nodes-h200-cr3` because the launch template was built with 32 EFA network cards (`gpu_config.efa_network_cards = 32`), but **`p5en.48xlarge` maxes out at 16 cards** (vs `p5e.48xlarge` and `p5.48xlarge` which support 32).

```
maximum number for p5en.48xlarge is 16. Specify a number from 0 to 15
```

## Fix
Add an optional `efa_network_cards` field to entries in `local.capacity_reservations`. Per-ASG launch template now uses `cr_config.efa_network_cards` if set, falling back to `gpu_config.efa_network_cards`. This lets us set 16 for the p5en CR without degrading the on-demand (mixed-instances) p5e ASG.

## Changes
- `terraform-gpu-devservers/main.tf` — set `efa_network_cards = 16` on `h200/cr3`
- `terraform-gpu-devservers/eks.tf` — flatten now resolves a per-ASG `efa_network_cards`; launch template `network_interfaces` blocks read from there

## Test plan
- [ ] `tofu plan` shows only `h200-cr3` launch template + ASG creation; existing h200/cr2 (on-demand) launch template unchanged
- [ ] `tf apply` succeeds; new ASG comes up with 1× p5en.48xlarge in us-east-2a
