### PR TITLE
chore: release 0.5.3 with clearer --gpu-type help, MIN_CLI 0.5.2

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -500,7 +500,7 @@ def main(ctx: click.Context) -> None:
     type=click.Choice(
         ["b200", "h200", "h100", "h100-mig-1g", "h100-mig-2g", "h100-mig-3g", "a100", "rtxpro6000", "a10g", "t4", "l4", "t4-small", "cpu-arm", "cpu-x86"], case_sensitive=False
     ),
-    help="GPU type to reserve (b200/h200/h100/h100-mig-1g/h100-mig-2g/h100-mig-3g/a100/rtxpro6000/a10g/t4/l4/t4-small/cpu-arm/cpu-x86)",
+    help="GPU type to reserve. Full GPUs: b200, h200, h100, a100, rtxpro6000, a10g, t4, l4, t4-small. H100 MIG slices (partial GPU on a single shared node): h100-mig-1g (10 GB / 1/7 H100 compute), h100-mig-2g (20 GB / 2/7 H100), h100-mig-3g (40 GB / 3/7 H100). CPU only: cpu-arm, cpu-x86.",
 )
 @click.option(
     "--hours",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.5.2"
+version = "0.5.3"
 description = "CLI tool for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"

--- a/terraform-gpu-devservers/lambda.tf
+++ b/terraform-gpu-devservers/lambda.tf
@@ -180,8 +180,8 @@ resource "aws_lambda_function" "reservation_processor" {
       HOSTED_ZONE_ID                     = local.effective_domain_name != "" ? local.hosted_zone_id : ""
       SSH_DOMAIN_MAPPINGS_TABLE          = local.effective_domain_name != "" ? aws_dynamodb_table.ssh_domain_mappings.name : ""
       SSL_CERTIFICATE_ARN                = local.effective_domain_name != "" ? aws_acm_certificate.wildcard[0].arn : ""
-      LAMBDA_VERSION                     = "0.5.1"
-      MIN_CLI_VERSION                    = "0.5.1"
+      LAMBDA_VERSION                     = "0.5.3"
+      MIN_CLI_VERSION                    = "0.5.2"
       DISK_CONTENTS_BUCKET               = aws_s3_bucket.disk_contents.bucket
       OPERATIONS_TABLE                   = aws_dynamodb_table.operations.name
     }, local.alb_env_vars)


### PR DESCRIPTION
Clearer help for --gpu-type (spells out MIG slice sizes instead of just listing names). Bumps pyproject to 0.5.3, LAMBDA_VERSION to 0.5.3, MIN_CLI_VERSION to 0.5.2 (any user below 0.5.2 must upgrade after tf apply). Plan diff is a single Lambda env-var update — verified locally.