### PR TITLE
fix: B300 instance type p6-b300.48xlarge (not p6e-)

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -662,7 +662,7 @@ def reserve(
             "b200-mig-3g": {"max_gpus": 2, "instance_type": "p6-b200.48xlarge"},
             "h200": {"max_gpus": 8, "instance_type": "p5e.48xlarge"},
             "b200": {"max_gpus": 8, "instance_type": "p6-b200.48xlarge"},
-            "b300": {"max_gpus": 8, "instance_type": "p6e-b300.48xlarge"},
+            "b300": {"max_gpus": 8, "instance_type": "p6-b300.48xlarge"},
             "cpu-arm": {"max_gpus": 0, "instance_type": "c7g.4xlarge"},
             "cpu-x86": {"max_gpus": 0, "instance_type": "c7i.4xlarge"},
         }

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -81,7 +81,7 @@ GPU_CONFIG = {
     "h100": {"instance_type": "p5.48xlarge", "max_gpus": 8, "cpus": 192, "memory_gb": 2048, "efa_count": 32},
     "h200": {"instance_type": "p5e.48xlarge", "max_gpus": 8, "cpus": 192, "memory_gb": 2048, "efa_count": 32},
     "b200": {"instance_type": "p6-b200.48xlarge", "max_gpus": 8, "cpus": 192, "memory_gb": 2048, "efa_count": 32},
-    "b300": {"instance_type": "p6e-b300.48xlarge", "max_gpus": 8, "cpus": 192, "memory_gb": 2048, "efa_count": 8},
+    "b300": {"instance_type": "p6-b300.48xlarge", "max_gpus": 8, "cpus": 192, "memory_gb": 2048, "efa_count": 8},
     "cpu-arm": {"instance_type": "c7g.8xlarge", "max_gpus": 0, "cpus": 32, "memory_gb": 64, "efa_count": 0},
     "cpu-x86": {"instance_type": "c7i.8xlarge", "max_gpus": 0, "cpus": 32, "memory_gb": 64, "efa_count": 0},
 }
@@ -6531,7 +6531,7 @@ def get_instance_type_and_gpu_info(k8s_client, pod_name: str) -> tuple[str, str]
             "p5e.48xlarge": "H200",
             "p5en.48xlarge": "H200",
             "p6-b200.48xlarge": "B200",
-            "p6e-b300.48xlarge": "B300",
+            "p6-b300.48xlarge": "B300",
         }
 
         gpu_type = gpu_type_mapping.get(instance_type, "Unknown")

--- a/terraform-gpu-devservers/main.tf
+++ b/terraform-gpu-devservers/main.tf
@@ -339,7 +339,7 @@ locals {
         # sits at 0 and gpu-dev reservations queue. Bump counts once we see what
         # actually gets fulfilled in us-east-1.
         "b300" = {
-          instance_type       = "p6e-b300.48xlarge"
+          instance_type       = "p6-b300.48xlarge"
           instance_types      = null
           instance_count      = 1
           gpus_per_instance   = 8


### PR DESCRIPTION
I guessed p6e-b300 but the real AWS type is p6-b300 (same prefix as B200). Found via describe-instance-types in us-east-1.