### PR TITLE
feat(cli): repro streams build progress + flags commit age

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -1574,7 +1574,9 @@ def repro(ctx, ref, test_args, gpu_type, gpus, hours, no_connect, keep):
         "echo \"[repro] HEAD $(git rev-parse --short HEAD)\"; "
         "git -c protocol.file.allow=always submodule update --init --recursive --jobs 8 >/dev/null 2>&1 || true; "
         "if ! PYTHONPATH=/home/dev/pytorch python -c 'import torch' 2>/dev/null; then "
-        "echo '[repro] incremental rebuild on warm build/...'; pip install --break-system-packages -e . --no-build-isolation; fi; "
+        "echo \"[repro] prebuilt torch != this commit -> rebuilding (ccache-accelerated, but the further this commit is from viable/strict, the more recompiles). checked-out: $(git log -1 --format='%h %ci')\"; "
+        # -v streams the cmake/ninja [x/N] progress instead of pip's blind 'still running...' spinner.
+        "pip install --break-system-packages -e . --no-build-isolation -v; fi; "
         f"echo '[repro] running: python {testcmd}'; "
         f"PYTHONPATH=/home/dev/pytorch python {testcmd}"
     )

--- a/tests/unit/cli/test_repro.py
+++ b/tests/unit/cli/test_repro.py
@@ -176,9 +176,9 @@ def test_remote_command_structure(cli_runner):
     assert "cd /home/dev/pytorch" in cmd
     assert "safe.directory /home/dev/pytorch" in cmd
     assert "submodule update --init --recursive" in cmd
-    # import torch guard -> incremental rebuild
+    # import torch guard -> rebuild (editable, no build isolation, streamed with -v)
     assert "import torch" in cmd
-    assert "incremental rebuild on warm build/" in cmd
+    assert "pip install" in cmd and "--no-build-isolation" in cmd and "-v" in cmd
     # PYTHONPATH-prefixed python invocation of the test args
     assert "PYTHONPATH=/home/dev/pytorch python test/inductor/test_flex_attention.py TestX.test_y" in cmd
 


### PR DESCRIPTION
The repro rebuild ran `pip install -e .` which buffers output → only pip's blind 'still running…' spinner, and a commit far from viable/strict (e.g. #184348 = 420 commits back) is a near-cold ~30min build that looks hung. Now: `-v` streams the cmake/ninja `[x/N]` progress, and we echo the checked-out commit sha+date before building so an old commit (= big rebuild) is obvious. (Reminder for users: repro is only fast for commits near viable/strict.)