### PR TITLE
feat: spot stages in CLI + price API + honest wait estimates

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
@@ -1070,6 +1070,7 @@ class ReservationManager:
                     "maintenance": bool(item.get("maintenance", False)),
                     "maintenance_reason": item.get("maintenance_reason", ""),
                     "size_etas": size_etas,
+                    "spot_info": item.get("spot_info", {}),
                 }
 
             return availability_info
@@ -1867,7 +1868,12 @@ class ReservationManager:
                                         else "Calculating..."
                                     )
 
-                                if is_multinode:
+                                detailed = first_queued.get("current_detailed_status", "")
+                                # Spot stages come through current_detailed_status — show those
+                                # directly instead of generic "Position #1, est wait X min"
+                                if detailed and ("spot" in detailed.lower() or "node" in detailed.lower() or "instance" in detailed.lower()):
+                                    message = f"⏳ {detailed}"
+                                elif is_multinode:
                                     total_gpus = sum(
                                         node["gpu_count"] for node in node_details if node["reservation"])
                                     message = f"📋 Position #{queue_position} in queue • Estimated wait: {wait_display} • {total_gpus} GPUs across {total_nodes} nodes"

--- a/terraform-gpu-devservers/availability.tf
+++ b/terraform-gpu-devservers/availability.tf
@@ -47,6 +47,9 @@ resource "aws_lambda_function" "availability_updater" {
       })
       EKS_CLUSTER_NAME    = aws_eks_cluster.gpu_dev_cluster.name
       REGION              = local.current_config.aws_region
+      SPOT_GPU_TYPES      = lookup({
+        "prod-east1" = "b300,b200,h200,h100,a100"
+      }, terraform.workspace, "")
     }
   }
 
