### PR TITLE
perf(ccache): CCACHE_MAXSIZE 150G -> 500G (EFS is elastic + IA)

### DIFF
--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -4710,7 +4710,7 @@ def get_cpu_thread_env_vars(gpu_count: int, gpu_type: str) -> list:
         # PyTorch build (10-20GB) so the shared cache holds many commits and repros
         # hit instead of recompiling (the default ~5GB evicts constantly).
         client.V1EnvVar(name="CCACHE_DIR", value="/ccache_shared"),
-        client.V1EnvVar(name="CCACHE_MAXSIZE", value="150G"),
+        client.V1EnvVar(name="CCACHE_MAXSIZE", value="500G"),
         # Pod Python is the system (PEP 668 externally-managed) interpreter and
         # venv is unavailable (no ensurepip), so `pip install -e . --no-build-isolation`
         # — the canonical pytorch dev build — otherwise errors. This lets it just work.
@@ -5041,7 +5041,7 @@ export MAX_JOBS=$GPU_DEV_THREAD_COUNT
 export CMAKE_BUILD_PARALLEL_LEVEL=$GPU_DEV_THREAD_COUNT
 export MAKEFLAGS="-j$GPU_DEV_THREAD_COUNT"
 export CCACHE_DIR="/ccache_shared"
-export CCACHE_MAXSIZE="150G"
+export CCACHE_MAXSIZE="500G"
 EOF
                             chmod 644 /etc/profile.d/cpu-limits.sh
 
@@ -5057,7 +5057,7 @@ export MAX_JOBS=$GPU_DEV_THREAD_COUNT
 export CMAKE_BUILD_PARALLEL_LEVEL=$GPU_DEV_THREAD_COUNT
 export MAKEFLAGS="-j$GPU_DEV_THREAD_COUNT"
 export CCACHE_DIR="/ccache_shared"
-export CCACHE_MAXSIZE="150G"
+export CCACHE_MAXSIZE="500G"
 EOF
                             chmod 644 /etc/zsh/zshenv
 

--- a/terraform-gpu-devservers/pytorch-prebuild.tf
+++ b/terraform-gpu-devservers/pytorch-prebuild.tf
@@ -96,12 +96,12 @@ resource "kubernetes_cron_job_v1" "pytorch_prebuild" {
                 # (~5GB) evicts constantly (prod was at 37k cleanups / ~45% hits).
                 # Size it to hold many commits so repros + the next viable/strict
                 # bump mostly hit. EFS is elastic; ~$0.30/GB-mo.
-                export CCACHE_MAXSIZE=150G
+                export CCACHE_MAXSIZE=500G
                 export CMAKE_C_COMPILER_LAUNCHER=ccache
                 export CMAKE_CXX_COMPILER_LAUNCHER=ccache
                 export CMAKE_CUDA_COMPILER_LAUNCHER=ccache
                 mkdir -p "$CCACHE_DIR"
-                ccache -M 150G 2>/dev/null || true   # persist max_size into the shared cache config
+                ccache -M 500G 2>/dev/null || true   # persist max_size into the shared cache config
 
                 # --- checkout viable/strict (last green trunk commit) ---
                 if [ ! -d "$SRC/.git" ]; then


### PR DESCRIPTION
Cache is on the `ccache_shared` EFS (elastic throughput + 30-day IA lifecycle), so capacity is unbounded and cold objects fall to cheap EFS-IA. Bump the eviction cap 150G→500G to retain many more commits (more back-jump/re-repro hits). EFS bills only for stored bytes (prod ~27GB / staging ~1GB today), so this is just a higher ceiling. Caveat: huge ccache-on-NFS can grow small-file metadata latency — dial back if lookups slow.