### PR TITLE
feat(cli): show Max Reservable column in gpu-dev reserve interactive (v0.5.22)

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/interactive.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/interactive.py
@@ -89,6 +89,7 @@ def select_gpu_type_interactive(
     table = Table()
     table.add_column("GPU Type", style="cyan")
     table.add_column("Avail", style="green")
+    table.add_column("Max\nReservable", style="bright_green")
     table.add_column("Total", style="blue")
     table.add_column("Queue\nLength", style="yellow")
     table.add_column("Est. Wait Time", style="magenta")
@@ -96,6 +97,7 @@ def select_gpu_type_interactive(
     choices = []
     for gpu_type, info in visible_info.items():
         available = info.get("available", 0)
+        max_reservable = info.get("max_reservable", 0)
         total = info.get("total", 0)
         queue_length = info.get("queue_length", 0)
         est_wait = info.get("estimated_wait_minutes", 0)
@@ -134,6 +136,7 @@ def select_gpu_type_interactive(
         table.add_row(
             gpu_type.upper(),
             available_display,
+            "-" if is_maintenance else str(max_reservable),
             str(total),
             str(queue_length) if not is_maintenance else "-",
             wait_display,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.5.21"
+version = "0.5.22"
 description = "CLI tool for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"


### PR DESCRIPTION
The reserve interactive picker only showed total Avail, not the per-node max. Users would see Avail=23 on H100 and try to reserve 23, hitting the multinode multiple-of-8 constraint. Adds the Max Reservable column (same as gpu-dev avail) before Total.