### PR TITLE
fix: spot scale-down via availability_updater (scheduled, not SQS-dependent)

### DIFF
--- a/terraform-gpu-devservers/availability.tf
+++ b/terraform-gpu-devservers/availability.tf
@@ -50,6 +50,7 @@ resource "aws_lambda_function" "availability_updater" {
       SPOT_GPU_TYPES      = lookup({
         "prod-east1" = "b300,b200,h200,h100,a100"
       }, terraform.workspace, "")
+      ASG_NAME_PREFIX     = "${var.prefix}-gpu-nodes"
     }
   }
 
@@ -128,7 +129,8 @@ resource "aws_iam_role_policy" "availability_updater_policy" {
       {
         Effect = "Allow"
         Action = [
-          "autoscaling:DescribeAutoScalingGroups"
+          "autoscaling:DescribeAutoScalingGroups",
+          "autoscaling:SetDesiredCapacity"
         ]
         Resource = "*"
       },

--- a/terraform-gpu-devservers/lambda/availability_updater/index.py
+++ b/terraform-gpu-devservers/lambda/availability_updater/index.py
@@ -163,6 +163,41 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         except Exception as cleanup_err:
             logger.warning(f"Stale-row cleanup failed: {cleanup_err}")
 
+        # Scale down idle spot ASGs. This runs every ~5 min (EventBridge schedule)
+        # and catches cases where: reservation cancelled/expired → no SQS messages
+        # → reservation_processor's sweep-end scale-down never fires because SQS
+        # has nothing to deliver.
+        if SPOT_GPU_TYPES:
+            spot_list = [t.strip() for t in SPOT_GPU_TYPES.split(",")] if SPOT_GPU_TYPES.strip() != "all" else list(SUPPORTED_GPU_TYPES.keys())
+            for st in spot_list:
+                try:
+                    asg = f"{os.environ.get('ASG_NAME_PREFIX', 'pytorch-gpu-dev-gpu-nodes')}-{st}"
+                    # Check if any active/queued/preparing reservations exist for this type
+                    has_active = False
+                    reservations_table = dynamodb.Table(os.environ.get("RESERVATIONS_TABLE", "pytorch-gpu-dev-reservations"))
+                    for status in ["active", "preparing", "queued", "pending"]:
+                        resp = reservations_table.query(
+                            IndexName="StatusIndex",
+                            KeyConditionExpression="#s = :status",
+                            ExpressionAttributeNames={"#s": "status"},
+                            ExpressionAttributeValues={":status": status, ":gt": st},
+                            FilterExpression="gpu_type = :gt",
+                            Limit=1,
+                        )
+                        if resp.get("Items"):
+                            has_active = True
+                            break
+                    if not has_active:
+                        resp = autoscaling.describe_auto_scaling_groups(AutoScalingGroupNames=[asg])
+                        groups = resp.get("AutoScalingGroups", [])
+                        if groups and groups[0]["DesiredCapacity"] > 0:
+                            logger.info(f"Scaling down idle spot ASG {asg} to 0")
+                            autoscaling.set_desired_capacity(AutoScalingGroupName=asg, DesiredCapacity=0)
+                        else:
+                            logger.debug(f"Spot ASG {asg} already at 0 or not found")
+                except Exception as sd_err:
+                    logger.warning(f"Spot scale-down check for {st} failed: {sd_err}")
+
         return {
             "statusCode": 200,
             "body": json.dumps(


### PR DESCRIPTION
Idle spot ASGs were never scaled down because the SQS-triggered queue sweep doesn't fire when there are no queued reservations. Moved to the availability_updater which runs on a 5-min schedule.