### PR TITLE
chore: bump MIN_CLI_VERSION + LAMBDA_VERSION to 0.5.16

### DIFF
--- a/terraform-gpu-devservers/lambda.tf
+++ b/terraform-gpu-devservers/lambda.tf
@@ -180,8 +180,8 @@ resource "aws_lambda_function" "reservation_processor" {
       HOSTED_ZONE_ID                     = local.effective_domain_name != "" ? local.hosted_zone_id : ""
       SSH_DOMAIN_MAPPINGS_TABLE          = local.effective_domain_name != "" ? aws_dynamodb_table.ssh_domain_mappings.name : ""
       SSL_CERTIFICATE_ARN                = local.effective_domain_name != "" ? aws_acm_certificate.wildcard[0].arn : ""
-      LAMBDA_VERSION                     = "0.5.13"
-      MIN_CLI_VERSION                    = "0.5.9"
+      LAMBDA_VERSION                     = "0.5.16"
+      MIN_CLI_VERSION                    = "0.5.16"
       DISK_CONTENTS_BUCKET               = aws_s3_bucket.disk_contents.bucket
       OPERATIONS_TABLE                   = aws_dynamodb_table.operations.name
     }, local.alb_env_vars)


### PR DESCRIPTION
Requires tf apply to roll the new env vars onto the Lambda. Forces all users onto v0.5.16 (auth cache, reservation_mgr fix, B200 MIG SKUs).