### PR TITLE
fix: ETA used_now should count all k8s pods, not just reservation-matched (v0.5.6)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.5.5"
+version = "0.5.6"
 description = "CLI tool for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"

--- a/terraform-gpu-devservers/lambda.tf
+++ b/terraform-gpu-devservers/lambda.tf
@@ -180,7 +180,7 @@ resource "aws_lambda_function" "reservation_processor" {
       HOSTED_ZONE_ID                     = local.effective_domain_name != "" ? local.hosted_zone_id : ""
       SSH_DOMAIN_MAPPINGS_TABLE          = local.effective_domain_name != "" ? aws_dynamodb_table.ssh_domain_mappings.name : ""
       SSL_CERTIFICATE_ARN                = local.effective_domain_name != "" ? aws_acm_certificate.wildcard[0].arn : ""
-      LAMBDA_VERSION                     = "0.5.5"
+      LAMBDA_VERSION                     = "0.5.6"
       MIN_CLI_VERSION                    = "0.5.5"
       DISK_CONTENTS_BUCKET               = aws_s3_bucket.disk_contents.bucket
       OPERATIONS_TABLE                   = aws_dynamodb_table.operations.name

--- a/terraform-gpu-devservers/lambda/availability_updater/index.py
+++ b/terraform-gpu-devservers/lambda/availability_updater/index.py
@@ -515,8 +515,14 @@ def compute_size_etas(v1, gpu_type, node_label_value, resource_name, gpus_per_in
                         pass
         if gpus > 0:
             pod_to_info[pod.metadata.name] = (pod.spec.node_name, gpus)
+            # used_now is the k8s ground-truth — count every running/pending pod, not just those
+            # we can match to a reservation row. Otherwise pods without DDB rows look like free GPUs.
+            node_state[pod.spec.node_name]["used_now"] += gpus
 
-    # 3) Cross-reference active reservations to populate per-node expirations.
+    # 3) Cross-reference active reservations to attach expiry timestamps to each known pod.
+    #    Pods without a matching reservation row keep their GPUs marked as used_now but have no
+    #    expiration → they're treated as "never expiring" by the simulation, which is the safe
+    #    fallback (we don't fabricate ETAs for usage we can't trace).
     target_gpu_type_lower = gpu_type.lower()
     for r in active_reservations:
         # Reservations table stores gpu_type uppercased ("H100"); compare case-insensitively.
@@ -534,7 +540,6 @@ def compute_size_etas(v1, gpu_type, node_label_value, resource_name, gpus_per_in
         except (ValueError, TypeError):
             continue
         node_name, gpus = pod_to_info[pod_name]
-        node_state[node_name]["used_now"] += gpus
         node_state[node_name]["expirations"].append((ts, gpus))
 
     # Sort each node's expirations by time.


### PR DESCRIPTION
size_etas were collapsing to 'now' for every type because used_now was only incremented when a pod's name matched a reservation row. With pods unmatched, free_now == capacity, every size 'available now'. Fix counts used_now from k8s ground truth; reservations cross-ref only attaches expiry timestamps.