### PR TITLE
fix(submit): catch missing -- on flag names before paying for a reservation (v0.5.21)

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -1398,6 +1398,18 @@ def submit(ctx, gpu_type, gpus, hours, disk, no_persistent_disk, dockerfile, doc
         rprint("[red]❌ Provide a command after --, e.g. gpu-dev submit --runtime ./ -- python train.py[/red]")
         sys.exit(2)
 
+    # Catch the common typo where the user drops the leading -- on an option name and
+    # the option's value gets swept into the command (because submit accepts arbitrary
+    # commands via ignore_unknown_options). Without this guard the remote shell happily
+    # runs `gpus 1 bash run.sh` and the user wonders why.
+    _submit_flag_names = {"gpus", "gpu-type", "hours", "disk", "no-persistent-disk",
+                          "dockerfile", "dockerimage", "preserve-entrypoint", "runtime",
+                          "no-pull", "keep-alive", "name", "timeout"}
+    if command[0] in _submit_flag_names:
+        rprint(f"[red]❌ '{command[0]}' looks like a missing '--'. Did you mean '--{command[0]}'? "
+               f"Put your command after '--', e.g. gpu-dev submit --{command[0]} <value> ... -- bash run.sh[/red]")
+        sys.exit(2)
+
     # rsync is on macOS by default and on virtually every Linux distro; bail early with a
     # readable message if the user has somehow uninstalled it locally rather than failing
     # mid-flight after the reservation has already been created.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.5.20"
+version = "0.5.21"
 description = "CLI tool for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"


### PR DESCRIPTION
If a user typos 'gpus 1' instead of '--gpus 1', Click swept it into the trailing command (which submit deliberately leaves unparsed for arbitrary remote commands). They got a reservation, ran 'gpus 1 bash run.sh' on the pod, command-not-found, exit 127. Add an upfront check: if command[0] matches a known submit flag name, bail with 'Did you mean --gpus?' before reserving anything.