### PR TITLE
fix(tf): filter Local Zones from AZ data source so us-east-1 apply works

### DIFF
--- a/terraform-gpu-devservers/main.tf
+++ b/terraform-gpu-devservers/main.tf
@@ -58,6 +58,13 @@ provider "helm" {
 # Data sources
 data "aws_availability_zones" "available" {
   state = "available"
+  # Exclude Local Zones (e.g. us-east-1-dfw-2a) and Wavelength Zones — EKS control
+  # plane only supports standard AZs. us-east-2 doesn't have Local Zones so the
+  # existing prod workspace was unaffected; us-east-1 has several (dfw, bos, …).
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
 }
 
 data "aws_caller_identity" "current" {}


### PR DESCRIPTION
data.aws_availability_zones.available was returning Local Zones (us-east-1-dfw-2a) which EKS rejects. Filter on opt-in-status=opt-in-not-required to keep only standard AZs. Prod (us-east-2) unaffected.