### PR TITLE
fix: auto-spot in interactive + better error message

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -689,6 +689,13 @@ def reserve(
             rprint(
                 "[dim]Use --no-interactive flag to disable interactive mode[/dim]\n")
 
+            # Auto-acknowledge spot in spot-only environments so users don't need --spot
+            from .config import Config as _Cfg
+            _env_name = load_config().user_config.get("environment", "prod")
+            if _Cfg.ENVIRONMENTS.get(_env_name, {}).get("all_spot") and not spot:
+                spot = True
+                rprint("[dim]Spot environment — --spot auto-acknowledged. Instances may be preempted by AWS with 2-min notice.[/dim]\n")
+
             # Run auth + SSH validation + availability fetch in parallel — they're independent
             # and total wall-clock time drops from sum to max(each).
             from concurrent.futures import ThreadPoolExecutor

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -2331,6 +2331,7 @@ def validate_reservation_request(request: dict[str, Any]) -> tuple[bool, str]:
             error_msg = (
                 f"{gpu_type.upper()} is only available as a spot instance in this environment. "
                 f"Spot instances are ~1/3 the cost but can be reclaimed by AWS with 2-min notice. "
+                f"Even if availability shows 0/0, a spot node will be requested from AWS when you reserve — it\'s worth trying. "
                 f"Pass --spot to confirm: gpu-dev reserve --gpu-type {gpu_type} --spot"
             )
             logger.warning(f"Reservation: spot acknowledgment missing for {gpu_type}")


### PR DESCRIPTION
Interactive mode auto-sets --spot in spot envs. Non-interactive error message now encourages trying even at 0/0.