@@ -127,6 +130,11 @@ resource "aws_iam_role_policy" "availability_updater_policy" {
         Action = [
           "autoscaling:DescribeAutoScalingGroups"
         ]
+        Resource = "*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["ec2:DescribeSpotPriceHistory"]
         Resource = "*"
       },
       {

--- a/terraform-gpu-devservers/lambda/availability_updater/index.py
+++ b/terraform-gpu-devservers/lambda/availability_updater/index.py
@@ -17,6 +17,47 @@ logger.setLevel(logging.INFO)
 # AWS clients
 dynamodb = boto3.resource("dynamodb")
 autoscaling = boto3.client("autoscaling")
+ec2_client = boto3.client("ec2")
+
+# Instance types per GPU type (for spot price lookups)
+GPU_INSTANCE_TYPES = {
+    "b300": "p6-b300.48xlarge", "b200": "p6-b200.48xlarge",
+    "h200": "p5e.48xlarge", "h100": "p5.48xlarge", "a100": "p4d.24xlarge",
+    "t4": "g4dn.12xlarge", "l4": "g6.12xlarge",
+    "rtxpro6000": "g7e.24xlarge", "a10g": "g5.12xlarge",
+    "cpu-x86": "c7i.8xlarge", "cpu-arm": "c7g.8xlarge",
+}
+SPOT_GPU_TYPES = os.environ.get("SPOT_GPU_TYPES", "")
+
+
+def get_spot_price_info(gpu_type: str) -> dict:
+    """Query AWS for current spot price and derive availability signal."""
+    instance_type = GPU_INSTANCE_TYPES.get(gpu_type)
+    if not instance_type:
+        return {}
+    try:
+        resp = ec2_client.describe_spot_price_history(
+            InstanceTypes=[instance_type],
+            ProductDescriptions=["Linux/UNIX"],
+            MaxResults=5,
+        )
+        prices = resp.get("SpotPriceHistory", [])
+        if not prices:
+            return {"spot_price": None, "spot_available": False, "spot_signal": "No spot data"}
+        latest = prices[0]
+        price = float(latest["SpotPrice"])
+        az = latest["AvailabilityZone"]
+        ts = latest["Timestamp"].isoformat() if hasattr(latest["Timestamp"], "isoformat") else str(latest["Timestamp"])
+        return {
+            "spot_price": str(round(price, 2)),
+            "spot_az": az,
+            "spot_price_updated": ts,
+            "spot_available": True,
+            "spot_signal": f"${round(price, 2)}/hr in {az}",
+        }
+    except Exception as e:
+        logger.warning(f"Spot price lookup failed for {gpu_type}: {e}")
+        return {}
 
 # Environment variables
 AVAILABILITY_TABLE = os.environ["AVAILABILITY_TABLE"]
@@ -325,26 +366,37 @@ def update_gpu_availability(gpu_type: str, k8s_client=None, active_reservations=
         last_updated = context.aws_request_id if "context" in locals() else "unknown"
         last_updated_ts = int(time.time()) if "time" in dir() else 0
 
+        # Fetch spot price info for spot-eligible types
+        spot_info = {}
+        if SPOT_GPU_TYPES and (SPOT_GPU_TYPES.strip() == "all" or gpu_type in [t.strip() for t in SPOT_GPU_TYPES.split(",")]):
+            spot_info = get_spot_price_info(gpu_type)
+
+        update_expr = (
+            "SET total_gpus = :tg, available_gpus = :ag, max_reservable = :mr, "
+            "full_nodes_available = :fn, running_instances = :ri, desired_capacity = :dc, "
+            "gpus_per_instance = :gpi, last_updated = :lu, last_updated_timestamp = :lut, "
+            "size_etas = :se"
+        )
+        expr_values = {
+            ":tg": total_gpus,
+            ":ag": available_gpus,
+            ":mr": max_reservable,
+            ":fn": full_nodes_available,
+            ":ri": running_instances,
+            ":dc": desired_capacity,
+            ":gpi": gpus_per_instance,
+            ":lu": last_updated,
+            ":lut": last_updated_ts,
+            ":se": size_etas,
+        }
+        if spot_info:
+            update_expr += ", spot_info = :si"
+            expr_values[":si"] = spot_info
+
         table.update_item(
             Key={"gpu_type": gpu_type},
-            UpdateExpression=(
-                "SET total_gpus = :tg, available_gpus = :ag, max_reservable = :mr, "
-                "full_nodes_available = :fn, running_instances = :ri, desired_capacity = :dc, "
-                "gpus_per_instance = :gpi, last_updated = :lu, last_updated_timestamp = :lut, "
-                "size_etas = :se"
-            ),
-            ExpressionAttributeValues={
-                ":tg": total_gpus,
-                ":ag": available_gpus,
-                ":mr": max_reservable,
-                ":fn": full_nodes_available,
-                ":ri": running_instances,
-                ":dc": desired_capacity,
-                ":gpi": gpus_per_instance,
-                ":lu": last_updated,
-                ":lut": last_updated_ts,
-                ":se": size_etas,
-            },
+            UpdateExpression=update_expr,
+            ExpressionAttributeValues=expr_values,
         )
 
         logger.info(

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -2242,7 +2242,7 @@ def process_reservation_request(record: dict[str, Any]) -> bool:
                 if available_gpus == 0:
                     if _is_spot_type(gpu_type):
                         scale_up_spot_asg(gpu_type, reservation_id)
-                        queue_message = f"Spot instance requested — waiting for AWS to provision {gpu_type.upper()} node (~5-10 min)"
+                        queue_message = f"Spot instance requested for {gpu_type.upper()} — fulfillment depends on AWS capacity (not guaranteed)"
                     else:
                         queue_message = f"No {gpu_type.upper()} nodes available - position #{queue_info.get('position', '?')} in queue"
                 elif available_gpus >= requested_gpus and max_single_node < requested_gpus:
@@ -7836,7 +7836,9 @@ def process_scheduled_queue_management():
                         if _is_spot_type(gpu_type):
                             scale_up_spot_asg(gpu_type, reservation_id)
                             spot_status = _get_spot_provision_status(gpu_type)
-                            estimated_wait_minutes = 10
+                            # Don\'t fake an ETA — spot fulfillment is unpredictable.
+                            # Set to None so the CLI shows "depends on AWS spot capacity" not "10min"
+                            estimated_wait_minutes = None
                             logger.info(
                                 f"Spot status for {gpu_type.upper()} reservation {reservation_id}: {spot_status}")
                         else:


### PR DESCRIPTION
CLI shows per-stage spot progress instead of fake 9min ETA. Availability updater queries spot price history and stores it in DDB. Lambda sends honest 'not guaranteed' messaging.