### PR TITLE
feat(cli): ssh agent auto-load + empty-agent warning from pods (v0.5.25)

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -4,6 +4,7 @@ Reserve and manage GPU development servers
 """
 
 import click
+import os
 from typing import Optional
 from rich.console import Console
 from rich.table import Table
@@ -3217,6 +3218,20 @@ def connect(ctx: click.Context, reservation_id: Optional[str]) -> None:
         # Add agent forwarding if not already present
         if "-A" not in ssh_command and "-o ForwardAgent=yes" not in ssh_command:
             ssh_command = ssh_command.replace("ssh ", "ssh -A ", 1)
+
+        # When running from inside a gpu-dev pod (=GPU_DEV_USER_ID env var set) and the
+        # forwarded SSH agent is reachable but empty, the next hop is going to fail with
+        # 'Permission denied (publickey)'. Warn upfront so the user knows to ssh-add on
+        # their laptop instead of debugging an opaque auth failure on the remote side.
+        if os.environ.get("GPU_DEV_USER_ID") and os.environ.get("SSH_AUTH_SOCK"):
+            try:
+                import subprocess as _sp
+                r = _sp.run(["ssh-add", "-L"], capture_output=True, text=True, timeout=3)
+                if r.returncode != 0 or not r.stdout.strip() or "no identities" in r.stdout.lower():
+                    rprint("[yellow]⚠️  Forwarded SSH agent is empty — second-hop SSH from a pod will fail auth.[/yellow]")
+                    rprint("[yellow]   On your laptop: `ssh-add ~/.ssh/id_ed25519` (or your GitHub key), then reconnect to this pod with `gpu-dev connect`.[/yellow]\n")
+            except Exception:
+                pass
 
         # Parse and execute the command, capturing exit code for auth failures
         rprint(f"[dim]Executing: {ssh_command}[/dim]\n")

--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
@@ -162,11 +162,20 @@ def _generate_ssh_config(hostname: str, pod_name: str) -> str:
     Returns:
         SSH config content as string
     """
+    import sys
+    # AddKeysToAgent makes SSH stash the IdentityFile into ssh-agent the first time it
+    # uses it for this Host, so the next agent-forwarding hop (pod → pod) actually has
+    # something to forward. On macOS, UseKeychain persists the passphrase via Keychain
+    # so users aren\'t prompted on every shell restart. Linux ssh errors on UseKeychain,
+    # so guard it with IgnoreUnknown.
+    extra = "    AddKeysToAgent yes\n"
+    if sys.platform == "darwin":
+        extra += "    IgnoreUnknown UseKeychain\n    UseKeychain yes\n"
     config_content = f"""Host {pod_name}
     HostName {hostname}
     User dev
     ForwardAgent yes
-    ProxyCommand gpu-dev-ssh-proxy %h %p
+{extra}    ProxyCommand gpu-dev-ssh-proxy %h %p
     StrictHostKeyChecking no
     UserKnownHostsFile /dev/null
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.5.24"
+version = "0.5.25"
 description = "CLI tool for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"


### PR DESCRIPTION
Generated sshconfig adds AddKeysToAgent yes (+UseKeychain on Mac) so first laptop->pod SSH loads the key into the agent — second hop (pod->pod) now has something to forward. gpu-dev connect warns up front when running inside a pod with an empty forwarded agent.