### PR TITLE
docs(repro): explain shared ccache (builds are warm, not cold)

### DIFF
--- a/docs/SDK_REPRO.md
+++ b/docs/SDK_REPRO.md
@@ -2,7 +2,10 @@
 
 Reserve a **warm** GPU box in ~1s, run code on it, and auto-clean up — from Python
 or one CLI command. Backed by a pool of pre-booted pods with **PyTorch prebuilt**
-(viable/strict), so `import torch` works instantly with no build.
+(viable/strict), so `import torch` works instantly with no build. And when you *do*
+have to compile — your ref moved past viable/strict, or you touch C++ — a shared
+compiler cache (ccache) makes it an **incremental, not a cold, build** (see
+[Builds are cached](#builds-are-cached-shared-ccache)).
 
 > Requires `gpu-dev` ≥ 0.7.1 (CLI **and** SDK in one package): `pip install --upgrade gpu-dev`
 
@@ -62,11 +65,40 @@ pip install -e . --no-build-isolation
 ```
 Python-only changes need no rebuild — `PYTHONPATH=~/pytorch` already resolves.
 
+## Builds are cached (shared ccache)
+
+Two layers of caching mean you almost never pay for a cold, from-scratch build —
+including the full C++/CUDA compile (gcc/nvcc):
+
+1. **Prebuilt tree.** Every box gets PyTorch already built at viable/strict and
+   staged at `~/pytorch`, so `import torch` works with **zero build**.
+2. **Shared compiler cache (ccache).** `CCACHE_DIR=/ccache_shared` is an EFS volume
+   mounted in **every** dev pod *and* the dedicated build node, so all the C++/CUDA
+   object compiles are cached and **shared across users and the build node**. When
+   you check out a ref past viable/strict — or edit C++ — the rebuild reuses those
+   cached objects (and the warm `build/` for ninja) instead of recompiling from
+   scratch. So even a "full" `pip install -e .` is a warm build, not a cold one.
+
+Measured (m7i build node, 128 jobs, CUDA 13.2):
+
+| scenario | time |
+|---|---|
+| `import torch` (prebuilt, no build) | ~0s |
+| incremental (1 kernel changed + relink) | ~40s |
+| ninja no-op (nothing changed) | ~20s |
+| from-scratch `build/` with warm ccache (~86% hit) | ~21 min |
+
+(A true cold build from an empty ccache is far longer.) The cache stays warm on its
+own: an hourly build-node job compiles each viable/strict bump into `/ccache_shared`,
+so the objects you need are usually already there by the time you build — and your
+own compiles populate it for the next person too.
+
 ## Gotchas
 - **`/merge` vs `/head`**: `/head` is the PR author's raw branch and often lacks
   trunk-added tests; `/merge` is what CI ran. `gpu-dev repro` / `--ref` use `/merge`.
 - **The prebuilt is viable/strict.** If your ref moved past it and a test needs new
-  C++, do the one incremental `pip install -e . --no-build-isolation`.
+  C++, do the one incremental `pip install -e . --no-build-isolation` — it's fast
+  (warm shared ccache), not a cold build. See [Builds are cached](#builds-are-cached-shared-ccache).
 - **Ephemeral by design.** Repro boxes have no persistent disk; bring code via
   `--ref`, `sb.upload`, or git.
 


### PR DESCRIPTION
Clarifies in `docs/SDK_REPRO.md` that the full C++/CUDA build is cached too, not just the prebuilt tree:

- `CCACHE_DIR=/ccache_shared` is an EFS volume mounted in **every** dev pod *and* the build node, so compiles (ref past viable/strict, or C++ edits) reuse cached gcc/nvcc objects + the warm `build/` instead of building from scratch.
- Adds a measured timing table (import 0s · incremental ~40s · ninja no-op ~20s · from-scratch w/ warm ccache ~21min).
- Notes the hourly build-node job keeps the cache warm, and your own compiles populate it for the next person.

Docs-only; no release.