### PR TITLE
fix(cli): environment Choice back to hardcoded list with prod-east1 (v0.5.30)

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -3664,7 +3664,7 @@ def set(key: str, value: str) -> None:
 
 
 @config.command()
-@click.argument("env_name", type=click.Choice(list(Config.ENVIRONMENTS.keys())))
+@click.argument("env_name", type=click.Choice(["test", "prod", "prod-east1"]))
 def environment(env_name: str) -> None:
     """Set the environment
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.5.29"
+version = "0.5.30"
 description = "CLI tool for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"


### PR DESCRIPTION
The dynamic Config.ENVIRONMENTS.keys() reference broke Click's module-load-time argument setup. Hardcoded the three envs. Not elegant but works. Bug is in Click 8.3's decorator evaluation, not our code.