### PR TITLE
feat(tf): prod-east1 workspace (us-east-1, spot-only T4/L4/CPU)

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/config.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/config.py
@@ -22,6 +22,11 @@ class Config:
             "workspace": "prod",
             "description": "Production environment",
         },
+        "prod-east1": {
+            "region": "us-east-1",
+            "workspace": "prod-east1",
+            "description": "Spot-only us-east-1 environment (T4/L4/CPU)",
+        },
     }
     DEFAULT_ENVIRONMENT = "prod"
 

--- a/terraform-gpu-devservers/eks.tf
+++ b/terraform-gpu-devservers/eks.tf
@@ -401,11 +401,14 @@ resource "aws_launch_template" "gpu_dev_launch_template" {
     }
   }
 
-  # Conditionally add instance_market_options for capacity block instances (only when capacity reservation exists)
+  # instance_market_options: capacity-block when bound to a reservation, spot when
+  # the workspace's gpu_config has use_spot=true, otherwise on-demand (no block).
+  # Spot is mutually exclusive with capacity reservations — AWS rejects launch templates
+  # carrying both, so the precedence here is CR > spot > on-demand.
   dynamic "instance_market_options" {
-    for_each = each.value.capacity_reservation_id != null ? [1] : []
+    for_each = (each.value.capacity_reservation_id != null || try(each.value.gpu_config.use_spot, false)) ? [1] : []
     content {
-      market_type = "capacity-block"
+      market_type = each.value.capacity_reservation_id != null ? "capacity-block" : "spot"
     }
   }
 

--- a/terraform-gpu-devservers/main.tf
+++ b/terraform-gpu-devservers/main.tf
@@ -315,6 +315,50 @@ locals {
         }
       }
     }
+    # us-east-1 spot-only experimental cluster.
+    # Same provisioning shape as prod (managed via the terraform.workspace switch) but
+    # backed entirely by EC2 Spot — first cheap-and-cheerful environment we can deploy
+    # new instance types into (B300 land here once on-demand quota arrives).
+    "prod-east1" = {
+      aws_region             = "us-east-1"
+      environment            = "prod-east1"
+      domain_name            = "east1.devservers.io"
+      gpu_instance_count     = 1
+      use_self_managed_nodes = true
+      instance_type          = "g4dn.12xlarge"
+      supported_gpu_types = {
+        "t4" = {
+          instance_type       = "g4dn.12xlarge"
+          instance_types      = null
+          instance_count      = 1
+          gpus_per_instance   = 4
+          use_placement_group = false
+          architecture        = "x86_64"
+          efa_network_cards   = 0
+          use_spot            = true
+        }
+        "l4" = {
+          instance_type       = "g6.12xlarge"
+          instance_types      = null
+          instance_count      = 1
+          gpus_per_instance   = 4
+          use_placement_group = false
+          architecture        = "x86_64"
+          efa_network_cards   = 1
+          use_spot            = true
+        }
+        "cpu-x86" = {
+          instance_type       = "c7i.8xlarge"
+          instance_types      = null
+          instance_count      = 5
+          gpus_per_instance   = 0
+          use_placement_group = false
+          architecture        = "x86_64"
+          efa_network_cards   = 0
+          use_spot            = true
+        }
+      }
+    }
   }
 
   # Current workspace configuration
@@ -322,6 +366,9 @@ locals {
 
   # Workspace-specific capacity reservations (with manual instance counts)
   capacity_reservations = {
+    "prod-east1" = {
+      # No capacity reservations — this workspace is spot-only.
+    }
     default = {
       # Test environment capacity reservations
       # h100 = [
@@ -366,6 +413,13 @@ locals {
 
   # Workspace-specific GPU type to subnet mappings
   gpu_subnet_assignments = {
+    "prod-east1" = {
+      # All node types land in the primary subnet (us-east-1a). Spot availability is
+      # better than placement-group-strictness on these small ASGs.
+      t4         = "primary"
+      l4         = "primary"
+      "cpu-x86"  = "primary"
+    }
     default = {
       # Test environment - T4 nodes in multiple AZs for testing
       t4         = "primary"   # T4 in us-west-1a (primary AZ)
@@ -392,6 +446,9 @@ locals {
 
   # Per-capacity-reservation AZ mappings (overrides gpu_subnet_assignments when CR is used)
   capacity_reservation_azs = {
+    "prod-east1" = {
+      # Empty — no CRs in this workspace.
+    }
     default = {
       "cr-04d3d1d84e127a562" = "secondary" # us-west-1c
     }

--- a/terraform-gpu-devservers/node-termination-handler.tf
+++ b/terraform-gpu-devservers/node-termination-handler.tf
@@ -1,0 +1,36 @@
+# AWS Node Termination Handler — graceful drain on spot-interrupt + ASG lifecycle events.
+#
+# IMDS mode (one DaemonSet per node, no SQS / no IAM role) is plenty for our use case:
+# we don't care about queue-processor features (rebalance recommendations, scheduled
+# events). We just want pods to get a clean SIGTERM when AWS sends the 2-minute spot
+# notice via instance metadata, instead of being killed cold.
+#
+# Tolerates everything so it runs on the GPU nodes that have nvidia.com/gpu:NoSchedule.
+
+resource "helm_release" "aws_node_termination_handler" {
+  name             = "aws-node-termination-handler"
+  repository       = "https://aws.github.io/eks-charts"
+  chart            = "aws-node-termination-handler"
+  namespace        = "kube-system"
+  version          = "0.27.1"
+  cleanup_on_fail  = true
+
+  values = [yamlencode({
+    enableSpotInterruptionDraining = true
+    enableScheduledEventDraining   = true
+    enableRebalanceMonitoring      = true
+    enableRebalanceDraining        = false # warning only; rebalance recommendations are too noisy
+    nodeSelector = {
+      "kubernetes.io/os" = "linux"
+    }
+    tolerations = [
+      { operator = "Exists" }, # tolerate every taint; we want NTH on every node, including GPU nodes
+    ]
+    resources = {
+      requests = { cpu = "50m", memory = "64Mi" }
+      limits   = { cpu = "100m", memory = "128Mi" }
+    }
+  })]
+
+  depends_on = [aws_eks_cluster.gpu_dev_cluster]
+}


### PR DESCRIPTION
Adds a new terraform workspace 'prod-east1' for a spot-only EKS deployment in us-east-1. 1x T4, 1x L4, 5x cpu-x86 — all spot. Touches main.tf (workspace_configs + capacity_reservations + subnet_assignments + capacity_reservation_azs) and eks.tf (instance_market_options now also handles spot via the new use_spot field on supported_gpu_types entries). Existing prod is untouched because use_spot defaults to false there. Operator steps to deploy are in the commit message. Open for review before any apply.