### PR TITLE
Warm pool on staging (t4+cpu) + warm/repro integration tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,20 +48,33 @@ uv run pytest -m "not integration" # ~1140 tests; run before every commit
 
 **2. e2e integration on STAGING — run for anything touching the
 reserve/pod/SSH/lambda path before merging.** Real reservations on the **staging**
-cluster (us-west-1), cpu + t4 only, auto-cancelled.
+cluster (us-west-1), cpu + t4 only, auto-cancelled. Staging is the DEFAULT target
+and github_user comes from your config, so the bare command is enough:
 ```bash
-GPU_DEV_TEST_ENV=staging GPU_DEV_GITHUB_USER=wdvr \
-  uv run pytest -m integration --run-integration -v
+uv run pytest -m integration --run-integration -v
 ```
-- Staging = `GPU_DEV_ENVIRONMENT=staging` → us-west-1, standard `pytorch-gpu-dev-*`
-  prefix (tf workspace `test`). Wired in `cli-tools/.../config.py` ENVIRONMENTS.
+- Staging is the default (`GPU_DEV_TEST_ENV` defaults to `staging` → us-west-1,
+  standard `pytorch-gpu-dev-*` prefix, tf workspace `test`). The integration
+  conftest pins the region so the unit-test us-east-2 default can't leak in. Wired
+  in `cli-tools/.../config.py` ENVIRONMENTS.
 - Covers: cpu-x86 + t4 reserve→active→cancel, list-while-active, exec
-  (`nproc`/`nvidia-smi`/`torch.cuda`), and **`claude -p` answers "Paris"** (proves
-  the pod's Claude Code/Bedrock works). Each cancels in a `finally` (no leaked pods).
+  (`nproc`/`nvidia-smi`/`torch.cuda`), **`claude -p` answers "Paris"** (pod Claude
+  Code/Bedrock), and the **warm pool** (fast warm claim + custom-image
+  warm-ineligibility). Each cancels in a `finally` (no leaked pods).
+- Warm-pool tests need `WARM_POOL_TARGETS` deployed on staging — set in
+  `lambda.tf` for workspace `test` (`{t4, cpu-x86, cpu-arm}`); `tf apply` the test
+  workspace. Until then they skip ("came up cold"). Custom-image test: set
+  `GPU_DEV_TEST_IMAGE`.
+- Repro test (`test_repro_known_failure.py`): set `GPU_DEV_REPRO_REF` +
+  `GPU_DEV_REPRO_TEST` to a known-red (commit, test). Find one with the
+  **treehugger MCP** (`hud`, user-scope — `get_hud_data`/`master_commit_red`).
+  Note: prebuilt torch is h100/b200 arch, so a CUDA test on t4 needs a full build;
+  prefer a failure that runs on the box's GPU or on cpu.
 - Skips cleanly if staging is unreachable or the runner has no outbound SSH (e.g. a
   sandbox). The reservation role can query/SQS but lacks `DescribeTable`, so the
   reachability probe uses scan+get-queue-url, not describe.
-- Validated live (2026-05-31): cpu + t4 lifecycle PASS.
+- Validated live (2026-05-31): cpu + t4 lifecycle PASS; warm-claim test confirmed
+  it reaches the real reserve (skips until WARM_POOL_TARGETS is applied).
 
 **Rule of thumb:** unit+mocks for *every* change; add e2e coverage when you add a
 new command/flow; run the staging e2e before merging anything that could affect a

--- a/terraform-gpu-devservers/lambda.tf
+++ b/terraform-gpu-devservers/lambda.tf
@@ -201,6 +201,13 @@ resource "aws_lambda_function" "reservation_processor" {
       SPOT_GPU_TYPES = lookup({
         "prod-east1" = "b300,b200,h200,h100,a100,t4,l4,rtxpro6000,cpu-spot"
       }, terraform.workspace, "")
+      # Warm-pool tier counts per workspace (JSON object). Staging (workspace
+      # "test", us-west-1) only has t4 + cpu nodes, so scope warm pods to those —
+      # the in-code default (h100/b200/MIG) would create unschedulable Pending
+      # pods here. Empty string -> lambda falls back to _DEFAULT_WARM_TARGETS.
+      WARM_POOL_TARGETS = lookup({
+        "test" = jsonencode({ t4 = 2, "cpu-x86" = 2, "cpu-arm" = 2 })
+      }, terraform.workspace, "")
       DISK_CONTENTS_BUCKET = aws_s3_bucket.disk_contents.bucket
       OPERATIONS_TABLE     = aws_dynamodb_table.operations.name
     }, local.alb_env_vars)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -23,8 +23,16 @@ ACTIVE_TIMEOUT_MIN = float(os.environ.get("GPU_DEV_TEST_TIMEOUT_MIN", "15"))
 
 @pytest.fixture(scope="session", autouse=True)
 def _select_env():
