### PR TITLE
fix: EKS bearer token TTL mismatch (60s vs 14m cache)

### DIFF
--- a/terraform-gpu-devservers/lambda.tf
+++ b/terraform-gpu-devservers/lambda.tf
@@ -180,7 +180,7 @@ resource "aws_lambda_function" "reservation_processor" {
       HOSTED_ZONE_ID                     = local.effective_domain_name != "" ? local.hosted_zone_id : ""
       SSH_DOMAIN_MAPPINGS_TABLE          = local.effective_domain_name != "" ? aws_dynamodb_table.ssh_domain_mappings.name : ""
       SSL_CERTIFICATE_ARN                = local.effective_domain_name != "" ? aws_acm_certificate.wildcard[0].arn : ""
-      LAMBDA_VERSION                     = "0.5.17"
+      LAMBDA_VERSION                     = "0.5.18"
       MIN_CLI_VERSION                    = "0.5.16"
       DISK_CONTENTS_BUCKET               = aws_s3_bucket.disk_contents.bucket
       OPERATIONS_TABLE                   = aws_dynamodb_table.operations.name

--- a/terraform-gpu-devservers/lambda/shared/k8s_client.py
+++ b/terraform-gpu-devservers/lambda/shared/k8s_client.py
@@ -31,9 +31,14 @@ def get_bearer_token() -> str:
     """
     Create a k8s-aws-v1 bearer token by presigning STS:GetCallerIdentity.
     IMPORTANT: base64url-encode the FULL presigned URL, then strip padding.
+
+    expires_in must match _EFFECTIVE_TOKEN_TTL: previously this was 60s while the cache
+    held the token for 14 min, so warm Lambda containers handed EKS expired URLs and got
+    401s for ~13 min until the next refresh. 900s is the typical EKS get-token default
+    and the max for IAM-role-derived presigned URLs.
     """
     logger.info("Starting bearer token generation")
-    STS_TOKEN_EXPIRES_IN = 60
+    STS_TOKEN_EXPIRES_IN = 900
     session = boto3.session.Session(region_name=REGION)
     logger.info(f"Created boto3 session for region {REGION}")
 


### PR DESCRIPTION
Lambda warm containers were silently returning 401 from k8s API calls. The presigned STS URL was generated with expires_in=60 but cached for 14 min, so the refresh hook never triggered while the token was actually invalid. Symptom: a B200 MIG reservation queued forever despite 2 free slices, and 'Schedulable B200-MIG-2G GPUs: 0' (the 401 was swallowed and treated as zero capacity). Bumping STS_TOKEN_EXPIRES_IN to 900s aligns it with the cache TTL.