### PR TITLE
feat(cli): availability counts on count menu (v0.5.4)

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/interactive.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/interactive.py
@@ -189,6 +189,12 @@ def select_gpu_count_interactive(
         # Add multinode options
         multinode_counts = [16, 24, 32, 40, 48]  # multiples of 8
 
+    # Pull live availability for the parent SKU once — used to annotate every option.
+    parent_info = (availability_info or {}).get(gpu_type, {}) if availability_info else {}
+    parent_max_reservable = int(parent_info.get("max_reservable", 0))
+    parent_full_nodes = int(parent_info.get("full_nodes_available", 0))
+    parent_available = int(parent_info.get("available", 0))
+
     # MIG slice submenu: only for h100. Each tuple is (target_gpu_type, gpu_count, gb_label).
     mig_options = []
     if gpu_type == "h100":
@@ -237,6 +243,11 @@ def select_gpu_count_interactive(
             label = f"1 GPU (single node)"
         else:
             label = f"{count} GPUs (single node)"
+        if parent_info:
+            if parent_max_reservable >= count:
+                label += f"  [{parent_available} free]"
+            else:
+                label += "  [unavailable now]"
         choices.append(questionary.Choice(title=label, value=count))
 
     # Multinode at the bottom.
@@ -246,6 +257,11 @@ def select_gpu_count_interactive(
         for count in multinode_counts:
             nodes = count // max_gpus
             label = f"{count} GPUs ({nodes} nodes × {max_gpus} GPUs)"
+            if parent_info:
+                if parent_max_reservable >= count:
+                    label += f"  [{parent_full_nodes} full nodes free]"
+                else:
+                    label += "  [unavailable now]"
             choices.append(questionary.Choice(title=label, value=count))
 
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.5.3"
+version = "0.5.4"
 description = "CLI tool for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"

--- a/terraform-gpu-devservers/lambda.tf
+++ b/terraform-gpu-devservers/lambda.tf
@@ -180,7 +180,7 @@ resource "aws_lambda_function" "reservation_processor" {
       HOSTED_ZONE_ID                     = local.effective_domain_name != "" ? local.hosted_zone_id : ""
       SSH_DOMAIN_MAPPINGS_TABLE          = local.effective_domain_name != "" ? aws_dynamodb_table.ssh_domain_mappings.name : ""
       SSL_CERTIFICATE_ARN                = local.effective_domain_name != "" ? aws_acm_certificate.wildcard[0].arn : ""
-      LAMBDA_VERSION                     = "0.5.3"
+      LAMBDA_VERSION                     = "0.5.4"
       MIN_CLI_VERSION                    = "0.5.2"
       DISK_CONTENTS_BUCKET               = aws_s3_bucket.disk_contents.bucket
       OPERATIONS_TABLE                   = aws_dynamodb_table.operations.name


### PR DESCRIPTION
Each option in the interactive count menu now shows live availability from the gpu-availability DDB table: '[N free]' for single-node, '[K full nodes free]' for multinode, '[unavailable now]' when the size doesn't fit. Bumps pyproject to 0.5.4 and LAMBDA_VERSION to 0.5.4 (MIN_CLI_VERSION stays at 0.5.2).