### PR TITLE
fix(cli): add spot to reserve() signature

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -598,6 +598,7 @@ def reserve(
     preserve_entrypoint: bool,
     disk: Optional[str],
     node_label: tuple,
+    spot: bool = False,
 ) -> None:
     """Reserve GPU development server(s)
 


### PR DESCRIPTION
Missing param from the --spot decorator addition.