### PR TITLE
fix(lambda): preserve B200 MIG SKU in DDB (was overwriting to B200)

### DIFF
--- a/terraform-gpu-devservers/lambda.tf
+++ b/terraform-gpu-devservers/lambda.tf
@@ -180,7 +180,7 @@ resource "aws_lambda_function" "reservation_processor" {
       HOSTED_ZONE_ID                     = local.effective_domain_name != "" ? local.hosted_zone_id : ""
       SSH_DOMAIN_MAPPINGS_TABLE          = local.effective_domain_name != "" ? aws_dynamodb_table.ssh_domain_mappings.name : ""
       SSL_CERTIFICATE_ARN                = local.effective_domain_name != "" ? aws_acm_certificate.wildcard[0].arn : ""
-      LAMBDA_VERSION                     = "0.5.18"
+      LAMBDA_VERSION                     = "0.5.19"
       MIN_CLI_VERSION                    = "0.5.16"
       DISK_CONTENTS_BUCKET               = aws_s3_bucket.disk_contents.bucket
       OPERATIONS_TABLE                   = aws_dynamodb_table.operations.name

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -6319,6 +6319,9 @@ def get_instance_type_and_gpu_info(k8s_client, pod_name: str) -> tuple[str, str]
             "nvidia.com/mig-3g.40gb": "h100-mig-3g",
             "nvidia.com/mig-4g.40gb": "h100-mig-4g",
             "nvidia.com/mig-7g.80gb": "h100-mig-7g",
+            "nvidia.com/mig-1g.23gb": "b200-mig-1g",
+            "nvidia.com/mig-2g.45gb": "b200-mig-2g",
+            "nvidia.com/mig-3g.90gb": "b200-mig-3g",
         }
         if pod.spec.containers:
             for c in pod.spec.containers:


### PR DESCRIPTION
Lambda's get_instance_type_and_gpu_info had only H100 MIG resource->SKU mappings, so B200 MIG pods got their SKU clobbered to plain B200 by the instance-type fallback (p6-b200.48xlarge). gpu-dev list then displayed '1× B200' instead of '1× 45GB B200 (MIG)'. Adds entries for nvidia.com/mig-{1g.23gb,2g.45gb,3g.90gb}.