### PR TITLE
fix(tf): add Bedrock permissions to pod IRSA role

### DIFF
--- a/terraform-gpu-devservers/gpu-dev-pod-irsa.tf
+++ b/terraform-gpu-devservers/gpu-dev-pod-irsa.tf
@@ -72,6 +72,14 @@ resource "aws_iam_role_policy" "gpu_dev_pod_policy" {
         Effect = "Allow"
         Action = "sts:GetCallerIdentity"
         Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "bedrock:InvokeModel",
+          "bedrock:InvokeModelWithResponseStream"
+        ]
+        Resource = "*"
       }
     ]
   })


### PR DESCRIPTION
Claude Code from inside pods was 403ing. Pod IAM role now includes bedrock:InvokeModel*.