### PR TITLE
fix: staging is the tf 'default' workspace (warm pool key + docs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ and github_user comes from your config, so the bare command is enough:
 uv run pytest -m integration --run-integration -v
 ```
 - Staging is the default (`GPU_DEV_TEST_ENV` defaults to `staging` → us-west-1,
-  standard `pytorch-gpu-dev-*` prefix, tf workspace `test`). The integration
+  standard `pytorch-gpu-dev-*` prefix, tf workspace `default`). The integration
   conftest pins the region so the unit-test us-east-2 default can't leak in. Wired
   in `cli-tools/.../config.py` ENVIRONMENTS.
 - Covers: cpu-x86 + t4 reserve→active→cancel, list-while-active, exec
@@ -62,9 +62,10 @@ uv run pytest -m integration --run-integration -v
   Code/Bedrock), and the **warm pool** (fast warm claim + custom-image
   warm-ineligibility). Each cancels in a `finally` (no leaked pods).
 - Warm-pool tests need `WARM_POOL_TARGETS` deployed on staging — set in
-  `lambda.tf` for workspace `test` (`{t4, cpu-x86, cpu-arm}`); `tf apply` the test
-  workspace. Until then they skip ("came up cold"). Custom-image test: set
-  `GPU_DEV_TEST_IMAGE`.
+  `lambda.tf` for the `default` workspace (`{t4, cpu-x86, cpu-arm}`). Staging IS the
+  tf `default` workspace (us-west-1, environment=test) — there is no `test`/`staging`
+  workspace: `tofu workspace select default && tofu apply`. Until then the warm
+  tests skip ("came up cold"). Custom-image test: set `GPU_DEV_TEST_IMAGE`.
 - Repro test (`test_repro_known_failure.py`): set `GPU_DEV_REPRO_REF` +
   `GPU_DEV_REPRO_TEST` to a known-red (commit, test). Find one with the
   **treehugger MCP** (`hud`, user-scope — `get_hud_data`/`master_commit_red`).

--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/config.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/config.py
@@ -29,13 +29,13 @@ class Config:
             "description": "Spot-only us-east-1 environment (T4/L4/CPU)",
             "spot_types": ["b300", "b200", "h200", "h100", "a100", "t4", "l4", "rtxpro6000"],
         },
-        # Staging (us-west-1, tf workspace "test"). Same standard resource prefix
-        # as prod, just a different region — so only the region changes. Live
-        # capacity: cpu-x86/arm + t4. Used for integration tests. Select via
-        # `GPU_DEV_ENVIRONMENT=staging` (or the legacy "test" env, same target).
+        # Staging (us-west-1, tf "default" workspace, environment=test). Same
+        # standard resource prefix as prod, just a different region — so only the
+        # region changes. Live capacity: cpu-x86/arm + t4. Used for integration
+        # tests. Select via `GPU_DEV_ENVIRONMENT=staging` (or the "test" env alias).
         "staging": {
             "region": "us-west-1",
-            "workspace": "test",
+            "workspace": "default",
             "description": "Staging (us-west-1, cpu + t4)",
         },
     }

--- a/terraform-gpu-devservers/lambda.tf
+++ b/terraform-gpu-devservers/lambda.tf
@@ -201,12 +201,13 @@ resource "aws_lambda_function" "reservation_processor" {
       SPOT_GPU_TYPES = lookup({
         "prod-east1" = "b300,b200,h200,h100,a100,t4,l4,rtxpro6000,cpu-spot"
       }, terraform.workspace, "")
-      # Warm-pool tier counts per workspace (JSON object). Staging (workspace
-      # "test", us-west-1) only has t4 + cpu nodes, so scope warm pods to those —
-      # the in-code default (h100/b200/MIG) would create unschedulable Pending
-      # pods here. Empty string -> lambda falls back to _DEFAULT_WARM_TARGETS.
+      # Warm-pool tier counts per workspace (JSON object). Staging is the "default"
+      # workspace (us-west-1, environment=test) and only has t4 + cpu nodes, so
+      # scope warm pods to those — the in-code default (h100/b200/MIG) would create
+      # unschedulable Pending pods here. Empty -> lambda falls back to
+      # _DEFAULT_WARM_TARGETS (prod keeps its h100/b200/cpu/MIG warm pool).
       WARM_POOL_TARGETS = lookup({
-        "test" = jsonencode({ t4 = 2, "cpu-x86" = 2, "cpu-arm" = 2 })
+        "default" = jsonencode({ t4 = 2, "cpu-x86" = 2, "cpu-arm" = 2 })
       }, terraform.workspace, "")
       DISK_CONTENTS_BUCKET = aws_s3_bucket.disk_contents.bucket
       OPERATIONS_TABLE     = aws_dynamodb_table.operations.name


### PR DESCRIPTION
No 'test'/'staging' tf workspace exists — staging (us-west-1, environment=test) is the **default** workspace (main.tf workspace_configs.default). Fixes the WARM_POOL_TARGETS lookup key (test→default; it never applied on staging before, and staging would otherwise get the h100/b200 code default = unschedulable Pending pods), the CLI config staging workspace field, and the CLAUDE.md docs. prod (workspace prod) unchanged. tofu validate ✓.