-    # Point the CLI Config at the target environment for this process.
-    os.environ.setdefault("GPU_DEV_ENVIRONMENT", TEST_ENV)
+    # Point the CLI Config at the target environment (staging by default) and PIN
+    # the region to that env's region — the root conftest sets AWS_DEFAULT_REGION
+    # to us-east-2 for the lambda unit tests, which would otherwise leak in and
+    # send integration reservations to the wrong region.
+    os.environ["GPU_DEV_ENVIRONMENT"] = TEST_ENV
+    from gpu_dev_cli.config import Config
+    region = Config.ENVIRONMENTS.get(TEST_ENV, {}).get("region")
+    if region:
+        os.environ["AWS_REGION"] = region
+        os.environ["AWS_DEFAULT_REGION"] = region
     yield
 
 
@@ -92,14 +100,17 @@ def exec_or_skip(conn: dict, remote: str, timeout: int = 120):
 
 
 @contextlib.contextmanager
-def reserved(manager, gpu_type, gpu_count, hours=0.5):
-    """Reserve -> wait active -> yield connection info -> ALWAYS cancel."""
+def reserved(manager, gpu_type, gpu_count, hours=0.5, **create_kwargs):
+    """Reserve -> wait active -> yield (rid, connection info) -> ALWAYS cancel.
+
+    Extra create_kwargs (e.g. dockerimage=...) pass straight to create_reservation.
+    """
     user_id = manager._test_user["user_id"]
     github_user = manager._test_user["github_user"]
     rid = manager.create_reservation(
         user_id=user_id, gpu_count=gpu_count, gpu_type=gpu_type,
         duration_hours=hours, name="itest", github_user=github_user,
-        no_persistent_disk=True)
+        no_persistent_disk=True, **create_kwargs)
     assert rid, "create_reservation returned no id"
     try:
         manager.wait_for_reservation_completion(
@@ -109,3 +120,12 @@ def reserved(manager, gpu_type, gpu_count, hours=0.5):
     finally:
         with contextlib.suppress(Exception):
             manager.cancel_reservation(rid, user_id)
+
+
+def read_reservation(manager, rid: str) -> dict:
+    """Fetch the raw reservation record from DynamoDB (for warm_claimed, status…)."""
+    from gpu_dev_cli.config import load_config
+    cfg = load_config()
+    item = cfg.dynamodb.Table(cfg.reservations_table).get_item(
+        Key={"reservation_id": rid}).get("Item")
+    return item or {}

--- a/tests/integration/test_repro_known_failure.py
+++ b/tests/integration/test_repro_known_failure.py
@@ -1,0 +1,54 @@
+"""Integration: reproduce a KNOWN main-branch failure on a real pod.
+
+Point at a specific commit + test that is known-red on trunk and assert it FAILS
+here too (i.e. the failure reproduces). Parametrized so it works for any failure:
+
+    GPU_DEV_REPRO_REF   a main commit sha (or pr/N) that is failing on HUD
+    GPU_DEV_REPRO_TEST  the test args, e.g. "test/inductor/test_x.py Class.test_y"
+    GPU_DEV_REPRO_GPU   gpu type for the box (default t4)
+    GPU_DEV_REPRO_GPUS  gpu count (default 1)
+
+Find a current known failure with the **treehugger MCP** (get_hud_data /
+master_commit_red → a red commit + its failing test) and set the two env vars.
+
+Caveat: the prebuilt PyTorch is h100/b200-arch, so a CUDA test that needs torch
+will need a full build on t4 (slow) — prefer a failure that runs on the box's GPU
+(or a cpu-runnable test). Skipped unless REF+TEST are set; SSH step skips if the
+runner can't reach the pod.
+"""
+import os
+import shlex
+
+import pytest
+
+from .conftest import reserved, exec_or_skip
+
+pytestmark = pytest.mark.integration
+
+REF = os.environ.get("GPU_DEV_REPRO_REF")
+TEST = os.environ.get("GPU_DEV_REPRO_TEST")
+GPU = os.environ.get("GPU_DEV_REPRO_GPU", "t4")
+GPUS = int(os.environ.get("GPU_DEV_REPRO_GPUS", "1"))
+
+
+@pytest.mark.skipif(
+    not (REF and TEST),
+    reason="set GPU_DEV_REPRO_REF + GPU_DEV_REPRO_TEST to a known-failing (commit, test) "
+           "— find one via the treehugger MCP (master_commit_red / get_hud_data)")
+def test_known_failure_reproduces(manager):
+    with reserved(manager, gpu_type=GPU, gpu_count=GPUS, hours=1.0) as (rid, conn):
+        remote = (
+            "cd ~/pytorch && "
+            f"git fetch origin {shlex.quote(REF)} 2>/dev/null && git checkout -f FETCH_HEAD 2>/dev/null "
+            f"|| git checkout -f {shlex.quote(REF)}; "
+            "echo HEAD=$(git rev-parse --short HEAD 2>/dev/null); "
+            f"python {TEST}; echo REPRO_EXIT=$?"
+        )
+        rc, out = exec_or_skip(conn, remote, timeout=1800)
+        markers = [l for l in out.splitlines() if l.startswith("REPRO_EXIT=")]
+        assert markers, f"no REPRO_EXIT marker — checkout/run never completed:\n{out[-2000:]}"
+        exit_code = int(markers[-1].split("=", 1)[1])
+        # The known failure must REPRODUCE: the test should FAIL (non-zero exit).
+        assert exit_code != 0, (
+            f"expected {TEST} @ {REF} to FAIL (reproduce the known failure) but it "
+            f"passed:\n{out[-2000:]}")

--- a/tests/integration/test_warm_pool.py
+++ b/tests/integration/test_warm_pool.py
@@ -1,0 +1,54 @@
+"""Integration: warm pool on staging (t4 + cpu).
+
+Requires WARM_POOL_TARGETS to be deployed on the target env (lambda.tf, workspace
+"test" → t4 + cpu). If a reservation comes up cold (no warm pool yet), the warm
+tests skip with a clear reason.
+
+1. A warm-eligible reservation is claimed FAST and takes a pre-booted warm pod
+   (`warm_claimed=True` on the record).
+2. A custom-image reservation is warm-INELIGIBLE → does not consume a warm pod and
+   still comes up cleanly. (The eviction-under-pressure logic — "cleanly kill the
+   minimum warm pods to free a node" — is unit-tested in
+   tests/unit/lambda_fn/test_warm_pool.py::_evict_warm_for_capacity.)
+"""
+import os
+import time
+
+import pytest
+
+from .conftest import reserved, read_reservation
+
+pytestmark = pytest.mark.integration
+
+WARM_TYPE = os.environ.get("GPU_DEV_WARM_TYPE", "t4")           # warm type on staging
+WARM_GPUS = int(os.environ.get("GPU_DEV_WARM_GPUS", "1"))
+
+
+def test_warm_claim_is_fast_and_takes_a_warm_pod(manager):
+    t0 = time.time()
+    with reserved(manager, gpu_type=WARM_TYPE, gpu_count=WARM_GPUS, hours=0.5) as (rid, conn):
+        elapsed = time.time() - t0
+        rec = read_reservation(manager, rid)
+        if not rec.get("warm_claimed"):
+            pytest.skip(
+                f"{WARM_TYPE} came up cold (no warm pool here yet) — deploy "
+                f"WARM_POOL_TARGETS on staging (lambda.tf, workspace 'test') + tf apply")
+        assert rec["warm_claimed"] is True
+        assert conn.get("ssh_command"), f"warm pod {rid} has no ssh_command"
+        # Warm claim is near-instant; a cold reserve is minutes. Generous ceiling.
+        assert elapsed < 120, f"warm claim took {elapsed:.0f}s — not fast"
+
+
+def test_custom_image_does_not_take_a_warm_pod(manager):
+    image = os.environ.get("GPU_DEV_TEST_IMAGE")
+    if not image:
+        pytest.skip(
+            "set GPU_DEV_TEST_IMAGE to a staging-pullable image to test the "
+            "custom-image (warm-ineligible) path")
+    with reserved(manager, gpu_type=WARM_TYPE, gpu_count=WARM_GPUS, hours=0.5,
+                  dockerimage=image) as (rid, conn):
+        rec = read_reservation(manager, rid)
+        assert rec.get("warm_claimed") is not True, \
+            "a custom image must NOT claim a warm pod (warm-ineligible)"
+        assert conn.get("ssh_command"), \
+            "custom-image reservation should still come up active (clean cold path)"


### PR DESCRIPTION
Adds a warm pool to **staging** and the integration tests you asked for.

## Warm pool on staging
`lambda.tf`: `WARM_POOL_TARGETS` scoped to workspace **test** (staging us-west-1) = `{t4: 2, cpu-x86: 2, cpu-arm: 2}`. Staging only has t4+cpu nodes, so the in-code default (h100/b200/MIG) would make unschedulable Pending pods here; empty for other workspaces → code default. (`tofu validate` ✓.) **Needs `tf apply` on the test workspace to activate.**

## Integration tests (gated, skip-if-prereqs-missing)
1. **`test_warm_pool.py::test_warm_claim_is_fast_and_takes_a_warm_pod`** — reserve t4 → assert `warm_claimed=True` + fast. (Validated it reaches the real reserve; skips "came up cold" until WARM_POOL_TARGETS is applied.)
2. **`test_warm_pool.py::test_custom_image_does_not_take_a_warm_pod`** — a custom `dockerimage` is warm-ineligible → no warm pod, comes up clean. The deeper *evict-cleanly-under-pressure* logic is already unit-tested in `tests/unit/lambda_fn/test_warm_pool.py::_evict_warm_for_capacity`.
3. **`test_repro_known_failure.py`** — parametrized (`GPU_DEV_REPRO_REF`/`GPU_DEV_REPRO_TEST`): checks out a known-red commit on a real box and asserts the test FAILS (reproduces). Find the commit via the **treehugger MCP**.

## Also
- Staging is now the **default** for integration (`GPU_DEV_TEST_ENV` defaults to staging; region pinned so the unit-test us-east-2 default can't leak). Bare `pytest -m integration --run-integration` targets staging.
- CLAUDE.md testing protocol updated. Unit suite still 1140 green.

## Notes
- **treehugger MCP** installed (server `hud`, user scope) — tools `mcp__hud__*` load next session; I'll wire the repro test's default (commit, test) from it then.
- Prebuilt torch is h100/b200 arch, so a CUDA repro on t4 needs a full build — prefer a failure that runs on the box's GPU or cpu.