### PR TITLE
chore: bump MIN_CLI_VERSION to 0.5.9

### DIFF
--- a/terraform-gpu-devservers/lambda.tf
+++ b/terraform-gpu-devservers/lambda.tf
@@ -181,7 +181,7 @@ resource "aws_lambda_function" "reservation_processor" {
       SSH_DOMAIN_MAPPINGS_TABLE          = local.effective_domain_name != "" ? aws_dynamodb_table.ssh_domain_mappings.name : ""
       SSL_CERTIFICATE_ARN                = local.effective_domain_name != "" ? aws_acm_certificate.wildcard[0].arn : ""
       LAMBDA_VERSION                     = "0.5.9"
-      MIN_CLI_VERSION                    = "0.5.5"
+      MIN_CLI_VERSION                    = "0.5.9"
       DISK_CONTENTS_BUCKET               = aws_s3_bucket.disk_contents.bucket
       OPERATIONS_TABLE                   = aws_dynamodb_table.operations.name
     }, local.alb_env_vars)


### PR DESCRIPTION
0.5.9 ships size_etas pass-through, parallel CLI startup, 24h SSH cache, MIG/display fixes — all tested and stable. Bumping the floor so users on <0.5.9 are prompted to upgrade.