### PR TITLE
feat(cli): h100 submenu surfaces MIG slice options

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -727,11 +727,18 @@ def reserve(
                     return
 
                 max_gpus = gpu_configs[gpu_type_lower]["max_gpus"]
-                gpu_count = select_gpu_count_interactive(
-                    gpu_type_lower, max_gpus)
-                if gpu_count is None:
+                result = select_gpu_count_interactive(
+                    gpu_type_lower, max_gpus, availability_info=availability_info)
+                if result is None:
                     rprint("[yellow]Reservation cancelled.[/yellow]")
                     return
+                # If user picked a MIG slice, the function returns (gpu_type, count).
+                if isinstance(result, tuple):
+                    gpu_type, gpu_count = result
+                    gpu_type_lower = gpu_type.lower()
+                    max_gpus = gpu_configs[gpu_type_lower]["max_gpus"]
+                else:
+                    gpu_count = result
 
                 # Show distributed warning for interactive multinode selections (always show)
                 if gpu_count > max_gpus:

--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/interactive.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/interactive.py
@@ -220,7 +220,18 @@ def select_gpu_count_interactive(
 
     choices = []
 
-    # Add single-node options
+    # MIG slice options come first (smallest unit), h100-only.
+    if mig_options:
+        choices.append(questionary.Separator(
+            "--- MIG slices (partial GPU, single node) ---"))
+        for sku, count, label in mig_options:
+            choices.append(questionary.Choice(title=label, value=(sku, count)))
+
+    # Full single-node options. Header only when slices were rendered above
+    # (otherwise the type already implies "Full GPUs").
+    if mig_options:
+        choices.append(questionary.Separator(
+            "--- Full GPUs (single node) ---"))
     for count in valid_counts:
         if count == 1:
             label = f"1 GPU (single node)"
@@ -228,14 +239,7 @@ def select_gpu_count_interactive(
             label = f"{count} GPUs (single node)"
         choices.append(questionary.Choice(title=label, value=count))
 
-    # Add separator and MIG slice options (h100 only)
-    if mig_options:
-        choices.append(questionary.Separator(
-            "--- MIG slices (partial GPU, single node) ---"))
-        for sku, count, label in mig_options:
-            choices.append(questionary.Choice(title=label, value=(sku, count)))
-
-    # Add separator and multinode options
+    # Multinode at the bottom.
     if multinode_counts:
         choices.append(questionary.Separator(
             "--- Multinode (Distributed) ---"))

--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/interactive.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/interactive.py
@@ -57,6 +57,13 @@ def select_gpu_type_interactive(
     if not check_interactive_support():
         return None
 
+    # Hide MIG slice SKUs from the top-level selector — reached via the h100 submenu.
+    # Direct `--gpu-type h100-mig-1g` still works for non-interactive scripts.
+    visible_info = {
+        gt: info for gt, info in availability_info.items()
+        if "-mig-" not in gt
+    }
+
     # Display availability table first
     console.print("\n[cyan]🖥️  GPU Availability:[/cyan]")
     table = Table()
@@ -67,7 +74,7 @@ def select_gpu_type_interactive(
     table.add_column("Est. Wait Time", style="magenta")
 
     choices = []
-    for gpu_type, info in availability_info.items():
+    for gpu_type, info in visible_info.items():
         available = info.get("available", 0)
         total = info.get("total", 0)
         queue_length = info.get("queue_length", 0)
@@ -143,8 +150,16 @@ def select_gpu_type_interactive(
         return None
 
 
-def select_gpu_count_interactive(gpu_type: str, max_gpus: int) -> Optional[int]:
-    """Interactive GPU count selection"""
+def select_gpu_count_interactive(
+    gpu_type: str,
+    max_gpus: int,
+    availability_info: Optional[Dict[str, Dict[str, Any]]] = None,
+):
+    """Interactive GPU count selection.
+
+    Returns int (gpu_count) for normal selections, or a (effective_gpu_type, gpu_count)
+    tuple when the user picks a MIG slice option from the h100 submenu.
+    """
     if not check_interactive_support():
         return None
 
@@ -174,6 +189,28 @@ def select_gpu_count_interactive(gpu_type: str, max_gpus: int) -> Optional[int]:
         # Add multinode options
         multinode_counts = [16, 24, 32, 40, 48]  # multiples of 8
 
+    # MIG slice submenu: only for h100. Each tuple is (target_gpu_type, gpu_count, gb_label).
+    mig_options = []
+    if gpu_type == "h100":
+        # Map to internal SKUs; the count menu surfaces 1/2/4 of each slice size.
+        mig_specs = [
+            ("h100-mig-1g", "10GB"),
+            ("h100-mig-2g", "20GB"),
+            ("h100-mig-3g", "40GB"),
+        ]
+        for sku, gb in mig_specs:
+            slice_max = {"h100-mig-1g": 16, "h100-mig-2g": 8, "h100-mig-3g": 8}[sku]
+            free = None
+            if availability_info and sku in availability_info:
+                free = availability_info[sku].get("available", 0)
+            for n in [1, 2, 4]:
+                if n > slice_max:
+                    continue
+                noun = "slice" if n == 1 else "slices"
+                avail_suffix = f"  [{free} free]" if free is not None else ""
+                label = f"{n} × {gb} {noun}{avail_suffix}"
+                mig_options.append((sku, n, label))
+
     # Filter single-node by actual max for this GPU type
     valid_counts = [count for count in valid_counts if count <= max_gpus]
 
@@ -190,6 +227,13 @@ def select_gpu_count_interactive(gpu_type: str, max_gpus: int) -> Optional[int]:
         else:
             label = f"{count} GPUs (single node)"
         choices.append(questionary.Choice(title=label, value=count))
+
+    # Add separator and MIG slice options (h100 only)
+    if mig_options:
+        choices.append(questionary.Separator(
+            "--- MIG slices (partial GPU, single node) ---"))
+        for sku, count, label in mig_options:
+            choices.append(questionary.Choice(title=label, value=(sku, count)))
 
     # Add separator and multinode options
     if multinode_counts:


### PR DESCRIPTION
## Summary
Hide MIG slice SKUs from the top-level interactive GPU-type picker; surface them as choices in the `h100` count submenu instead. UX-only — Lambda + DDB unchanged.

## Before / after

**Before** — users had to know the four h100 SKUs exist:
```
? Select GPU type:
  ✅ H100 (14/32 available)
  ✅ H100-MIG-1G (16/16 available)
  ✅ H100-MIG-2G (8/8 available)
  ✅ H100-MIG-3G (8/8 available)
```

**After** — slices live under h100:
```
? Select GPU type:
  ✅ H100 (14/32 available)
? How many H100 GPUs?
  » 1 GPU (single node)
    2 GPUs (single node)
    4 GPUs (single node)
    8 GPUs (single node)
    --- MIG slices (partial GPU, single node) ---
    1 × 10GB slice  [16 free]
    2 × 10GB slices  [16 free]
    4 × 10GB slices  [16 free]
    1 × 20GB slice  [8 free]
    2 × 20GB slices  [8 free]
    4 × 20GB slices  [8 free]
    1 × 40GB slice  [8 free]
    2 × 40GB slices  [8 free]
    4 × 40GB slices  [8 free]
    --- Multinode (Distributed) ---
    16 GPUs (2 nodes × 8 GPUs)
    ...
```

Free counts are sourced from the existing `availability_info` dict, so they update with the cluster.

## Implementation

- `interactive.py` `select_gpu_type_interactive` filters keys containing `-mig-` from `availability_info` for display.
- `interactive.py` `select_gpu_count_interactive` accepts an optional `availability_info`. For `gpu_type == "h100"`, it appends 9 MIG choice items whose `value` is a `(sku, count)` tuple.
- `cli.py` caller checks `isinstance(result, tuple)` and rewrites `gpu_type` + `max_gpus` accordingly.

## Backwards compat

- `gpu-dev reserve --gpu-type h100-mig-1g --gpus 1` (non-interactive) still works.
- Old reservations / DDB schemas unchanged.
- Lambda unchanged.

## Test plan
- [ ] `pip install -e ./cli-tools/gpu-dev-cli` and run `gpu-dev reserve` interactively
- [ ] H100 submenu shows 9 MIG options with live free counts
- [ ] Selecting `1 × 10GB slice` creates an `h100-mig-1g` reservation with `gpu_count=1`
- [ ] Selecting `4 GPUs (single node)` creates an `h100` reservation with `gpu_count=4` (unchanged behavior)
- [ ] `--gpu-type h100-mig-1g --gpus 1` still works as a flag
