### PR TITLE
feat: require --spot flag for spot-only GPU types (v0.5.28)

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -576,6 +576,8 @@ def main(ctx: click.Context) -> None:
     multiple=True,
     help="Request nodes with specific label (format: key=value). Example: --node-label nsight=true for Nsight profiling nodes",
 )
+@click.option("--spot", is_flag=True, default=False,
+              help="Acknowledge spot instance (~1/3 cost, may be preempted with 2-min notice). Required for spot-only types.")
 @click.pass_context
 def reserve(
     ctx: click.Context,
@@ -1271,6 +1273,7 @@ def reserve(
                     no_persistent_disk=no_persistent_disk,
                     preserve_entrypoint=preserve_entrypoint,
                     disk_name=disk,
+                    spot=spot,
                     node_labels=node_labels if node_labels else None,
                 )
             else:
@@ -1289,6 +1292,7 @@ def reserve(
                     no_persistent_disk=no_persistent_disk,
                     preserve_entrypoint=preserve_entrypoint,
                     disk_name=disk,
+                    spot=spot,
                     node_labels=node_labels if node_labels else None,
                     trace=trace,
                 )
@@ -1362,6 +1366,8 @@ _SUBMIT_GPU_TYPES = ["b300", "b200", "b200-mig-1g", "b200-mig-2g", "b200-mig-3g"
 @click.option("--hours", type=float, default=1.0, show_default=True, help="Reservation lifetime ceiling — job auto-cancels well before this if it finishes.")
 @click.option("--disk", type=str, default=None, help="Persistent disk name (master node only). Omit for ephemeral storage.")
 @click.option("--no-persistent-disk", is_flag=True, help="Skip persistent disk entirely.")
+@click.option("--spot", is_flag=True, default=False,
+              help="Acknowledge spot instance (~1/3 cost, may be preempted). Required for spot-only types.")
 @click.option("--dockerfile", type=click.Path(exists=True, dir_okay=False, resolve_path=True), default=None,
               help="Local Dockerfile to build into the pod image (build context = the Dockerfile's directory).")
 @click.option("--dockerimage", type=str, default=None,
@@ -1377,7 +1383,7 @@ _SUBMIT_GPU_TYPES = ["b300", "b200", "b200-mig-1g", "b200-mig-2g", "b200-mig-3g"
               help="Minutes to wait for the reservation to become active. Defaults to 24h since GPU reservations may queue when the cluster is full.")
 @click.argument("command", nargs=-1, required=True)
 @click.pass_context
-def submit(ctx, gpu_type, gpus, hours, disk, no_persistent_disk, dockerfile, dockerimage, preserve_entrypoint,
+def submit(ctx, gpu_type, gpus, hours, disk, no_persistent_disk, spot, dockerfile, dockerimage, preserve_entrypoint,
            runtime, no_pull, keep_alive, name, timeout, command):
     """Submit a job: reserve, sync code, run, sync results back, auto-cancel.
 
@@ -1491,7 +1497,7 @@ def submit(ctx, gpu_type, gpus, hours, disk, no_persistent_disk, dockerfile, doc
             user_id=user_info["user_id"], gpu_count=gpus, gpu_type=gt,
             duration_hours=hours, name=name, github_user=user_info["github_user"],
             no_persistent_disk=no_persistent_disk, disk_name=disk_name,
-            dockerfile=dockerfile_payload, dockerimage=dockerimage,
+            spot=spot, dockerfile=dockerfile_payload, dockerimage=dockerimage,
             preserve_entrypoint=preserve_entrypoint)
         if not reservation_ids:
             rprint("[red]❌ Failed to create multinode reservation[/red]")
@@ -1502,7 +1508,7 @@ def submit(ctx, gpu_type, gpus, hours, disk, no_persistent_disk, dockerfile, doc
             user_id=user_info["user_id"], gpu_count=gpus, gpu_type=gt,
             duration_hours=hours, name=name, github_user=user_info["github_user"],
             no_persistent_disk=no_persistent_disk, disk_name=disk_name,
-            dockerfile=dockerfile_payload, dockerimage=dockerimage,
+            spot=spot, dockerfile=dockerfile_payload, dockerimage=dockerimage,
             preserve_entrypoint=preserve_entrypoint)
         if not primary_id:
             rprint("[red]❌ Failed to create reservation[/red]")

--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
@@ -421,6 +421,7 @@ class ReservationManager:
         disk_name: Optional[str] = None,
         node_labels: Optional[Dict[str, str]] = None,
         trace: bool = False,
+        spot: bool = False,
     ) -> Optional[str]:
         """Create a new GPU reservation"""
         try:
@@ -500,6 +501,9 @@ class ReservationManager:
             if node_labels:
                 message["node_labels"] = node_labels
 
+            if spot:
+                message["spot"] = True
+
             # Add trace flag and CLI start timestamp
             if trace:
                 message["trace"] = True
@@ -536,6 +540,7 @@ class ReservationManager:
         preserve_entrypoint: bool = False,
         disk_name: Optional[str] = None,
         node_labels: Optional[Dict[str, str]] = None,
+        spot: bool = False,
     ) -> Optional[List[str]]:
         """Create multiple GPU reservations for multinode setup"""
         try:
@@ -602,6 +607,7 @@ class ReservationManager:
                     "recreate_env": recreate_env,
                     "is_multinode": True,
                     "no_persistent_disk": no_persistent_disk,
+                    "spot": spot,
                 }
 
                 if github_user:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.5.27"
+version = "0.5.28"
 description = "CLI tool for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"

--- a/terraform-gpu-devservers/lambda.tf
+++ b/terraform-gpu-devservers/lambda.tf
@@ -180,8 +180,13 @@ resource "aws_lambda_function" "reservation_processor" {
       HOSTED_ZONE_ID                     = local.effective_domain_name != "" ? local.hosted_zone_id : ""
       SSH_DOMAIN_MAPPINGS_TABLE          = local.effective_domain_name != "" ? aws_dynamodb_table.ssh_domain_mappings.name : ""
       SSL_CERTIFICATE_ARN                = local.effective_domain_name != "" ? aws_acm_certificate.wildcard[0].arn : ""
-      LAMBDA_VERSION                     = "0.5.27"
+      LAMBDA_VERSION                     = "0.5.28"
       MIN_CLI_VERSION                    = "0.5.16"
+      # Comma-separated GPU types that require --spot flag, or "all" for every type.
+      # Empty = no spot types (on-demand / reserved). Set per-workspace.
+      SPOT_GPU_TYPES                     = lookup({
+        "prod-east1" = "all"
+      }, terraform.workspace, "")
       DISK_CONTENTS_BUCKET               = aws_s3_bucket.disk_contents.bucket
       OPERATIONS_TABLE                   = aws_dynamodb_table.operations.name
     }, local.alb_env_vars)

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -59,6 +59,7 @@ ECR_REPOSITORY_URL = os.environ.get("ECR_REPOSITORY_URL")
 # Version validation - injected via Terraform
 LAMBDA_VERSION = os.environ.get("LAMBDA_VERSION", "0.3.9")
 MIN_CLI_VERSION = os.environ.get("MIN_CLI_VERSION", "0.3.9")
+SPOT_GPU_TYPES = os.environ.get("SPOT_GPU_TYPES", "")
 OPERATIONS_TABLE = os.environ.get("OPERATIONS_TABLE", "pytorch-gpu-dev-operations")
 
 # GPU Configuration - single source of truth for all GPU type mappings
@@ -2204,6 +2205,19 @@ def validate_reservation_request(request: dict[str, Any]) -> tuple[bool, str]:
             reason = maintenance.get("reason", "under maintenance")
             error_msg = f"GPU type {gpu_type.upper()} is currently unavailable: {reason}"
             logger.warning(f"User {user_id} blocked from {gpu_type}: maintenance mode")
+            return False, error_msg
+
+    # Spot acknowledgment: if this workspace marks the GPU type as spot-only and
+    # the user didn't pass --spot, reject with a clear message.
+    if SPOT_GPU_TYPES and not request.get("spot", False):
+        is_spot = SPOT_GPU_TYPES.strip() == "all" or gpu_type in [t.strip() for t in SPOT_GPU_TYPES.split(",")]
+        if is_spot:
+            error_msg = (
+                f"{gpu_type.upper()} is only available as a spot instance in this environment. "
+                f"Spot instances are ~1/3 the cost but can be reclaimed by AWS with 2-min notice. "
+                f"Pass --spot to confirm: gpu-dev reserve --gpu-type {gpu_type} --spot"
+            )
+            logger.warning(f"Reservation: spot acknowledgment missing for {gpu_type}")
             return False, error_msg
 
     # Validate GPU count based on type


### PR DESCRIPTION
Explicit opt-in for spot. Without --spot on a spot-only type, reservation immediately fails: 'B300 is only available as a spot instance... Pass --spot to confirm.' Gated per workspace via SPOT_GPU_TYPES Lambda env var (prod = empty, prod-east1 = 'all').