### PR TITLE
feat: mixed spot/on-demand in prod-east1

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -692,9 +692,7 @@ def reserve(
             # Auto-acknowledge spot in spot-only environments so users don't need --spot
             from .config import Config as _Cfg
             _env_name = load_config().user_config.get("environment", "prod")
-            if _Cfg.ENVIRONMENTS.get(_env_name, {}).get("all_spot") and not spot:
-                spot = True
-                rprint("[dim]Spot environment — --spot auto-acknowledged. Instances may be preempted by AWS with 2-min notice.[/dim]\n")
+            _spot_types_env = _Cfg.ENVIRONMENTS.get(_env_name, {}).get("spot_types", [])
 
             # Run auth + SSH validation + availability fetch in parallel — they're independent
             # and total wall-clock time drops from sum to max(each).
@@ -755,6 +753,11 @@ def reserve(
                 if gpu_type is None:
                     rprint("[yellow]Reservation cancelled.[/yellow]")
                     return
+
+            # Auto-acknowledge spot for spot types in this environment
+            if _spot_types_env and gpu_type and gpu_type.lower() in _spot_types_env and not spot:
+                spot = True
+                rprint(f"[dim]{gpu_type.upper()} is a spot instance in this environment — --spot auto-acknowledged. May be preempted by AWS.[/dim]")
 
             # Interactive GPU count selection
             if gpus is None:

--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/config.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/config.py
@@ -26,7 +26,7 @@ class Config:
             "region": "us-east-1",
             "workspace": "prod-east1",
             "description": "Spot-only us-east-1 environment (T4/L4/CPU)",
-            "all_spot": True,
+            "spot_types": ["b300", "b200", "h200", "h100", "a100"],
         },
     }
     DEFAULT_ENVIRONMENT = "prod"

--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/interactive.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/interactive.py
@@ -89,11 +89,13 @@ def select_gpu_type_interactive(
     _cfg = load_config()
     _env_name = _cfg.user_config.get("environment", "prod")
     _env_config = Config.ENVIRONMENTS.get(_env_name, {})
-    is_all_spot = _env_config.get("all_spot", False)
+    _spot_types = set(_env_config.get("spot_types", []))
+    is_all_spot = False  # legacy compat
+    has_spot_types = len(_spot_types) > 0
 
     # Display availability table first
-    if is_all_spot:
-        console.print("\n[cyan]🖥️  GPU Availability[/cyan] [dim](spot environment — all instances require --spot)[/dim]")
+    if has_spot_types:
+        console.print("\n[cyan]🖥️  GPU Availability[/cyan] [dim](* = spot instance, requires --spot)[/dim]")
     else:
         console.print("\n[cyan]🖥️  GPU Availability:[/cyan]")
     table = Table()
@@ -103,7 +105,7 @@ def select_gpu_type_interactive(
     table.add_column("Total", style="blue")
     table.add_column("Queue\nLength", style="yellow")
     table.add_column("Est. Wait Time", style="magenta")
-    if is_all_spot:
+    if has_spot_types:
         table.add_column("Spot\nStatus", style="dim")
 
     choices = []
@@ -145,7 +147,7 @@ def select_gpu_type_interactive(
         else:
             available_display = f"[red]{available}[/red]"
 
-        type_label = f"{gpu_type.upper()} *" if is_all_spot else gpu_type.upper()
+        type_label = f"{gpu_type.upper()} *" if gpu_type in _spot_types else gpu_type.upper()
         row = [
             type_label,
             available_display,
@@ -154,7 +156,7 @@ def select_gpu_type_interactive(
             str(queue_length) if not is_maintenance else "-",
             wait_display,
         ]
-        if is_all_spot:
+        if gpu_type in _spot_types:
             ri = info.get("running_instances", 0)
             dc = info.get("desired_capacity", 0)
             if ri > 0:
@@ -186,7 +188,7 @@ def select_gpu_type_interactive(
             choices.append(questionary.Choice(title=choice_label, value=gpu_type))
 
     console.print(table)
-    if is_all_spot:
+    if has_spot_types:
         console.print("[dim]* = spot instance (--spot required, ~1/3 cost, may be preempted by AWS)[/dim]")
     console.print()
 

--- a/terraform-gpu-devservers/lambda.tf
+++ b/terraform-gpu-devservers/lambda.tf
@@ -191,7 +191,7 @@ resource "aws_lambda_function" "reservation_processor" {
       # Empty = no spot types (on-demand / reserved). Set per-workspace.
       ASG_NAME_PREFIX                    = "${var.prefix}-gpu-nodes"
       SPOT_GPU_TYPES                     = lookup({
-        "prod-east1" = "all"
+        "prod-east1" = "b300,b200,h200,h100,a100"
       }, terraform.workspace, "")
       DISK_CONTENTS_BUCKET               = aws_s3_bucket.disk_contents.bucket
       OPERATIONS_TABLE                   = aws_dynamodb_table.operations.name

--- a/terraform-gpu-devservers/main.tf
+++ b/terraform-gpu-devservers/main.tf
@@ -391,32 +391,29 @@ locals {
         "t4" = {
           instance_type       = "g4dn.12xlarge"
           instance_types      = null
-          instance_count      = 0
+          instance_count      = 1
           gpus_per_instance   = 4
           use_placement_group = false
           architecture        = "x86_64"
           efa_network_cards   = 0
-          use_spot            = true
         }
         "l4" = {
           instance_type       = "g6.12xlarge"
           instance_types      = null
-          instance_count      = 0
+          instance_count      = 1
           gpus_per_instance   = 4
           use_placement_group = false
           architecture        = "x86_64"
           efa_network_cards   = 1
-          use_spot            = true
         }
         "cpu-x86" = {
           instance_type       = "c7i.8xlarge"
           instance_types      = null
-          instance_count      = 0
+          instance_count      = 5
           gpus_per_instance   = 0
           use_placement_group = false
           architecture        = "x86_64"
           efa_network_cards   = 0
-          use_spot            = true
         }
       }
     }


### PR DESCRIPTION
T4/L4/CPU are always-on (on-demand). B300/B200/H200/H100/A100 are spot-only (scale-to-zero). Interactive picker shows per-type spot indicators.