### PR TITLE
fix(lambda): MULTINODE_* env vars now visible in SSH login shells

### DIFF
--- a/terraform-gpu-devservers/lambda.tf
+++ b/terraform-gpu-devservers/lambda.tf
@@ -180,7 +180,7 @@ resource "aws_lambda_function" "reservation_processor" {
       HOSTED_ZONE_ID                     = local.effective_domain_name != "" ? local.hosted_zone_id : ""
       SSH_DOMAIN_MAPPINGS_TABLE          = local.effective_domain_name != "" ? aws_dynamodb_table.ssh_domain_mappings.name : ""
       SSL_CERTIFICATE_ARN                = local.effective_domain_name != "" ? aws_acm_certificate.wildcard[0].arn : ""
-      LAMBDA_VERSION                     = "0.5.21"
+      LAMBDA_VERSION                     = "0.5.22"
       MIN_CLI_VERSION                    = "0.5.16"
       DISK_CONTENTS_BUCKET               = aws_s3_bucket.disk_contents.bucket
       OPERATIONS_TABLE                   = aws_dynamodb_table.operations.name

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -4476,6 +4476,16 @@ EOF_PROFILE
 # User identification
 export GPU_DEV_USER_ID="{user_id or 'dev'}"
 
+# Multinode peer info — inlined from container env at pod startup. sshd strips
+# container env vars from login shells, so we materialize the values into rc files.
+# Skipped (empty exports) for single-node reservations where MULTINODE_* aren't set.
+export MULTINODE_HOSTS="$MULTINODE_HOSTS"
+export MULTINODE_PEER_PODS="$MULTINODE_PEER_PODS"
+export MULTINODE_RANK="$MULTINODE_RANK"
+export MULTINODE_SIZE="$MULTINODE_SIZE"
+export MASTER_ADDR="$MASTER_ADDR"
+export MASTER_PORT="$MASTER_PORT"
+
 # Function to check for GPU reservation expiry warnings and startup script status
 check_warnings() {{
     # Check for startup script still running
@@ -4519,6 +4529,15 @@ EOF_BASHRC_EXT
 
 # User identification
 export GPU_DEV_USER_ID="{user_id or 'dev'}"
+
+# Multinode peer info — inlined from container env at pod startup. sshd strips
+# container env vars from login shells, so we materialize the values into rc files.
+export MULTINODE_HOSTS="$MULTINODE_HOSTS"
+export MULTINODE_PEER_PODS="$MULTINODE_PEER_PODS"
+export MULTINODE_RANK="$MULTINODE_RANK"
+export MULTINODE_SIZE="$MULTINODE_SIZE"
+export MASTER_ADDR="$MASTER_ADDR"
+export MASTER_PORT="$MASTER_PORT"
 
 # Function to check for GPU reservation expiry warnings and startup script status
 check_warnings() {{


### PR DESCRIPTION
openssh strips container env vars from login shells. The MULTINODE_HOSTS/RANK/SIZE/MASTER_ADDR feature shipped in v0.5.21 set them on the pod spec but they came back empty when SSH'd in. Materialize the values into .bashrc_ext / .zshrc_ext at pod startup via the existing unquoted heredoc — bash expands $MULTINODE_HOSTS etc. at write time, baking the literal values into the rc files.