### PR TITLE
fix(tf): B300 efa=0 until quota approved

### DIFF
--- a/terraform-gpu-devservers/main.tf
+++ b/terraform-gpu-devservers/main.tf
@@ -345,7 +345,7 @@ locals {
           gpus_per_instance   = 8
           use_placement_group = false
           architecture        = "x86_64"
-          efa_network_cards   = 8
+          efa_network_cards   = 0  # EFA disabled until quota approved for p6-b300 in us-east-1
           use_spot            = true
         }
         "b200" = {


### PR DESCRIPTION
EFA launch failures. Disable for now, single-node works fine without it.