### PR TITLE
feat(cli): repro drops you into the box to iterate (0.7.6)

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -1523,12 +1523,19 @@ def reserve(
 @click.option("--gpu-type", default="b200", show_default=True, help="GPU type for the repro box.")
 @click.option("--gpus", type=int, default=1, show_default=True)
 @click.option("--hours", type=float, default=3.0, show_default=True,
-              help="Lifetime ceiling; the box auto-cancels when the test exits unless --keep.")
+              help="Lifetime ceiling for the box.")
+@click.option("--no-connect", is_flag=True, default=False,
+              help="CI mode: run the test, auto-cancel, exit code = test result. Default (on a TTY) drops you into the box to iterate.")
 @click.option("--keep", is_flag=True, default=False,
-              help="Keep the reservation after the test exits (default: auto-cancel).")
+              help="Never cancel the box (skip the cancel prompt / auto-cancel).")
 @click.pass_context
-def repro(ctx, ref, test_args, gpu_type, gpus, hours, keep):
-    """Reserve a GPU, check out a PR/commit, run a test, then auto-cancel.
+def repro(ctx, ref, test_args, gpu_type, gpus, hours, no_connect, keep):
+    """Reserve a GPU, check out a PR/commit, run a test, then drop you into the box.
+
+    By default (in a terminal) repro runs the test and then **connects you into the
+    box** at ~/pytorch — the ref is checked out, so you can fix and re-run. The box
+    stays alive until you cancel it (you're prompted on exit). Use --no-connect for
+    CI/scripts (run the test, auto-cancel, process exit code = the test result).
 
     REF: pr/<N>, #<N>, a bare PR number, a branch, or a commit sha. PRs use
     pull/<N>/merge (what CI tests), falling back to /head.
@@ -1539,6 +1546,7 @@ def repro(ctx, ref, test_args, gpu_type, gpus, hours, keep):
     """
     import shlex
     import subprocess
+    import sys
     config = load_config()
     reservation_mgr = ReservationManager(config)
     try:
@@ -1602,21 +1610,55 @@ def repro(ctx, ref, test_args, gpu_type, gpus, hours, keep):
     if "StrictHostKeyChecking" not in ssh_cmd:
         ssh_cmd = ssh_cmd.replace("ssh ", "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ", 1)
     rprint(f"[dim]→ {ssh_cmd}[/dim]\n")
+    rid8 = str(rid)[:8]
     rc = 1
     try:
         rc = subprocess.run(f"{ssh_cmd} {shlex.quote(remote)}", shell=True).returncode
     except KeyboardInterrupt:
-        rprint("\n[yellow]interrupted[/yellow]")
-    finally:
+        rprint("\n[yellow]interrupted[/yellow]"); rc = 130
+
+    verdict = "[green]✓ test passed[/green]" if rc == 0 else f"[red]✗ test failed (exit {rc})[/red]"
+
+    # Default (TTY): drop into the box so you can fix and re-run. --no-connect is the
+    # CI path: auto-cancel and exit with the test's code.
+    connect = (not no_connect) and sys.stdout.isatty()
+    if connect:
+        rprint(f"\n{verdict} — dropping you into the box at ~/pytorch ({ref} checked out).")
+        rprint(f"[dim]  re-run:  python {testcmd}[/dim]")
+        rprint(f"[dim]  finish:  gpu-dev cancel  (from inside)  •  or exit this shell[/dim]\n")
+        shell_cmd = f"{ssh_cmd} -t {shlex.quote('cd /home/dev/pytorch 2>/dev/null; exec ${SHELL:-bash} -l')}"
+        try:
+            subprocess.run(shell_cmd, shell=True)
+        except KeyboardInterrupt:
+            pass
         if keep:
-            rprint(f"[cyan]📌 kept {str(rid)[:8]} — gpu-dev connect {str(rid)[:8]} • gpu-dev cancel {str(rid)[:8]}[/cyan]")
-        else:
+            rprint(f"[cyan]📌 left {rid8} running — connect: gpu-dev connect {rid8} • cancel: gpu-dev cancel {rid8}[/cyan]")
+            return
+        try:
+            drop = click.confirm(f"Cancel repro box {rid8}?", default=True)
+        except (KeyboardInterrupt, EOFError, click.Abort):
+            drop = False
+        if drop:
             try:
                 reservation_mgr.cancel_reservation(rid, user_info["user_id"])
-                rprint(f"[green]🧹 cancelled repro box {str(rid)[:8]}[/green]")
+                rprint(f"[green]🧹 cancelled {rid8}[/green]")
             except Exception as e:
-                rprint(f"[yellow]auto-cancel failed for {str(rid)[:8]}: {e}[/yellow]")
-    rprint(f"\n[bold]repro exit code: {rc}[/bold]")
+                rprint(f"[yellow]cancel failed for {rid8}: {e}[/yellow]")
+        else:
+            rprint(f"[cyan]📌 left {rid8} running — connect: gpu-dev connect {rid8} • cancel: gpu-dev cancel {rid8}[/cyan]")
+        return
+
+    # --no-connect / non-TTY: auto-cancel unless --keep, exit code = test result.
+    if keep:
+        rprint(f"[cyan]📌 kept {rid8} — gpu-dev connect {rid8} • gpu-dev cancel {rid8}[/cyan]")
+    else:
+        try:
+            reservation_mgr.cancel_reservation(rid, user_info["user_id"])
+            rprint(f"[green]🧹 cancelled repro box {rid8}[/green]")
+        except Exception as e:
+            rprint(f"[yellow]auto-cancel failed for {rid8}: {e}[/yellow]")
+    rprint(f"\n[bold]repro exit code: {rc}[/bold] ({verdict})")
+    sys.exit(rc)
 
 
 _SUBMIT_GPU_TYPES = ["b300", "b200", "b200-mig-1g", "b200-mig-2g", "b200-mig-3g", "h200", "h100",

--- a/docs/SDK_REPRO.md
+++ b/docs/SDK_REPRO.md
@@ -35,14 +35,18 @@ with client.reserve(gpu_type="b200", gpu_count=1, hours=1) as sb:
 PyTorch is pre-staged at `~/pytorch` (importable). To reproduce a failure, point at
 the **PR or commit** and run the test.
 
-**One CLI command** (reserve → checkout → run → auto-cancel):
+**One CLI command** (reserve → checkout → run → **drop you into the box to fix**):
 ```bash
 gpu-dev repro pr/185264 test/inductor/test_flex_attention.py TestFlexAttentionCUDA.test_large_kv_int64_pointer_math_cuda
 ```
 - `REF`: `pr/<N>`, `#<N>`, a bare PR number, a branch, or a commit sha.
 - PRs use **`pull/<N>/merge`** (what CI actually tests — the PR merged onto current
   trunk), falling back to `/head`. Use this, not the raw branch.
-- `--keep` to inspect afterward instead of auto-cancelling.
+- By default (in a terminal) repro runs the test, prints the verdict, then **lands
+  you in the box** at `~/pytorch` with the ref checked out so you can fix and re-run;
+  it stays alive until you cancel (prompted on exit).
+- `--no-connect` = CI mode: run, auto-cancel, process exit code = the test result.
+- `--keep` never cancels (no prompt). `--gpu-type` / `--gpus` / `--hours` to size it.
 
 **From the SDK:**
 ```python
@@ -101,5 +105,12 @@ own compiles populate it for the next person too.
   (warm shared ccache), not a cold build. See [Builds are cached](#builds-are-cached-shared-ccache).
 - **Ephemeral by design.** Repro boxes have no persistent disk; bring code via
   `--ref`, `sb.upload`, or git.
+- **Reproducing a reverted PR / an OOM.** `pr/N` uses `/merge` = the PR re-applied
+  onto *current* trunk — so if the PR was reverted, `/merge` effectively un-reverts
+  it and you test the **fixed** tree (it'll pass). To repro the failing trunk state,
+  check out the **exact land commit** instead (`gpu-dev repro <sha> …`). And match the
+  CI runner's GPU: an **OOM** only reproduces on a GPU as small as the runner's — the
+  default `b200` has far more memory, so a memory-bound failure won't show there
+  (`--gpu-type h100`/`a100`/… to match).
 
 See also: `sdk/python/README.md` and `sdk/python/examples/`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.7.5"
+version = "0.7.6"
 description = "CLI + Python SDK for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"

--- a/sdk/python/src/gpu_dev/__init__.py
+++ b/sdk/python/src/gpu_dev/__init__.py
@@ -63,4 +63,4 @@ try:
 
     __version__ = _pkg_version("gpu-dev")
 except Exception:
-    __version__ = "0.7.5"
+    __version__ = "0.7.6"


### PR DESCRIPTION
## `gpu-dev repro` drops you into the box to iterate

Per feedback: `repro` used to run the test and immediately auto-cancel — fine for a
one-shot "did it repro?", useless for "now let me fix it." Now:

- **Default (TTY):** run the test → print the verdict → **connect you into the box**
  at `~/pytorch` with the ref checked out, so you can edit and re-run. The box stays
  alive until you cancel it (you're prompted on exit; `gpu-dev cancel` from inside
  also works now).
- **`--no-connect`:** CI mode — run, auto-cancel, process exit code = the test result.
- **`--keep`:** never cancel (no prompt).

Also documents two gotchas we just hit in practice:
- **Reverted PR:** `pr/N` uses `/merge`, which re-applies the PR onto *current* trunk
  — so a reverted PR gets un-reverted and you test the **fixed** tree (it passes). Use
  the **land commit sha** to repro the failing state.
- **OOM failures** only reproduce on a GPU as small as the CI runner's; the default
  `b200` has far more memory (`--gpu-type h100`/`a100`/… to match).

Release **0.7.6** (CLI/laptop-side; `repro` runs from your machine).
