### PR TITLE
fix: IRSA reachable to dev user + auto-populate github_user inside pods (v0.5.23)

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/config.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/config.py
@@ -240,8 +240,17 @@ class Config:
         return self.user_config.get(key)
 
     def get_github_username(self) -> Optional[str]:
-        """Get GitHub username from config."""
-        return self.user_config.get("github_user")
+        """Get GitHub username, falling back to GPU_DEV_GITHUB_USER env var.
+
+        Lambda sets GPU_DEV_GITHUB_USER on every pod from the reservation's
+        github_user field, so a user running gpu-dev from inside their dev pod
+        doesn\'t have to `gpu-dev config set github_user <name>` first.
+        """
+        v = self.user_config.get("github_user")
+        if v:
+            return v
+        v = os.environ.get("GPU_DEV_GITHUB_USER")
+        return v or None
 
 
 def load_config() -> Config:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.5.22"
+version = "0.5.23"
 description = "CLI tool for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"

--- a/terraform-gpu-devservers/lambda.tf
+++ b/terraform-gpu-devservers/lambda.tf
@@ -180,7 +180,7 @@ resource "aws_lambda_function" "reservation_processor" {
       HOSTED_ZONE_ID                     = local.effective_domain_name != "" ? local.hosted_zone_id : ""
       SSH_DOMAIN_MAPPINGS_TABLE          = local.effective_domain_name != "" ? aws_dynamodb_table.ssh_domain_mappings.name : ""
       SSL_CERTIFICATE_ARN                = local.effective_domain_name != "" ? aws_acm_certificate.wildcard[0].arn : ""
-      LAMBDA_VERSION                     = "0.5.23"
+      LAMBDA_VERSION                     = "0.5.24"
       MIN_CLI_VERSION                    = "0.5.16"
       DISK_CONTENTS_BUCKET               = aws_s3_bucket.disk_contents.bucket
       OPERATIONS_TABLE                   = aws_dynamodb_table.operations.name

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -4486,6 +4486,18 @@ export MULTINODE_SIZE="$MULTINODE_SIZE"
 export MASTER_ADDR="$MASTER_ADDR"
 export MASTER_PORT="$MASTER_PORT"
 
+# IRSA + region — same reason as MULTINODE: sshd strips these from login shells, so
+# we bake the current container values into the rc file. Lets gpu-dev / aws / boto3
+# inside an SSH session pick up the gpu-dev-pod-sa IAM role automatically.
+export AWS_ROLE_ARN="$AWS_ROLE_ARN"
+export AWS_WEB_IDENTITY_TOKEN_FILE="$AWS_WEB_IDENTITY_TOKEN_FILE"
+export AWS_ROLE_SESSION_NAME="$AWS_ROLE_SESSION_NAME"
+export AWS_REGION="$AWS_REGION"
+export AWS_DEFAULT_REGION="$AWS_DEFAULT_REGION"
+export AWS_STS_REGIONAL_ENDPOINTS="$AWS_STS_REGIONAL_ENDPOINTS"
+# CLI falls back to this when ~/.config/gpu-dev/config.json has no github_user
+export GPU_DEV_GITHUB_USER="$GPU_DEV_GITHUB_USER"
+
 # Function to check for GPU reservation expiry warnings and startup script status
 check_warnings() {{
     # Check for startup script still running
@@ -4538,6 +4550,15 @@ export MULTINODE_RANK="$MULTINODE_RANK"
 export MULTINODE_SIZE="$MULTINODE_SIZE"
 export MASTER_ADDR="$MASTER_ADDR"
 export MASTER_PORT="$MASTER_PORT"
+
+# IRSA + region (see .bashrc_ext for rationale)
+export AWS_ROLE_ARN="$AWS_ROLE_ARN"
+export AWS_WEB_IDENTITY_TOKEN_FILE="$AWS_WEB_IDENTITY_TOKEN_FILE"
+export AWS_ROLE_SESSION_NAME="$AWS_ROLE_SESSION_NAME"
+export AWS_REGION="$AWS_REGION"
+export AWS_DEFAULT_REGION="$AWS_DEFAULT_REGION"
+export AWS_STS_REGIONAL_ENDPOINTS="$AWS_STS_REGIONAL_ENDPOINTS"
+export GPU_DEV_GITHUB_USER="$GPU_DEV_GITHUB_USER"
 
 # Function to check for GPU reservation expiry warnings and startup script status
 check_warnings() {{
@@ -5314,6 +5335,9 @@ EOF
                         ),
                         client.V1EnvVar(
                             name="AWS_ROLE_SESSION_NAME", value=(user_id or "gpu-dev-pod")[:64]
+                        ),
+                        client.V1EnvVar(
+                            name="GPU_DEV_GITHUB_USER", value=github_user or ""
                         )
                     ] + get_nccl_env_vars(gpu_type) + get_cpu_thread_env_vars(gpu_count, gpu_type) + _get_multinode_env_vars(multinode_peer_pods, multinode_rank),
                     resources=client.V1ResourceRequirements(
@@ -5501,6 +5525,10 @@ EOF
             # with the AWS_ROLE_SESSION_NAME env var below this lets users run
             # `gpu-dev submit` from inside their dev pod with no manual aws sso login.
             service_account_name="gpu-dev-pod-sa",
+            # fs_group=1081 makes the IRSA-projected token (default 0600 root:root)
+            # readable by the dev user. Without it boto3-as-dev falls through to IMDS
+            # and gets the node's IAM role, which doesn't have DDB/SQS permissions.
+            security_context=client.V1PodSecurityContext(fs_group=1081),
             # EFA requires host network namespace for RDMA access to efa0 interface
             **({
                 "host_network": True,


### PR DESCRIPTION
gpu-dev inside a pod was falling back to the node IAM role (AccessDenied on DDB) because the IRSA token was 0600 root:root and SSH was stripping the AWS_* env vars. Adds fs_group=1081 to the pod sec context and bakes AWS_* + GPU_DEV_GITHUB_USER into the rc files at startup. Lambda also sets GPU_DEV_GITHUB_USER from the reservation, and CLI falls back to it. Bumps CLI to 0.5.23 and LAMBDA_VERSION to 0.5.24.