### PR TITLE
chore: bump version to 0.5.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.5.1"
+version = "0.5.2"
 description = "CLI tool for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"


### PR DESCRIPTION
H100 MIG slice submenu in interactive CLI (additive). Lambda code unchanged, so LAMBDA_VERSION/MIN_CLI_VERSION stay at 0.5.1 — no tf apply needed. Tag v0.5.2 after merge to publish to PyPI.