### PR TITLE
feat(tf): auto-publish NS delegation for child workspaces

### DIFF
--- a/terraform-gpu-devservers/main.tf
+++ b/terraform-gpu-devservers/main.tf
@@ -512,6 +512,22 @@ locals {
     }
   }
 
+  # Subdomain NS delegations to create in *this* workspace's parent zone. Lets
+  # prod (which owns devservers.io) auto-publish NS records pointing at child zones
+  # in other workspaces (prod-east1, future regions) without manual -var flags.
+  # The NS values come from `tofu output devservers_name_servers` in the child
+  # workspace once its hosted zone has been created.
+  prod_subdomain_delegations = {
+    prod = {
+      "east1.devservers.io" = [
+        "ns-1079.awsdns-06.org",
+        "ns-1999.awsdns-57.co.uk",
+        "ns-341.awsdns-42.com",
+        "ns-624.awsdns-14.net",
+      ]
+    }
+  }
+
   # Per-capacity-reservation AZ mappings (overrides gpu_subnet_assignments when CR is used)
   capacity_reservation_azs = {
     "prod-east1" = {

--- a/terraform-gpu-devservers/route53.tf
+++ b/terraform-gpu-devservers/route53.tf
@@ -51,6 +51,19 @@ resource "aws_route53_record" "manual_subdomain_delegation" {
   records = var.subdomain_ns_records
 }
 
+# Auto-published NS delegations for child workspaces. Iterates prod_subdomain_delegations
+# (defined in main.tf) for the current workspace and creates an NS record per entry in
+# the parent zone — so `tofu apply` in prod automatically wires up east1.devservers.io
+# (and any future region) without -var flags.
+resource "aws_route53_record" "workspace_subdomain_delegations" {
+  for_each = local.effective_domain_name != "" && !local.is_subdomain ? try(local.prod_subdomain_delegations[terraform.workspace], {}) : {}
+  zone_id  = data.aws_route53_zone.parent[0].zone_id
+  name     = each.key
+  type     = "NS"
+  ttl      = 300
+  records  = each.value
+}
+
 # Use appropriate hosted zone (subdomain if created, otherwise parent)
 locals {
   hosted_zone_id = local.is_subdomain ? aws_route53_zone.subdomain[0].zone_id : (local.effective_domain_name != "" ? data.aws_route53_zone.parent[0].zone_id : "")


### PR DESCRIPTION
Replaces manual -var subdomain_to_delegate / subdomain_ns_records dance with a workspace-keyed map in main.tf. tofu apply in prod automatically writes the east1.devservers.io NS record into devservers.io. Future region zones just append a key to prod_subdomain_delegations.