### PR TITLE
perf(ccache): set CCACHE_MAXSIZE=150G (was ~5G default, evicting hard)

### DIFF
--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -4706,8 +4706,11 @@ def get_cpu_thread_env_vars(gpu_count: int, gpu_type: str) -> list:
         client.V1EnvVar(name="MAKEFLAGS", value=f"-j{thread_str}"),  # make parallelism
         # Used by startup script to write to /etc/environment for SSH sessions
         client.V1EnvVar(name="GPU_DEV_THREAD_COUNT", value=thread_str),
-        # ccache configuration for faster C++ compilation
+        # ccache configuration for faster C++ compilation. MAXSIZE >> a single
+        # PyTorch build (10-20GB) so the shared cache holds many commits and repros
+        # hit instead of recompiling (the default ~5GB evicts constantly).
         client.V1EnvVar(name="CCACHE_DIR", value="/ccache_shared"),
+        client.V1EnvVar(name="CCACHE_MAXSIZE", value="150G"),
         # Pod Python is the system (PEP 668 externally-managed) interpreter and
         # venv is unavailable (no ensurepip), so `pip install -e . --no-build-isolation`
         # — the canonical pytorch dev build — otherwise errors. This lets it just work.
@@ -5038,6 +5041,7 @@ export MAX_JOBS=$GPU_DEV_THREAD_COUNT
 export CMAKE_BUILD_PARALLEL_LEVEL=$GPU_DEV_THREAD_COUNT
 export MAKEFLAGS="-j$GPU_DEV_THREAD_COUNT"
 export CCACHE_DIR="/ccache_shared"
+export CCACHE_MAXSIZE="150G"
 EOF
                             chmod 644 /etc/profile.d/cpu-limits.sh
 
@@ -5053,6 +5057,7 @@ export MAX_JOBS=$GPU_DEV_THREAD_COUNT
 export CMAKE_BUILD_PARALLEL_LEVEL=$GPU_DEV_THREAD_COUNT
 export MAKEFLAGS="-j$GPU_DEV_THREAD_COUNT"
 export CCACHE_DIR="/ccache_shared"
+export CCACHE_MAXSIZE="150G"
 EOF
                             chmod 644 /etc/zsh/zshenv
 

--- a/terraform-gpu-devservers/pytorch-prebuild.tf
+++ b/terraform-gpu-devservers/pytorch-prebuild.tf
@@ -92,10 +92,16 @@ resource "kubernetes_cron_job_v1" "pytorch_prebuild" {
                 export BUILD_TEST=0
                 export MAX_JOBS=128
                 export CCACHE_DIR=/ccache_shared
+                # A single PyTorch build is 10-20GB of objects; the ccache default
+                # (~5GB) evicts constantly (prod was at 37k cleanups / ~45% hits).
+                # Size it to hold many commits so repros + the next viable/strict
+                # bump mostly hit. EFS is elastic; ~$0.30/GB-mo.
+                export CCACHE_MAXSIZE=150G
                 export CMAKE_C_COMPILER_LAUNCHER=ccache
                 export CMAKE_CXX_COMPILER_LAUNCHER=ccache
                 export CMAKE_CUDA_COMPILER_LAUNCHER=ccache
                 mkdir -p "$CCACHE_DIR"
+                ccache -M 150G 2>/dev/null || true   # persist max_size into the shared cache config
 
                 # --- checkout viable/strict (last green trunk commit) ---
                 if [ ! -d "$SRC/.git" ]; then


### PR DESCRIPTION
`CCACHE_MAXSIZE` was never set → ccache's ~5GB default. A PyTorch build is 10-20GB, so /ccache_shared evicted constantly — **prod: 37,184 cleanups, ~45% hits @ 25GB cap; staging: 5GB default**. Set it to **150G** in the prebuild (+ `ccache -M` to persist) and the pod env + shell-ext exports, so the build node and every user repro share one large cache. Bigger cache → holds many commits → fewer evictions → higher hit rate → faster repros (near viable/strict + re-repros; doesn't help far-back commits — only CI's cache has those). EFS is elastic (~$45/mo @ 150GB). tofu validate ✓, unit suite 1142 green.