### PR TITLE
fix(tf): management-ns resources depends_on the namespace (fresh-cluster race)

### DIFF
--- a/terraform-gpu-devservers/git-cache.tf
+++ b/terraform-gpu-devservers/git-cache.tf
@@ -42,6 +42,7 @@ resource "kubernetes_persistent_volume_claim" "git_cache" {
 }
 
 resource "kubernetes_deployment" "git_cache" {
+  depends_on = [kubernetes_namespace.management]
   metadata {
     name      = "git-cache"
     namespace = "management"
@@ -345,6 +346,7 @@ NGINXCONF
 }
 
 resource "kubernetes_service" "git_cache" {
+  depends_on = [kubernetes_namespace.management]
   metadata {
     name      = "git-cache"
     namespace = "management"

--- a/terraform-gpu-devservers/pytorch-prebuild.tf
+++ b/terraform-gpu-devservers/pytorch-prebuild.tf
@@ -35,6 +35,7 @@ locals {
 }
 
 resource "kubernetes_cron_job_v1" "pytorch_prebuild" {
+  depends_on = [kubernetes_namespace.management]
   metadata {
     name      = "pytorch-prebuild"
     namespace = "management"


### PR DESCRIPTION
Fresh-cluster (staging) apply failed with `namespaces "management" not found` for git_cache service + pytorch_prebuild cronjob — they reference namespace=management with no depends_on, racing the namespace creation. Worked on prod only because the ns already existed. Adds `depends_on [kubernetes_namespace.management]` to the git_cache deployment + service and the prebuild cronjob. tofu validate ✓.