### PR TITLE
perf(ccache): settle CCACHE_MAXSIZE at 250G

### DIFF
--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -4710,7 +4710,7 @@ def get_cpu_thread_env_vars(gpu_count: int, gpu_type: str) -> list:
         # PyTorch build (10-20GB) so the shared cache holds many commits and repros
         # hit instead of recompiling (the default ~5GB evicts constantly).
         client.V1EnvVar(name="CCACHE_DIR", value="/ccache_shared"),
-        client.V1EnvVar(name="CCACHE_MAXSIZE", value="500G"),
+        client.V1EnvVar(name="CCACHE_MAXSIZE", value="250G"),
         # Pod Python is the system (PEP 668 externally-managed) interpreter and
         # venv is unavailable (no ensurepip), so `pip install -e . --no-build-isolation`
         # — the canonical pytorch dev build — otherwise errors. This lets it just work.
@@ -5041,7 +5041,7 @@ export MAX_JOBS=$GPU_DEV_THREAD_COUNT
 export CMAKE_BUILD_PARALLEL_LEVEL=$GPU_DEV_THREAD_COUNT
 export MAKEFLAGS="-j$GPU_DEV_THREAD_COUNT"
 export CCACHE_DIR="/ccache_shared"
-export CCACHE_MAXSIZE="500G"
+export CCACHE_MAXSIZE="250G"
 EOF
                             chmod 644 /etc/profile.d/cpu-limits.sh
 
@@ -5057,7 +5057,7 @@ export MAX_JOBS=$GPU_DEV_THREAD_COUNT
 export CMAKE_BUILD_PARALLEL_LEVEL=$GPU_DEV_THREAD_COUNT
 export MAKEFLAGS="-j$GPU_DEV_THREAD_COUNT"
 export CCACHE_DIR="/ccache_shared"
-export CCACHE_MAXSIZE="500G"
+export CCACHE_MAXSIZE="250G"
 EOF
                             chmod 644 /etc/zsh/zshenv
 

--- a/terraform-gpu-devservers/pytorch-prebuild.tf
+++ b/terraform-gpu-devservers/pytorch-prebuild.tf
@@ -96,12 +96,12 @@ resource "kubernetes_cron_job_v1" "pytorch_prebuild" {
                 # (~5GB) evicts constantly (prod was at 37k cleanups / ~45% hits).
                 # Size it to hold many commits so repros + the next viable/strict
                 # bump mostly hit. EFS is elastic; ~$0.30/GB-mo.
-                export CCACHE_MAXSIZE=500G
+                export CCACHE_MAXSIZE=250G
                 export CMAKE_C_COMPILER_LAUNCHER=ccache
                 export CMAKE_CXX_COMPILER_LAUNCHER=ccache
                 export CMAKE_CUDA_COMPILER_LAUNCHER=ccache
                 mkdir -p "$CCACHE_DIR"
-                ccache -M 500G 2>/dev/null || true   # persist max_size into the shared cache config
+                ccache -M 250G 2>/dev/null || true   # persist max_size into the shared cache config
 
                 # --- checkout viable/strict (last green trunk commit) ---
                 if [ ! -d "$SRC/.git" ]; then


### PR DESCRIPTION
Settles the ccache eviction ceiling at **250G** (was bouncing 25G→150G→500G).

**Why 250G:**
- Kills the eviction that hurt prod at the ~25G effective cap (37k cleanups / ~45% hits).
- Holds many commits' worth of objects, so back-jumps (compile v1 → v2 → back to v1) and re-repros near viable/strict mostly hit the cache.
- Stays under the scale where ccache-on-NFS small-file metadata latency starts to bite (the concern that made 500G borderline).

**Cost:** `ccache_shared` is elastic EFS with a 30-day IA lifecycle — this is just the eviction ceiling, billed on stored bytes, not provisioned. Prod is currently ~27.6GB stored.

**Spots changed (5):** `pytorch-prebuild.tf` (`export CCACHE_MAXSIZE` + `ccache -M`), `reservation_processor/index.py` (build-pod env var + two `export` lines in the pod rc). The unrelated `size_limit="500Gi"` PVC at index.py:6441 is untouched.

Validated: `tofu validate` ✅, `py_compile` ✅.