### PR TITLE
feat: gpu-dev pods as login nodes — IRSA + bundled CLI + auto-upgrade

### DIFF
--- a/terraform-gpu-devservers/docker/Dockerfile
+++ b/terraform-gpu-devservers/docker/Dockerfile
@@ -103,6 +103,8 @@ ENV NCCL_ASYNC_ERROR_HANDLING=1
 ENV SUPPORTS_EFA=true
 
 # Install Python packages (Jupyter and common ML packages)
+# gpu-dev itself is bundled so users can run `gpu-dev submit` from inside their pod
+# (combined with IRSA on the pod's service account, no manual aws sso login needed).
 RUN pip install --no-cache-dir --break-system-packages \
         jupyterlab \
         ipywidgets \
@@ -112,7 +114,8 @@ RUN pip install --no-cache-dir --break-system-packages \
         numpy \
         scikit-learn \
         plotly \
-        tensorboard
+        tensorboard \
+        gpu-dev
 
 # Create dev user with UID 1081 to avoid conflicts with common base image users (e.g., ubuntu=1000)
 RUN useradd -u 1081 -m -s /usr/bin/zsh dev && \

--- a/terraform-gpu-devservers/gpu-dev-pod-irsa.tf
+++ b/terraform-gpu-devservers/gpu-dev-pod-irsa.tf
@@ -1,0 +1,88 @@
+# IRSA wiring for user-facing gpu-dev pods.
+#
+# Goal: when a user SSHs into their CPU dev pod (or any gpu-dev pod) and runs
+# `gpu-dev submit ...`, boto3 picks up temporary AWS credentials via the
+# IAM-roles-for-service-accounts mechanism — no manual `aws sso login` needed.
+#
+# Identity preservation: Lambda sets AWS_ROLE_SESSION_NAME=<user identity>
+# on the pod env, so STS GetCallerIdentity returns
+#   arn:aws:sts::<acct>:assumed-role/<role>/<user>
+# and the existing `authenticate_user` ARN-tail parsing keeps working unchanged.
+
+# Policy mirrors cli-tools/gpu-dev-cli/minimal-iam-policy.json — same scope a
+# user gets when they `aws sso login` from their laptop.
+resource "aws_iam_role" "gpu_dev_pod_role" {
+  name = "gpu-dev-pod-role-${local.current_config.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.eks.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${replace(aws_iam_openid_connect_provider.eks.url, "https://", "")}:sub" = "system:serviceaccount:gpu-dev:gpu-dev-pod-sa"
+            "${replace(aws_iam_openid_connect_provider.eks.url, "https://", "")}:aud" = "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "GPU Dev Pod IRSA Role"
+    Environment = local.current_config.environment
+  }
+}
+
+resource "aws_iam_role_policy" "gpu_dev_pod_policy" {
+  name = "gpu-dev-pod-policy"
+  role = aws_iam_role.gpu_dev_pod_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "sqs:SendMessage",
+          "sqs:GetQueueUrl",
+          "sqs:GetQueueAttributes"
+        ]
+        Resource = "arn:aws:sqs:*:*:pytorch-gpu-dev-reservation-queue"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:Query",
+          "dynamodb:Scan"
+        ]
+        Resource = [
+          "arn:aws:dynamodb:*:*:table/pytorch-gpu-dev-reservations",
+          "arn:aws:dynamodb:*:*:table/pytorch-gpu-dev-reservations/index/*",
+          "arn:aws:dynamodb:*:*:table/pytorch-gpu-dev-gpu-availability"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = "sts:GetCallerIdentity"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "kubernetes_service_account" "gpu_dev_pod" {
+  metadata {
+    name      = "gpu-dev-pod-sa"
+    namespace = kubernetes_namespace.gpu_dev.metadata[0].name
+    annotations = {
+      "eks.amazonaws.com/role-arn" = aws_iam_role.gpu_dev_pod_role.arn
+    }
+  }
+}

--- a/terraform-gpu-devservers/lambda.tf
+++ b/terraform-gpu-devservers/lambda.tf
@@ -180,7 +180,7 @@ resource "aws_lambda_function" "reservation_processor" {
       HOSTED_ZONE_ID                     = local.effective_domain_name != "" ? local.hosted_zone_id : ""
       SSH_DOMAIN_MAPPINGS_TABLE          = local.effective_domain_name != "" ? aws_dynamodb_table.ssh_domain_mappings.name : ""
       SSL_CERTIFICATE_ARN                = local.effective_domain_name != "" ? aws_acm_certificate.wildcard[0].arn : ""
-      LAMBDA_VERSION                     = "0.5.22"
+      LAMBDA_VERSION                     = "0.5.23"
       MIN_CLI_VERSION                    = "0.5.16"
       DISK_CONTENTS_BUCKET               = aws_s3_bucket.disk_contents.bucket
       OPERATIONS_TABLE                   = aws_dynamodb_table.operations.name

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -4577,6 +4577,16 @@ EOF_ZSHRC_EXT
                         chown 1081:1081 /home/dev/.bashrc_ext /home/dev/.zshrc_ext
                         echo "[STARTUP] ✓ Shell extension files written"
 
+                        # Background-refresh gpu-dev so older images / persistent disks pick up the
+                        # latest CLI without forcing the user to pip install it themselves. The
+                        # baseline gpu-dev is already in the image; this just upgrades.
+                        (
+                            pip install --no-cache-dir --break-system-packages --upgrade gpu-dev \
+                                > /tmp/gpu-dev-upgrade.log 2>&1 \
+                                && echo "[STARTUP] gpu-dev upgraded to $(gpu-dev --version 2>&1 | tail -1)" \
+                                || echo "[STARTUP] gpu-dev upgrade failed (non-fatal); see /tmp/gpu-dev-upgrade.log"
+                        ) &
+
                         # Ensure existing rc files source the extensions (for persistent disks with old configs)
                         for rcfile in /home/dev/.bashrc /home/dev/.zshrc; do
                             if [ -f "$rcfile" ]; then
@@ -5301,6 +5311,9 @@ EOF
                         ),
                         client.V1EnvVar(
                             name="NVIDIA_DRIVER_CAPABILITIES", value="compute,utility"
+                        ),
+                        client.V1EnvVar(
+                            name="AWS_ROLE_SESSION_NAME", value=(user_id or "gpu-dev-pod")[:64]
                         )
                     ] + get_nccl_env_vars(gpu_type) + get_cpu_thread_env_vars(gpu_count, gpu_type) + _get_multinode_env_vars(multinode_peer_pods, multinode_rank),
                     resources=client.V1ResourceRequirements(
@@ -5483,6 +5496,11 @@ EOF
             ] if not gpu_type.startswith("cpu-") else [],
             # Faster pod deletion (default is 30s)
             termination_grace_period_seconds=10,
+            # IRSA: bind the pod to the gpu-dev-pod-sa service account so boto3 inside
+            # the pod gets temporary creds via STS AssumeRoleWithWebIdentity. Combined
+            # with the AWS_ROLE_SESSION_NAME env var below this lets users run
+            # `gpu-dev submit` from inside their dev pod with no manual aws sso login.
+            service_account_name="gpu-dev-pod-sa",
             # EFA requires host network namespace for RDMA access to efa0 interface
             **({
                 "host_network": True,


### PR DESCRIPTION
Users SSH into a CPU pod and 'gpu-dev submit' just works. New IRSA role mirrors the minimal CLI IAM policy. AWS_ROLE_SESSION_NAME=<user> on pod env preserves ARN-tail identity for the existing authenticate_user parser. CLI is installed in the base image, with a background 'pip install --upgrade' at pod startup.