### PR TITLE
fix(warm): reconciler cleans up de-targeted + over-target warm pods

### DIFF
--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -1505,6 +1505,20 @@ def _provision_warm_pod(v1, pod) -> None:
     }}})
 
 
+def _recycle_warm_pod(v1, p) -> bool:
+    """Delete a warm pod + its SSH service. Returns True on pod delete success."""
+    try:
+        v1.delete_namespaced_pod(p.metadata.name, "gpu-dev")
+        try:
+            v1.delete_namespaced_service(f"{p.metadata.name}-ssh", "gpu-dev")
+        except Exception:
+            pass
+        return True
+    except Exception as de:
+        logger.warning(f"warm recycle delete failed for {p.metadata.name}: {de}")
+        return False
+
+
 def reconcile_warm_pool() -> dict:
     """Top up / recycle the standby pool of pre-booted pods per GPU type."""
     v1 = client.CoreV1Api(get_k8s_client())
@@ -1527,17 +1541,18 @@ def reconcile_warm_pool() -> dict:
                 age_s = time.time() - created_ts
                 stale = labels.get("warm-state") == "ready" and age_s > max_age_s
                 if phase in ("Failed", "Succeeded") or stale:
-                    try:
-                        v1.delete_namespaced_pod(p.metadata.name, "gpu-dev")
-                        try:
-                            v1.delete_namespaced_service(f"{p.metadata.name}-ssh", "gpu-dev")
-                        except Exception:
-                            pass
+                    if _recycle_warm_pod(v1, p):
                         recycled += 1
-                    except Exception as de:
-                        logger.warning(f"warm recycle delete failed for {p.metadata.name}: {de}")
                     continue
                 live.append(p)
+            # Scale DOWN when over target (e.g. the target count was just lowered):
+            # delete the excess standby pods so we don't hold more than configured.
+            excess = len(live) - int(target)
+            if excess > 0:
+                for p in live[int(target):]:
+                    if _recycle_warm_pod(v1, p):
+                        recycled += 1
+                live = live[:int(target)]
             # Backfill connection details on ready pods so claims stay fast.
             for p in live:
                 if (p.metadata.labels or {}).get("warm-state") == "ready":
@@ -1555,6 +1570,22 @@ def reconcile_warm_pool() -> dict:
                     break
         except Exception as e:
             logger.warning(f"warm reconcile failed for {gpu_type}: {e}")
+
+    # Clean up standby pods of types NO LONGER in WARM_POOL_TARGETS. Without this,
+    # changing the targets (or applying them on a cluster that lacks those node
+    # types, e.g. h100/b200 on staging) leaves orphaned warm pods stuck Pending
+    # forever. Claimed pods (real reservations) are never touched.
+    try:
+        for p in _list_warm_pods(v1):
+            labels = p.metadata.labels or {}
+            if labels.get("warm-state") == "claimed":
+                continue
+            if labels.get("warm-gpu-type") not in WARM_POOL_TARGETS:
+                if _recycle_warm_pod(v1, p):
+                    recycled += 1
+    except Exception as e:
+        logger.warning(f"warm de-targeted cleanup failed: {e}")
+
     logger.info(f"Warm pool reconcile: created={created} recycled={recycled}")
     return {"statusCode": 200, "body": json.dumps({"created": created, "recycled": recycled})}
 

--- a/tests/unit/lambda_fn/test_warm_pool.py
+++ b/tests/unit/lambda_fn/test_warm_pool.py
@@ -453,3 +453,43 @@ def test_evict_outer_exception_returns_none(lambda_index, monkeypatch):
     az, node = lambda_index._evict_warm_for_capacity(
         v1, "h100", 1, [_node("node-a", 0)])
     assert (az, node) == (None, None)
+
+
+# --- reconcile_warm_pool: scale-down + de-targeted cleanup --------------------
+
+def test_reconcile_scales_down_when_over_target(lambda_index, monkeypatch):
+    # Target lowered to 2 but 5 ready standby pods exist -> delete the 3 excess.
+    pods = [_make_pod(f"gpu-dev-cpu-x86-{i}", warm_state="ready", gpu_type="cpu-x86",
+                      gpu_held=0, creation_ts=time.time()) for i in range(5)]
+    v1, created, result = _reconcile_with(
+        lambda_index, monkeypatch,
+        pods_by_type={"cpu-x86": pods, None: pods},
+        target_overrides={"cpu-x86": 2},
+    )
+    deleted = [c.args[0] for c in v1.delete_namespaced_pod.call_args_list]
+    assert len(deleted) == 3, deleted          # 5 live - 2 target
+    assert created == []                         # already over target
+    import json
+    assert json.loads(result["body"])["recycled"] == 3
+
+
+def test_reconcile_cleans_up_detargeted_types(lambda_index, monkeypatch):
+    # Targets = {t4:1}. Stale h100 standby pods (a type no longer targeted, e.g.
+    # left over from the default targets on a cluster with no h100 nodes) must be
+    # deleted; a CLAIMED h100 (real reservation) must NOT be touched.
+    t4 = _make_pod("gpu-dev-t4-x", warm_state="ready", gpu_type="t4", creation_ts=time.time())
+    h1 = _make_pod("gpu-dev-h100-a", warm_state="ready", gpu_type="h100", creation_ts=time.time())
+    h2 = _make_pod("gpu-dev-h100-b", warm_state="ready", gpu_type="h100", creation_ts=time.time())
+    hclaim = _make_pod("gpu-dev-h100-claimed", warm_state="claimed", gpu_type="h100",
+                       creation_ts=time.time())
+    allpods = [t4, h1, h2, hclaim]
+    v1, created, _ = _reconcile_with(
+        lambda_index, monkeypatch,
+        pods_by_type={"t4": [t4], None: allpods},
+        target_overrides={"t4": 1},
+    )
+    deleted = [c.args[0] for c in v1.delete_namespaced_pod.call_args_list]
+    assert "gpu-dev-h100-a" in deleted and "gpu-dev-h100-b" in deleted   # de-targeted -> cleaned
+    assert "gpu-dev-h100-claimed" not in deleted                         # real reservation, untouched
+    assert "gpu-dev-t4-x" not in deleted                                 # targeted type kept
+    assert created == []                                                 # t4 already at target


### PR DESCRIPTION
Found live on staging while validating: after correcting WARM_POOL_TARGETS to {t4,cpu-x86,cpu-arm}, stale `h100`/`h100-mig` standby pods sat **Pending forever** (no such nodes on staging) and `cpu-x86` stayed at 5 (target 2). Cause: `reconcile_warm_pool` only iterated types **in** WARM_POOL_TARGETS, so de-targeted types were never cleaned up and over-target counts never scaled down (`deficit = max(0, …)`).

Fix: (1) scale **down** when over target; (2) after the per-type loop, delete standby pods whose `warm-gpu-type` is no longer in WARM_POOL_TARGETS. **Claimed pods (real reservations) are never touched.** Extracted `_recycle_warm_pod`. +2 unit tests (scale-down, de-targeted cleanup incl. claimed-safety). Unit suite 1142 green.

Deploy: `tf apply` — the next reconcile tick then clears staging's stale Pending pods automatically.