### PR TITLE
fix(submit): install rsync in base image + local rsync precheck (v0.5.20)

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -1398,6 +1398,15 @@ def submit(ctx, gpu_type, gpus, hours, disk, no_persistent_disk, dockerfile, doc
         rprint("[red]❌ Provide a command after --, e.g. gpu-dev submit --runtime ./ -- python train.py[/red]")
         sys.exit(2)
 
+    # rsync is on macOS by default and on virtually every Linux distro; bail early with a
+    # readable message if the user has somehow uninstalled it locally rather than failing
+    # mid-flight after the reservation has already been created.
+    if runtime:
+        import shutil
+        if not shutil.which("rsync"):
+            rprint("[red]❌ rsync not found on PATH locally. Install it (Mac: 'brew install rsync', Debian/Ubuntu: 'sudo apt install rsync') and retry.[/red]")
+            sys.exit(2)
+
     gt = gpu_type.lower()
     # Per-type max GPUs (mirrors gpu_configs in reserve flow)
     max_per_node = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.5.19"
+version = "0.5.20"
 description = "CLI tool for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"

--- a/terraform-gpu-devservers/docker/Dockerfile
+++ b/terraform-gpu-devservers/docker/Dockerfile
@@ -36,7 +36,8 @@ RUN apt-get install -y --no-install-recommends \
         unzip \
         ccache \
         htop \
-        tree
+        tree \
+        rsync
 # Install Node.js 20 from NodeSource (required for Claude CLI)
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs


### PR DESCRIPTION
submit was failing post-reserve with 'rsync: command not found' because the base image lacked rsync. Add rsync to the apt install list (tiny, useful generally). Also fail fast if rsync is missing on the client before any reservation is created. Requires tofu apply to rebuild + push the new image to ECR.