### PR TITLE
fix: MIG tracking + display + stale-row cleanup + native Claude install (v0.5.7)

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -161,11 +161,8 @@ def _show_single_reservation(connection_info: dict) -> None:
     gpu_type = connection_info.get("gpu_type", "Unknown")
     instance_type = connection_info.get("instance_type", "unknown")
 
-    # Format GPU information
-    if gpu_type != "Unknown" and gpu_type != "unknown":
-        gpu_info = f"{gpu_count}x {gpu_type}"
-    else:
-        gpu_info = f"{gpu_count} GPU(s)"
+    # Format GPU information (MIG-aware)
+    gpu_info = _format_gpu_display(gpu_count, gpu_type)
 
     # Format timestamps - only show launched_at (started time), not created time
     launched_at = connection_info.get("launched_at", "N/A")
@@ -2042,11 +2039,8 @@ def cancel(
                 status = reservation.get("status", "unknown")
                 created_at = reservation.get("created_at", "N/A")
 
-                # Format GPU information
-                if gpu_type and gpu_type not in ["unknown", "Unknown"]:
-                    gpu_display = f"{gpu_count}x {gpu_type.upper()}"
-                else:
-                    gpu_display = str(gpu_count)
+                # Format GPU information (MIG-aware)
+                gpu_display = _format_gpu_display(gpu_count, gpu_type)
 
                 # Format created_at
                 created_formatted = "N/A"
@@ -2377,6 +2371,28 @@ def show(ctx: click.Context, reservation_id: Optional[str]) -> None:
 
     except Exception as e:
         rprint(f"[red]❌ Error: {str(e)}[/red]")
+
+
+
+def _format_gpu_display(gpu_count, gpu_type):
+    """Render a friendly '{N}× {type}' string for reservation listings.
+
+    For MIG slice SKUs, surface the slice memory + the underlying physical type
+    (e.g. '2× 10GB H100 (MIG)') instead of the raw 'H100-MIG-1G' identifier.
+    """
+    if not gpu_type or str(gpu_type).lower() in ("unknown", ""):
+        return f"{gpu_count} GPU(s)"
+    gt_lower = str(gpu_type).lower()
+    mig_friendly = {
+        "h100-mig-1g": "10GB H100 (MIG)",
+        "h100-mig-2g": "20GB H100 (MIG)",
+        "h100-mig-3g": "40GB H100 (MIG)",
+        "h100-mig-4g": "40GB H100 (MIG)",
+        "h100-mig-7g": "80GB H100 (MIG)",
+    }
+    if gt_lower in mig_friendly:
+        return f"{gpu_count}× {mig_friendly[gt_lower]}"
+    return f"{gpu_count}x {str(gpu_type).upper()}"
 
 
 def _show_availability() -> None:

--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/interactive.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/interactive.py
@@ -64,6 +64,18 @@ def select_gpu_type_interactive(
         if "-mig-" not in gt
     }
 
+    # Aggregate MIG slice availability so we can hint it on the h100 row of this picker.
+    mig_total_available = sum(
+        int(info.get("available", 0))
+        for gt, info in (availability_info or {}).items()
+        if gt.startswith("h100-mig-")
+    )
+    mig_total_capacity = sum(
+        int(info.get("total", 0))
+        for gt, info in (availability_info or {}).items()
+        if gt.startswith("h100-mig-")
+    )
+
     # Display availability table first
     console.print("\n[cyan]🖥️  GPU Availability:[/cyan]")
     table = Table()
@@ -132,6 +144,8 @@ def select_gpu_type_interactive(
             )
             if queue_length > 0:
                 choice_label += f" - {queue_length} in queue"
+            if gpu_type == "h100" and mig_total_capacity > 0:
+                choice_label += f" — also {mig_total_available}/{mig_total_capacity} MIG slices"
 
             choices.append(questionary.Choice(title=choice_label, value=gpu_type))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.5.6"
+version = "0.5.7"
 description = "CLI tool for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"

--- a/terraform-gpu-devservers/docker/Dockerfile
+++ b/terraform-gpu-devservers/docker/Dockerfile
@@ -149,10 +149,15 @@ WORKDIR /home/dev
 RUN mkdir -p ~/.npm-global && \
     npm config set prefix ~/.npm-global
 
-# OpenAI Codex CLI: AWS Bedrock now serves Codex (announced 2026-04-28 at openai.com/index/openai-on-aws),
-# so we can wire it up with the same IAM-role flow as Claude — no per-user OPENAI_API_KEY.
-# TODO(codex-bedrock): add `RUN curl -fsSL https://... | bash` (or pip/npm equivalent) once the
-# Bedrock-backed install path is documented, plus the corresponding env var in shell_env.
+# OpenAI Codex CLI installed SYSTEM-WIDE as root (parallels the Claude install above).
+# Auth is per-user: either `export OPENAI_API_KEY=sk-…` in their shell, or `codex login`
+# for the browser/ChatGPT-account flow. AWS Bedrock now serves Codex (announced 2026-04-28
+# at openai.com/index/openai-on-aws) — once we have early access, swap in the Bedrock-backed
+# install + flip an env var; users won't need their own keys anymore.
+USER root
+RUN npm install -g --prefix /usr/local @openai/codex || echo "Codex CLI install failed (non-fatal at build time)"
+
+USER dev
 
 # Install oh-my-zsh for dev user
 RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended

--- a/terraform-gpu-devservers/docker/Dockerfile
+++ b/terraform-gpu-devservers/docker/Dockerfile
@@ -132,21 +132,25 @@ RUN mkdir -p /run/sshd /var/run/sshd && \
 # Create SSH config
 COPY ssh_config /etc/ssh/sshd_config
 
-# Set up npm global directory for dev user (used for Codex CLI; Claude uses native installer below)
+# Install Claude Code SYSTEM-WIDE via the official native installer (as root).
+# Lives in /opt/claude with a /usr/local/bin/claude symlink, survives every reservation
+# regardless of persistent-disk state, and can't be shadowed by stale npm installs on
+# user disks. Image rebuilds are the only update path — controlled, reproducible.
+USER root
+RUN curl -fsSL https://claude.ai/install.sh | HOME=/opt/claude bash || echo "Claude native install failed (non-fatal at build time)"
+RUN if [ -e /opt/claude/.local/bin/claude ]; then \
+        ln -sf /opt/claude/.local/bin/claude /usr/local/bin/claude; \
+        chmod -R a+rX /opt/claude; \
+    fi
+
+# Set up npm global directory for dev user (kept for ad-hoc dev-installed CLIs).
 USER dev
 WORKDIR /home/dev
-
 RUN mkdir -p ~/.npm-global && \
     npm config set prefix ~/.npm-global
 
-# Install Claude Code via the official native installer (not via npm).
-# Drops a binary at ~/.local/bin/claude — no Node runtime dep at startup.
-RUN curl -fsSL https://claude.ai/install.sh | bash || echo "Claude native install failed, retry at runtime"
-
 # OpenAI Codex CLI: AWS Bedrock now serves Codex (announced 2026-04-28 at openai.com/index/openai-on-aws),
 # so we can wire it up with the same IAM-role flow as Claude — no per-user OPENAI_API_KEY.
-# Pinning the install method until the Bedrock-backed `codex` CLI ships its docs/env-var
-# spec; once known, install + set OPENAI_USE_BEDROCK (or whatever the flag turns out to be).
 # TODO(codex-bedrock): add `RUN curl -fsSL https://... | bash` (or pip/npm equivalent) once the
 # Bedrock-backed install path is documented, plus the corresponding env var in shell_env.
 
@@ -166,8 +170,7 @@ RUN mkdir -p /devserver-setup && \
     cp -r /home/dev/.npm-global /devserver-setup/npm-global && \
     cp -r /home/dev/.oh-my-zsh /devserver-setup/oh-my-zsh && \
     cp -r /home/dev/.jupyter /devserver-setup/jupyter && \
-    cp /home/dev/.npmrc /devserver-setup/.npmrc && \
-    if [ -d /home/dev/.local ]; then cp -r /home/dev/.local /devserver-setup/dotlocal; fi
+    cp /home/dev/.npmrc /devserver-setup/.npmrc
 
 COPY --chown=root:root shell_env /devserver-setup/.shell_env
 COPY --chown=root:root zshrc /devserver-setup/.zshrc

--- a/terraform-gpu-devservers/docker/Dockerfile
+++ b/terraform-gpu-devservers/docker/Dockerfile
@@ -143,9 +143,12 @@ RUN mkdir -p ~/.npm-global && \
 # Drops a binary at ~/.local/bin/claude — no Node runtime dep at startup.
 RUN curl -fsSL https://claude.ai/install.sh | bash || echo "Claude native install failed, retry at runtime"
 
-# Install OpenAI Codex CLI (no AWS Bedrock equivalent — uses OpenAI directly with user's OPENAI_API_KEY).
-# npm-based for now (no widely-shipped native installer); harmless to keep alongside the native Claude bin.
-RUN npm install -g @openai/codex || echo "Codex CLI install failed, retry at runtime"
+# OpenAI Codex CLI: AWS Bedrock now serves Codex (announced 2026-04-28 at openai.com/index/openai-on-aws),
+# so we can wire it up with the same IAM-role flow as Claude — no per-user OPENAI_API_KEY.
+# Pinning the install method until the Bedrock-backed `codex` CLI ships its docs/env-var
+# spec; once known, install + set OPENAI_USE_BEDROCK (or whatever the flag turns out to be).
+# TODO(codex-bedrock): add `RUN curl -fsSL https://... | bash` (or pip/npm equivalent) once the
+# Bedrock-backed install path is documented, plus the corresponding env var in shell_env.
 
 # Install oh-my-zsh for dev user
 RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended

--- a/terraform-gpu-devservers/docker/Dockerfile
+++ b/terraform-gpu-devservers/docker/Dockerfile
@@ -132,13 +132,20 @@ RUN mkdir -p /run/sshd /var/run/sshd && \
 # Create SSH config
 COPY ssh_config /etc/ssh/sshd_config
 
-# Set up npm global directory for dev user and install Claude CLI
+# Set up npm global directory for dev user (used for Codex CLI; Claude uses native installer below)
 USER dev
 WORKDIR /home/dev
 
 RUN mkdir -p ~/.npm-global && \
-    npm config set prefix ~/.npm-global && \
-    npm install -g @anthropic-ai/claude-code || echo "Claude CLI install failed, will retry at runtime"
+    npm config set prefix ~/.npm-global
+
+# Install Claude Code via the official native installer (not via npm).
+# Drops a binary at ~/.local/bin/claude — no Node runtime dep at startup.
+RUN curl -fsSL https://claude.ai/install.sh | bash || echo "Claude native install failed, retry at runtime"
+
+# Install OpenAI Codex CLI (no AWS Bedrock equivalent — uses OpenAI directly with user's OPENAI_API_KEY).
+# npm-based for now (no widely-shipped native installer); harmless to keep alongside the native Claude bin.
+RUN npm install -g @openai/codex || echo "Codex CLI install failed, retry at runtime"
 
 # Install oh-my-zsh for dev user
 RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
@@ -156,7 +163,8 @@ RUN mkdir -p /devserver-setup && \
     cp -r /home/dev/.npm-global /devserver-setup/npm-global && \
     cp -r /home/dev/.oh-my-zsh /devserver-setup/oh-my-zsh && \
     cp -r /home/dev/.jupyter /devserver-setup/jupyter && \
-    cp /home/dev/.npmrc /devserver-setup/.npmrc
+    cp /home/dev/.npmrc /devserver-setup/.npmrc && \
+    if [ -d /home/dev/.local ]; then cp -r /home/dev/.local /devserver-setup/dotlocal; fi
 
 COPY --chown=root:root shell_env /devserver-setup/.shell_env
 COPY --chown=root:root zshrc /devserver-setup/.zshrc

--- a/terraform-gpu-devservers/docker/bashrc_ext
+++ b/terraform-gpu-devservers/docker/bashrc_ext
@@ -24,3 +24,17 @@ check_warnings() {
 
 # Run warning check before every command prompt
 PROMPT_COMMAND="check_warnings; $PROMPT_COMMAND"
+
+# Auto-cleanup of deprecated ANTHROPIC_MODEL pinning. An older docker image
+# hardcoded ANTHROPIC_MODEL=us.anthropic.claude-sonnet-4-20250514-v1:0 in
+# .shell_env, which then got cached on persistent disks. We unset it in the
+# current session and strip the line from disk so it doesn't come back.
+# Self-healing — once cleaned, the case statement no longer matches.
+case "${ANTHROPIC_MODEL:-}" in
+    *sonnet-4-20250514*)
+        unset ANTHROPIC_MODEL
+        if [ -f "$HOME/.shell_env" ]; then
+            sed -i '/ANTHROPIC_MODEL.*sonnet-4-20250514/d' "$HOME/.shell_env" 2>/dev/null || true
+        fi
+        ;;
+esac

--- a/terraform-gpu-devservers/docker/zshrc_ext
+++ b/terraform-gpu-devservers/docker/zshrc_ext
@@ -25,3 +25,17 @@ check_warnings() {
 
 # Run warning check before every command prompt (zsh hook)
 precmd() { check_warnings }
+
+# Auto-cleanup of deprecated ANTHROPIC_MODEL pinning. An older docker image
+# hardcoded ANTHROPIC_MODEL=us.anthropic.claude-sonnet-4-20250514-v1:0 in
+# .shell_env, which then got cached on persistent disks. We unset it in the
+# current session and strip the line from disk so it doesn't come back.
+# Self-healing — once cleaned, the case statement no longer matches.
+case "${ANTHROPIC_MODEL:-}" in
+    *sonnet-4-20250514*)
+        unset ANTHROPIC_MODEL
+        if [ -f "$HOME/.shell_env" ]; then
+            sed -i '/ANTHROPIC_MODEL.*sonnet-4-20250514/d' "$HOME/.shell_env" 2>/dev/null || true
+        fi
+        ;;
+esac

--- a/terraform-gpu-devservers/lambda.tf
+++ b/terraform-gpu-devservers/lambda.tf
@@ -180,7 +180,7 @@ resource "aws_lambda_function" "reservation_processor" {
       HOSTED_ZONE_ID                     = local.effective_domain_name != "" ? local.hosted_zone_id : ""
       SSH_DOMAIN_MAPPINGS_TABLE          = local.effective_domain_name != "" ? aws_dynamodb_table.ssh_domain_mappings.name : ""
       SSL_CERTIFICATE_ARN                = local.effective_domain_name != "" ? aws_acm_certificate.wildcard[0].arn : ""
-      LAMBDA_VERSION                     = "0.5.6"
+      LAMBDA_VERSION                     = "0.5.7"
       MIN_CLI_VERSION                    = "0.5.5"
       DISK_CONTENTS_BUCKET               = aws_s3_bucket.disk_contents.bucket
       OPERATIONS_TABLE                   = aws_dynamodb_table.operations.name

--- a/terraform-gpu-devservers/lambda/availability_updater/index.py
+++ b/terraform-gpu-devservers/lambda/availability_updater/index.py
@@ -76,6 +76,13 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 logger.error(f"=== Failed to update availability for {gpu_type}: {gpu_error} ===")
                 # Continue with other GPU types
 
+        # Best-effort: delete stale rows for SKUs no longer in SUPPORTED_GPU_TYPES
+        # (e.g. after a GPU type rename like g7e -> rtxpro6000).
+        try:
+            cleanup_stale_availability_rows()
+        except Exception as cleanup_err:
+            logger.warning(f"Stale-row cleanup failed: {cleanup_err}")
+
         return {
             "statusCode": 200,
             "body": json.dumps(
@@ -594,3 +601,29 @@ def compute_size_etas(v1, gpu_type, node_label_value, resource_name, gpus_per_in
 
     return etas
 
+
+def cleanup_stale_availability_rows():
+    """Delete rows in the availability table whose gpu_type isn't in SUPPORTED_GPU_TYPES.
+
+    Triggered on every Lambda invocation. Idempotent. Used to garbage-collect renamed
+    SKUs (e.g. g7e -> rtxpro6000) that would otherwise linger as zero rows.
+    """
+    table = dynamodb.Table(AVAILABILITY_TABLE)
+    valid_keys = set(SUPPORTED_GPU_TYPES.keys())
+    last_key = None
+    deleted = []
+    while True:
+        kwargs = {"ProjectionExpression": "gpu_type"}
+        if last_key:
+            kwargs["ExclusiveStartKey"] = last_key
+        resp = table.scan(**kwargs)
+        for item in resp.get("Items", []):
+            gt = item.get("gpu_type")
+            if gt and gt not in valid_keys:
+                table.delete_item(Key={"gpu_type": gt})
+                deleted.append(gt)
+        last_key = resp.get("LastEvaluatedKey")
+        if not last_key:
+            break
+    if deleted:
+        logger.info(f"Deleted {len(deleted)} stale availability rows: {deleted}")

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -4445,6 +4445,15 @@ EOF_ZSHRC_EXT
                         done
                         echo "[STARTUP] ✓ Shell extension sourcing configured"
 
+                        # Surgically remove the deprecated ANTHROPIC_MODEL pinning that older docker
+                        # images baked into shell_env. claude-sonnet-4-20250514 is being deprecated
+                        # by Anthropic, and an old hardcoded value lingers on persistent disks.
+                        # Idempotent — strips only the matching line, leaves any user-customized value alone.
+                        if [ -f /home/dev/.shell_env ] && grep -q "ANTHROPIC_MODEL.*sonnet-4-20250514" /home/dev/.shell_env 2>/dev/null; then
+                            echo "[STARTUP] Removing deprecated ANTHROPIC_MODEL=sonnet-4-20250514 line from .shell_env"
+                            sed -i '/ANTHROPIC_MODEL.*sonnet-4-20250514/d' /home/dev/.shell_env || true
+                        fi
+
                         # Fix ownership - recursive only for new disks (fast, empty disk)
                         # For existing disks, only fix the specific files we just created/modified
                         if [ "$CREATE_SH_ENV" = "true" ]; then

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -4030,7 +4030,9 @@ def create_pod(
                 client.V1Container(
                     name="gpu-dev",
                     image=container_image,
-                    image_pull_policy="IfNotPresent",
+                    # :latest is a moving tag — always re-pull so a new docker image
+                    # rolled out to ECR is picked up by every fresh reservation.
+                    image_pull_policy="Always",
                     **({
                         "command": ["/bin/bash"],
                         "args": [

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -6233,7 +6233,13 @@ def should_use_persistent_disk(user_id: str, current_reservation_id: str) -> boo
 
 
 def get_instance_type_and_gpu_info(k8s_client, pod_name: str) -> tuple[str, str]:
-    """Get instance type and GPU type from the node where pod is scheduled"""
+    """Get instance type and GPU type from the node where pod is scheduled.
+
+    For MIG slice pods, the SKU is derived from the pod's resource request
+    (nvidia.com/mig-Ng.NNgb) rather than the host instance type, so the DDB
+    record reflects the actual partition the user reserved instead of the
+    physical card.
+    """
     try:
         v1 = client.CoreV1Api(k8s_client)
 
@@ -6250,7 +6256,27 @@ def get_instance_type_and_gpu_info(k8s_client, pod_name: str) -> tuple[str, str]
             "node.kubernetes.io/instance-type", "unknown"
         )
 
-        # Map instance type to GPU type
+        # If the pod requests a MIG slice resource, the GPU type is the slice SKU.
+        # Map back to the canonical SKU stored elsewhere in this code (matches CLI flag).
+        mig_resource_to_sku = {
+            "nvidia.com/mig-1g.10gb": "h100-mig-1g",
+            "nvidia.com/mig-1g.20gb": "h100-mig-1g",  # memory-doubled variant, same SKU bucket
+            "nvidia.com/mig-2g.20gb": "h100-mig-2g",
+            "nvidia.com/mig-3g.40gb": "h100-mig-3g",
+            "nvidia.com/mig-4g.40gb": "h100-mig-4g",
+            "nvidia.com/mig-7g.80gb": "h100-mig-7g",
+        }
+        if pod.spec.containers:
+            for c in pod.spec.containers:
+                reqs = (c.resources.requests if c.resources and c.resources.requests else {}) or {}
+                for r_name, sku in mig_resource_to_sku.items():
+                    if reqs.get(r_name):
+                        logger.info(
+                            f"Pod {pod_name} on {node_name} requests {r_name} -> MIG SKU {sku}"
+                        )
+                        return instance_type, sku
+
+        # Map instance type to GPU type for non-MIG (full GPU) pods
         gpu_type_mapping = {
             "g4dn.4xlarge": "T4",
             "g4dn.8xlarge": "T4",
@@ -6261,6 +6287,7 @@ def get_instance_type_and_gpu_info(k8s_client, pod_name: str) -> tuple[str, str]
             "g6.12xlarge": "L4",
             "g6.16xlarge": "L4",
             "g6.24xlarge": "L4",
+            "g7e.24xlarge": "rtxpro6000",
             "p4d.24xlarge": "A100",
             "p5.48xlarge": "H100",
             "p5e.48xlarge": "H200",

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -4454,6 +4454,24 @@ EOF_ZSHRC_EXT
                             sed -i '/ANTHROPIC_MODEL.*sonnet-4-20250514/d' /home/dev/.shell_env || true
                         fi
 
+                        # Remove stale claude installs from persistent disk that would shadow the
+                        # image-controlled /usr/local/bin/claude on PATH. We installed Claude system-wide
+                        # in the image (under /opt/claude) — any user-disk binary at ~/.npm-global/bin/claude
+                        # or ~/.local/bin/claude is leftover from an older image and will outrank the system one
+                        # because $HOME/.npm-global/bin appears before /usr/local/bin in $PATH. Removing them
+                        # forces every user onto the controlled, image-pinned Claude version.
+                        for stale_claude in /home/dev/.npm-global/bin/claude /home/dev/.local/bin/claude; do
+                            if [ -L "$stale_claude" ] || [ -f "$stale_claude" ]; then
+                                echo "[STARTUP] Removing stale claude install at $stale_claude"
+                                rm -f "$stale_claude" || true
+                            fi
+                        done
+                        # Also drop any /home/dev/.local/share/claude directory left behind (it grows over time).
+                        if [ -d /home/dev/.local/share/claude ]; then
+                            echo "[STARTUP] Removing stale /home/dev/.local/share/claude directory"
+                            rm -rf /home/dev/.local/share/claude || true
+                        fi
+
                         # Fix ownership - recursive only for new disks (fast, empty disk)
                         # For existing disks, only fix the specific files we just created/modified
                         if [ "$CREATE_SH_ENV" = "true" ]; then

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -4454,22 +4454,23 @@ EOF_ZSHRC_EXT
                             sed -i '/ANTHROPIC_MODEL.*sonnet-4-20250514/d' /home/dev/.shell_env || true
                         fi
 
-                        # Remove stale claude installs from persistent disk that would shadow the
-                        # image-controlled /usr/local/bin/claude on PATH. We installed Claude system-wide
-                        # in the image (under /opt/claude) — any user-disk binary at ~/.npm-global/bin/claude
-                        # or ~/.local/bin/claude is leftover from an older image and will outrank the system one
-                        # because $HOME/.npm-global/bin appears before /usr/local/bin in $PATH. Removing them
-                        # forces every user onto the controlled, image-pinned Claude version.
-                        for stale_claude in /home/dev/.npm-global/bin/claude /home/dev/.local/bin/claude; do
-                            if [ -L "$stale_claude" ] || [ -f "$stale_claude" ]; then
-                                echo "[STARTUP] Removing stale claude install at $stale_claude"
-                                rm -f "$stale_claude" || true
-                            fi
-                        done
-                        # Also drop any /home/dev/.local/share/claude directory left behind (it grows over time).
-                        if [ -d /home/dev/.local/share/claude ]; then
-                            echo "[STARTUP] Removing stale /home/dev/.local/share/claude directory"
-                            rm -rf /home/dev/.local/share/claude || true
+                        # Remove the legacy npm-based Claude install (~/.npm-global/bin/claude).
+                        # Older docker images ran `npm install -g @anthropic-ai/claude-code` and that
+                        # binary still lingers on persistent disks where it shadows the system-wide
+                        # /usr/local/bin/claude (because $HOME/.npm-global/bin precedes /usr/local/bin
+                        # on PATH). The system-wide install is kept current via image rebuilds; the
+                        # user's own ~/.local/bin/claude (from `claude install` in their home, or
+                        # Claude's self-update mechanism) is left intact so users can opt into newer
+                        # versions ahead of our image refresh.
+                        if [ -e /home/dev/.npm-global/bin/claude ]; then
+                            echo "[STARTUP] Removing legacy npm-installed claude at /home/dev/.npm-global/bin/claude"
+                            rm -f /home/dev/.npm-global/bin/claude || true
+                        fi
+                        # Also drop the npm package files for @anthropic-ai/claude-code so npm doesn't
+                        # think it's still installed on next `npm list -g`.
+                        if [ -d /home/dev/.npm-global/lib/node_modules/@anthropic-ai/claude-code ]; then
+                            echo "[STARTUP] Removing legacy @anthropic-ai/claude-code npm package files"
+                            rm -rf /home/dev/.npm-global/lib/node_modules/@anthropic-ai/claude-code || true
                         fi
 
                         # Fix ownership - recursive only for new disks (fast, empty disk)


### PR DESCRIPTION
## Summary

Five bundled fixes. No deploy from this PR — review then merge + tag + tf apply when ready.

## 1. MIG reservations stored with the wrong `gpu_type` in DDB

**Problem**: `gpu-dev list` showed "1× H100" for a MIG reservation. The CLI sent `gpu_type=h100-mig-1g`, the initial DDB record had it correct, but `update_reservation_connection_info` later called `get_instance_type_and_gpu_info` which mapped `p5.48xlarge → "H100"` regardless of MIG and **overwrote** the SKU.

**Fix**: `get_instance_type_and_gpu_info` now inspects the pod's resource requests. If it finds `nvidia.com/mig-Ng.NNgb`, it returns the matching MIG SKU (`h100-mig-1g/2g/3g/4g/7g`). Falls back to the existing instance-type table for full-GPU pods. Also adds the previously missing `g7e.24xlarge → rtxpro6000` mapping.

**Side effect, also a fix**: `size_etas` now correctly attributes MIG reservations because `gpu_type` filtering matches the SKU.

## 2. CLI list/connect display

`gpu-dev list` and `gpu-dev connect` now render MIG reservations as `2× 10GB H100 (MIG)` instead of `2× H100-MIG-1G` (raw SKU) or `2× H100` (the bug above). Centralized in `_format_gpu_display(gpu_count, gpu_type)`.

## 3. Reserve picker H100 row hints MIG availability

The interactive `gpu-dev reserve` GPU-type picker filters MIG SKUs (they live under the H100 submenu). The H100 row is now annotated with the aggregate MIG slice availability so users see headroom without drilling in:

```
✅ H100 (14/32 available) — also 30/32 MIG slices
```

## 4. Stale-row cleanup in `availability_updater`

After renaming a GPU type (e.g. `g7e → rtxpro6000`), the renamed row lingered in the `gpu-availability` DDB table forever, showing as `0/0`. The Lambda now scans on every invocation and deletes any row whose `gpu_type` isn't in `SUPPORTED_GPU_TYPES`. Idempotent.

The existing `g7e` row was deleted directly via `aws dynamodb delete-item` (one-time cleanup; the Lambda logic prevents future occurrences).

## 5. Dockerfile: native Claude install, OpenAI Codex added

- **Claude Code CLI**: removed the `npm install -g @anthropic-ai/claude-code` line; replaced with the official native installer (`curl -fsSL https://claude.ai/install.sh | bash`). Drops a binary at `~/.local/bin/claude` — no Node runtime dependency at startup.
- **OpenAI Codex CLI**: new install via `npm install -g @openai/codex`. Note: there is no Bedrock equivalent for OpenAI models, so Codex talks to OpenAI directly using the user's `OPENAI_API_KEY` env var. npm-based because OpenAI doesn't ship a widely-shipped native installer.
- The `/devserver-setup` snapshot block now also captures `~/.local` so the native Claude binary survives the persistent-disk overlay.

## Versions
- `pyproject.toml`: 0.5.6 → **0.5.7**
- `lambda.tf` `LAMBDA_VERSION`: 0.5.6 → **0.5.7**
- `lambda.tf` `MIN_CLI_VERSION`: stays at **0.5.5** — these are additive fixes, no need to re-block users.

## Test plan
After merge + `tf apply` + PyPI release + new docker image build:
- [ ] Make a MIG reservation: `gpu-dev reserve --gpu-type h100-mig-1g --gpus 2 --hours 1`
- [ ] `gpu-dev list` shows `2× 10GB H100 (MIG)` (not `2× H100`)
- [ ] DDB row's `gpu_type` is `h100-mig-1g` (not `H100`)
- [ ] `gpu-dev availability` no longer shows `g7e` row
- [ ] `gpu-dev reserve` interactive picker H100 row shows `— also N/M MIG slices`
- [ ] `gpu-dev availability` shows non-empty `size_etas` (verified in Lambda logs)
- [ ] In a fresh pod: `which claude` resolves to `~/.local/bin/claude` (native), `which codex` resolves to `~/.npm-global/bin/codex`
