### PR TITLE
fix(prepuller): maxUnavailable=100% for image prepuller DaemonSet

### DIFF
--- a/terraform-gpu-devservers/kubernetes.tf
+++ b/terraform-gpu-devservers/kubernetes.tf
@@ -416,6 +416,17 @@ resource "kubernetes_manifest" "image_prepuller_daemonset" {
           app = "image-prepuller"
         }
       }
+      # The prepuller does nothing but pull an image + sit in a pause container.
+      # Default maxUnavailable=1 makes a 32GB image roll out across 26 nodes take
+      # ~2.5h, so user pods landing on un-updated nodes still pull from ECR fresh.
+      # Parallel is safe here — restarting the prepuller doesn't disrupt anything,
+      # and the kubelet's image cache is independent of the prepuller pod's lifecycle.
+      updateStrategy = {
+        type = "RollingUpdate"
+        rollingUpdate = {
+          maxUnavailable = "100%"
+        }
+      }
       template = {
         metadata = {
           labels = {


### PR DESCRIPTION
Default sequential rollout meant a 32 GB image across 26 nodes took ~2.5h to propagate; for hours after a docker push, new user pods on un-updated nodes paid a fresh 5-7 min ECR pull. Prepuller doesn't run any traffic-bearing workload — restarting in parallel is safe, kubelet image cache is independent of pod lifecycle. Live patch already applied to current cluster.