### PR TITLE
fix(cli): SSH alias keys off reservation id (warm pods reachable by resid)

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -319,6 +319,9 @@ def _show_single_reservation(connection_info: dict) -> None:
         reservation_id = connection_info["reservation_id"]
         reservation_name = connection_info.get("name")
         pod_name = connection_info.get("pod_name", "")
+        # SSH host alias keys off the reservation id (works for warm-claimed pods,
+        # whose pod_name != gpu-dev-<resid8>). pod_name is shown separately below.
+        host_alias = f"gpu-dev-{short_id}"
         ssh_config_path = get_ssh_config_path(reservation_id, reservation_name)
         use_include = is_ssh_include_enabled()
 
@@ -328,14 +331,14 @@ def _show_single_reservation(connection_info: dict) -> None:
             if use_include:
                 # User approved Include - show simple commands
                 from .reservations import _make_vscode_link
-                ssh_command_display = f"[green]ssh {pod_name}[/green]"
-                vscode_url = _make_vscode_link(pod_name)
-                vscode_cmd_text = f"code --remote ssh-remote+{pod_name} /home/dev"
+                ssh_command_display = f"[green]ssh {host_alias}[/green]"
+                vscode_url = _make_vscode_link(host_alias)
+                vscode_cmd_text = f"code --remote ssh-remote+{host_alias} /home/dev"
                 vscode_command_display = f"[link={vscode_url}][green]{vscode_cmd_text}[/green][/link]"
                 vscode_info = f"[blue]VS Code Remote:[/blue] {vscode_command_display}\n"
             else:
                 # User declined Include - show commands with -F flag
-                ssh_command_display = f"[green]ssh -F {ssh_config_path} {pod_name}[/green]"
+                ssh_command_display = f"[green]ssh -F {ssh_config_path} {host_alias}[/green]"
                 vscode_command_display = f"Add [green]Include ~/.gpu-dev/*-sshconfig[/green] to ~/.ssh/config and ~/.cursor/ssh_config (or: [green]gpu-dev config ssh-include enable[/green])"
                 vscode_info = f"[blue]VS Code/Cursor:[/blue] {vscode_command_display}\n"
         else:
@@ -1881,7 +1884,9 @@ def submit(ctx, gpu_type, gpus, hours, disk, ref, no_persistent_disk, spot, dock
                 sys.exit(1)
             create_ssh_config_for_reservation(master_fqdn, master_pod, master_id, master_name)
 
-        ssh_alias = master_pod
+        # Host alias matches the Host line written by create_ssh_config_for_reservation
+        # (keyed off the reservation id, so warm-claimed masters resolve too).
+        ssh_alias = f"gpu-dev-{master_id[:8]}"
         ssh_base = ["ssh", "-F", str(config_file), "-o", "StrictHostKeyChecking=accept-new"]
         rsync_e = " ".join(shlex.quote(x) for x in ssh_base)
 
@@ -3168,11 +3173,15 @@ def _show_direct_success(res: dict, elapsed: float) -> None:
     """Print the success block for an instant warm-pool claim,
     matching the normal reserve output (SSH config + VS Code/Cursor remote)."""
     from gpu_dev_cli.reservations import (
-        create_ssh_config_for_reservation, _generate_vscode_command, _generate_cursor_command)
+        create_ssh_config_for_reservation, _generate_vscode_command,
+        _generate_cursor_command, _make_vscode_link, _make_cursor_link)
     rid = res.get("reservation_id", "") or ""
     ssh_command = res.get("ssh_command", "") or ""
     pod_name = res.get("pod_name", "") or ""
     fqdn = res.get("fqdn") or ""
+    # Host alias keys off the reservation id — warm-claimed pods have a pod_name
+    # that is NOT gpu-dev-<resid8>, so we must not use pod_name as the ssh alias.
+    host_alias = f"gpu-dev-{rid[:8]}" if rid else pod_name
 
     rprint(f"\n[green]✅ Instant reservation ready in {elapsed:.1f}s![/green]")
     rprint(f"[bold]📋 Reservation ID:[/bold] {rid}")
@@ -3181,24 +3190,28 @@ def _show_direct_success(res: dict, elapsed: float) -> None:
     if rid:
         rprint(f"[bold]⚡ Quick Connect:[/bold] gpu-dev connect {rid[:8]}")
 
-    # Build the per-reservation SSH config so `ssh <pod>` and connect work cleanly.
+    # Build the per-reservation SSH config so `ssh gpu-dev-<resid8>` and connect work cleanly.
     use_include = False
     if fqdn and pod_name and rid:
         try:
             _cfg, use_include = create_ssh_config_for_reservation(fqdn, pod_name, rid, None)
         except Exception:
             pass
-    if pod_name and use_include:
-        rprint(f"[bold]🖥️  SSH Command:[/bold] ssh {pod_name}")
-    elif ssh_command:
-        rprint(f"[bold]🖥️  SSH Command:[/bold] {ssh_command}")
-
-    vsc = _generate_vscode_command(ssh_command) if ssh_command else None
-    cur = _generate_cursor_command(ssh_command) if ssh_command else None
-    if vsc:
-        rprint(f"[bold]💻 VS Code Remote:[/bold] {vsc}")
-    if cur:
-        rprint(f"[bold]🖥️ Cursor Remote:[/bold] {cur}")
+    if use_include and rid:
+        rprint(f"[bold]🖥️  SSH Command:[/bold] ssh {host_alias}")
+        vscode_url = _make_vscode_link(host_alias)
+        cursor_url = _make_cursor_link(host_alias)
+        rprint(f"[bold]💻 VS Code Remote:[/bold] [link={vscode_url}]code --remote ssh-remote+{host_alias} /home/dev[/link]")
+        rprint(f"[bold]🖥️ Cursor Remote:[/bold] [link={cursor_url}]cursor --remote ssh-remote+{host_alias} /home/dev[/link]")
+    else:
+        if ssh_command:
+            rprint(f"[bold]🖥️  SSH Command:[/bold] {ssh_command}")
+        vsc = _generate_vscode_command(ssh_command) if ssh_command else None
+        cur = _generate_cursor_command(ssh_command) if ssh_command else None
+        if vsc:
+            rprint(f"[bold]💻 VS Code Remote:[/bold] {vsc}")
+        if cur:
+            rprint(f"[bold]🖥️ Cursor Remote:[/bold] {cur}")
 
 
 def _format_gpu_display(gpu_count, gpu_type):
@@ -3781,7 +3794,8 @@ def connect(ctx: click.Context, reservation_id: Optional[str]) -> None:
             for node in nodes:
                 status_display = "✅ Active" if node.get("status") == "active" else f"⏳ {node.get('status', 'unknown')}"
                 pod_name = node.get("pod_name", "unknown")
-                ssh_cmd_short = f"ssh {pod_name}" if pod_name != "unknown" else "N/A"
+                node_rid = node.get("reservation_id")
+                ssh_cmd_short = f"ssh gpu-dev-{node_rid[:8]}" if node_rid else "N/A"
 
                 table.add_row(
                     f"Node {node.get('node_index', 0) + 1}",
@@ -4038,10 +4052,11 @@ def get_ssh_config_cmd(ctx: click.Context, reservation_id: Optional[str]) -> Non
                 )
 
                 if config_path:
+                    node_alias = f"gpu-dev-{node_res_id[:8]}"
                     if use_include:
-                        rprint(f"[green]✅ Node {node_idx + 1}:[/green] [cyan]ssh {pod_name}[/cyan]")
+                        rprint(f"[green]✅ Node {node_idx + 1}:[/green] [cyan]ssh {node_alias}[/cyan]")
                     else:
-                        rprint(f"[green]✅ Node {node_idx + 1}:[/green] [cyan]ssh -F {config_path} {pod_name}[/cyan]")
+                        rprint(f"[green]✅ Node {node_idx + 1}:[/green] [cyan]ssh -F {config_path} {node_alias}[/cyan]")
                 else:
                     rprint(f"[yellow]⚠️  Node {node_idx + 1}: Failed to create SSH config[/yellow]")
 
@@ -4069,12 +4084,13 @@ def get_ssh_config_cmd(ctx: click.Context, reservation_id: Optional[str]) -> Non
             )
 
             if config_path:
+                host_alias = f"gpu-dev-{reservation_id[:8]}"
                 rprint(f"[green]✅ SSH config created:[/green] [cyan]{config_path}[/cyan]\n")
                 if use_include:
-                    rprint(f"[green]🎉 You can now connect with:[/green] [cyan]ssh {pod_name}[/cyan]")
+                    rprint(f"[green]🎉 You can now connect with:[/green] [cyan]ssh {host_alias}[/cyan]")
                     rprint(f"[dim]   or:[/dim] [cyan]gpu-dev connect {reservation_id[:8]}[/cyan]")
                 else:
-                    rprint(f"[green]🎉 You can now connect with:[/green] [cyan]ssh -F {config_path} {pod_name}[/cyan]")
+                    rprint(f"[green]🎉 You can now connect with:[/green] [cyan]ssh -F {config_path} {host_alias}[/cyan]")
                     rprint(f"[dim]   or:[/dim] [cyan]gpu-dev connect {reservation_id[:8]}[/cyan]")
             else:
                 rprint("[red]❌ Failed to create SSH config[/red]")
@@ -4641,13 +4657,13 @@ def ssh_include(action: str):
 
     \b
     When enabled:
-      • Simple SSH commands: ssh <pod-name>
-      • VS Code Remote works: code --remote ssh-remote+<pod-name>
+      • Simple SSH commands: ssh gpu-dev-<reservation-id>
+      • VS Code Remote works: code --remote ssh-remote+gpu-dev-<reservation-id>
       • Cursor Remote works: Open Remote SSH in Cursor
 
     \b
     When disabled:
-      • Need -F flag: ssh -F ~/.gpu-dev/<id>-sshconfig <pod-name>
+      • Need -F flag: ssh -F ~/.gpu-dev/<id>-sshconfig gpu-dev-<reservation-id>
       • VS Code/Cursor requires manual config setup
 
     \b

--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
@@ -177,12 +177,14 @@ def _generate_cursor_command(ssh_command: str) -> Optional[str]:
         return None
 
 
-def _generate_ssh_config(hostname: str, pod_name: str) -> str:
+def _generate_ssh_config(hostname: str, host_alias: str) -> str:
     """Generate SSH config for a reservation
 
     Args:
-        hostname: The FQDN hostname (e.g., old_bison.devservers.io)
-        pod_name: The pod name to use as SSH host alias
+        hostname: The FQDN hostname (e.g., old_bison.devservers.io). SSH routing
+            happens via this HostName (the ProxyCommand routes on the FQDN), so
+            host_alias is a purely local label.
+        host_alias: The local SSH host alias (e.g., gpu-dev-<resid8>)
 
     Returns:
         SSH config content as string
@@ -196,7 +198,7 @@ def _generate_ssh_config(hostname: str, pod_name: str) -> str:
     extra = "    AddKeysToAgent yes\n"
     if sys.platform == "darwin":
         extra += "    IgnoreUnknown UseKeychain\n    UseKeychain yes\n"
-    config_content = f"""Host {pod_name}
+    config_content = f"""Host {host_alias}
     HostName {hostname}
     User dev
     ForwardAgent yes
@@ -255,10 +257,10 @@ def _check_ssh_config_permission() -> bool:
     console.print("[dim]  • ~/.cursor/ssh_config[/dim]")
     console.print("[dim]Line added: Include ~/.gpu-dev/*-sshconfig[/dim]\n")
     console.print("[green]Benefits:[/green]")
-    console.print("  • Simple commands: [green]ssh <pod-name>[/green]")
-    console.print("  • VS Code Remote works: [green]code --remote ssh-remote+<pod-name>[/green]")
+    console.print("  • Simple commands: [green]ssh gpu-dev-<reservation-id>[/green]")
+    console.print("  • VS Code Remote works: [green]code --remote ssh-remote+gpu-dev-<reservation-id>[/green]")
     console.print("  • Cursor Remote works: Open Remote SSH in Cursor")
-    console.print("\n[dim]Without this, you'll need to use: [green]ssh -F ~/.gpu-dev/<id>-sshconfig <pod-name>[/green][/dim]")
+    console.print("\n[dim]Without this, you'll need to use: [green]ssh -F ~/.gpu-dev/<id>-sshconfig gpu-dev-<reservation-id>[/green][/dim]")
     console.print("[yellow]━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[/yellow]\n")
 
     approved = click.confirm("Add Include directive to SSH config files?", default=True)
@@ -326,7 +328,8 @@ def create_ssh_config_for_reservation(hostname: str, pod_name: str, reservation_
 
     Args:
         hostname: The FQDN hostname (e.g., old_bison.devservers.io)
-        pod_name: The pod name to use as SSH host alias
+        pod_name: The k8s pod name (kept for API compat; no longer used for the
+            host alias — warm-claimed pods have a pod_name != gpu-dev-<resid8>)
         reservation_id: The reservation ID (full or short)
         name: Optional reservation name to use for filename (falls back to short ID)
 
@@ -346,8 +349,12 @@ def create_ssh_config_for_reservation(hostname: str, pod_name: str, reservation_
     short_id = reservation_id[:8]
     filename = f"{short_id}-sshconfig"
 
+    # Key the host alias off the reservation id (not pod_name) so warm-claimed pods,
+    # whose pod_name differs from gpu-dev-<resid8>, are still reachable as gpu-dev-<resid8>.
+    host_alias = f"gpu-dev-{short_id}"
+
     config_file = gpu_dev_dir / filename
-    config_content = _generate_ssh_config(hostname, pod_name)
+    config_content = _generate_ssh_config(hostname, host_alias)
 
     try:
         config_file.write_text(config_content)
@@ -2220,10 +2227,11 @@ class ReservationManager:
                                                     console.print(
                                                         f"[yellow]⚠️  Could not create SSH config for node {node['index']+1}: {str(e)}[/yellow]")
 
-                                            # Show connection info
+                                            # Show connection info (alias keys off the reservation id)
+                                            node_alias = f"gpu-dev-{res_id[:8]}" if res_id else pod_name
                                             if config_path and pod_name and use_include:
                                                 console.print(
-                                                    f"[cyan]🖥️  Node {node['index']+1}:[/cyan] [green]ssh {pod_name}[/green]")
+                                                    f"[cyan]🖥️  Node {node['index']+1}:[/cyan] [green]ssh {node_alias}[/green]")
                                             else:
                                                 ssh_command = res.get(
                                                     "ssh_command", "ssh user@pending")
@@ -2321,27 +2329,29 @@ class ReservationManager:
                                         console.print(
                                             f"[yellow]⚠️  Could not create SSH config: {str(e)}[/yellow]")
 
-                                # Show SSH command using config file if created, otherwise fallback
+                                # Show SSH command using config file if created, otherwise fallback.
+                                # Alias keys off the reservation id (works for warm-claimed pods too).
+                                host_alias = f"gpu-dev-{short_id}"
                                 if config_path and pod_name:
                                     if use_include:
                                         # User approved Include - show simple commands
                                         console.print(
-                                            f"[cyan]🖥️  SSH Command:[/cyan] [green]ssh {pod_name}[/green]")
+                                            f"[cyan]🖥️  SSH Command:[/cyan] [green]ssh {host_alias}[/green]")
                                         # Create clickable VS Code link
-                                        vscode_url = _make_vscode_link(pod_name)
-                                        vscode_command = f"code --remote ssh-remote+{pod_name} /home/dev"
+                                        vscode_url = _make_vscode_link(host_alias)
+                                        vscode_command = f"code --remote ssh-remote+{host_alias} /home/dev"
                                         console.print(
                                             f"[cyan]💻 VS Code Remote:[/cyan] [link={vscode_url}][green]{vscode_command}[/green][/link]")
 
                                         # Create clickable Cursor link
-                                        cursor_url = _make_cursor_link(pod_name)
-                                        cursor_command = f"cursor --remote ssh-remote+{pod_name} /home/dev"
+                                        cursor_url = _make_cursor_link(host_alias)
+                                        cursor_command = f"cursor --remote ssh-remote+{host_alias} /home/dev"
                                         console.print(
                                             f"[cyan]🖥️ Cursor Remote:[/cyan] [link={cursor_url}][green]{cursor_command}[/green][/link]")
                                     else:
                                         # User declined Include - show commands with -F flag
                                         console.print(
-                                            f"[cyan]🖥️  SSH Command:[/cyan] [green]ssh -F {config_path} {pod_name}[/green]")
+                                            f"[cyan]🖥️  SSH Command:[/cyan] [green]ssh -F {config_path} {host_alias}[/green]")
                                         console.print(
                                             f"[cyan]💻 VS Code/Cursor:[/cyan] Add [green]Include ~/.gpu-dev/*-sshconfig[/green] to ~/.ssh/config and ~/.cursor/ssh_config")
                                         console.print(

--- a/tests/unit/cli/test_ssh_alias.py
+++ b/tests/unit/cli/test_ssh_alias.py
@@ -1,0 +1,130 @@
+"""Unit tests for the reservation-id-based SSH host alias.
+
+The SSH host alias (the `Host` line in ~/.gpu-dev/<id>-sshconfig) and every
+user-facing ssh/vscode/cursor display string must key off the RESERVATION ID
+(`gpu-dev-<resid8>`), not the k8s pod name. Warm-claimed pods have a pod_name
+like `gpu-dev-h100-1e3f9c` (!= gpu-dev-<resid>), so using pod_name as the alias
+would make `ssh gpu-dev-<resid>` / `gpu-dev connect <resid>` fail for them.
+
+Routing is unaffected: the ProxyCommand routes on the FQDN (HostName), so the
+Host alias is a purely local label (see ssh_proxy.py / _generate_ssh_config).
+"""
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+from rich.console import Console
+
+from gpu_dev_cli.reservations import create_ssh_config_for_reservation
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
+
+
+def _clean(output: str) -> str:
+    return _ANSI_RE.sub("", output)
+
+
+def _write_config(tmp_path, pod_name, reservation_id):
+    """Create the SSH config under a tmp HOME and return its parsed lines."""
+    with patch("pathlib.Path.home", return_value=tmp_path), \
+         patch("gpu_dev_cli.reservations._ensure_ssh_config_includes_devgpu", return_value=True):
+        config_path, use_include = create_ssh_config_for_reservation(
+            "magic_hawk.devservers.io", pod_name, reservation_id, None)
+    assert config_path is not None
+    return Path(config_path).read_text()
+
+
+def _host_line(text):
+    return next(l.strip() for l in text.splitlines() if l.strip().startswith("Host "))
+
+
+def _hostname_line(text):
+    return next(l.strip() for l in text.splitlines() if l.strip().startswith("HostName "))
+
+
+class TestSshConfigAlias:
+    def test_warm_pod_name_does_not_leak_into_alias(self, tmp_path):
+        """Warm-claimed pod: pod_name != gpu-dev-<resid8>; alias keys off resid."""
+        rid = "404e4039-44a5-4562-9d4a-deadbeefcafe"
+        text = _write_config(tmp_path, "gpu-dev-h100-1e3f9c", rid)
+        assert _host_line(text) == "Host gpu-dev-404e4039"
+        assert _hostname_line(text) == "HostName magic_hawk.devservers.io"
+        # the raw warm pod name must never appear as the alias
+        assert "gpu-dev-h100-1e3f9c" not in text
+
+    def test_cold_pod_name_still_yields_resid_alias(self, tmp_path):
+        """Cold pod (pod_name == gpu-dev-<resid8>): no regression."""
+        rid = "abcd1234-0000-0000-0000-000000000000"
+        text = _write_config(tmp_path, "gpu-dev-abcd1234", rid)
+        assert _host_line(text) == "Host gpu-dev-abcd1234"
+        assert _hostname_line(text) == "HostName magic_hawk.devservers.io"
+
+    def test_config_filename_uses_short_id(self, tmp_path):
+        rid = "404e4039-44a5-4562-9d4a-deadbeefcafe"
+        with patch("pathlib.Path.home", return_value=tmp_path), \
+             patch("gpu_dev_cli.reservations._ensure_ssh_config_includes_devgpu", return_value=True):
+            config_path, _ = create_ssh_config_for_reservation(
+                "magic_hawk.devservers.io", "gpu-dev-h100-1e3f9c", rid, None)
+        assert config_path.endswith("404e4039-sshconfig")
+
+
+class TestDisplayUsesResid:
+    def _rec_console(self):
+        return Console(width=400, force_terminal=False, record=True)
+
+    def test_show_single_reservation_warm_pod(self, tmp_path):
+        """_show_single_reservation for a warm-claimed reservation displays the
+        resid-based ssh alias, NOT the k8s pod name (but still shows Pod Name)."""
+        from gpu_dev_cli import cli as cli_mod
+        rid = "404e4039-44a5-4562-9d4a-deadbeefcafe"
+        conn = {
+            "reservation_id": rid,
+            "status": "active",
+            "gpu_count": 1,
+            "gpu_type": "h100",
+            "instance_type": "p5.48xlarge",
+            "pod_name": "gpu-dev-h100-1e3f9c",
+            "fqdn": "magic_hawk.devservers.io",
+            "ssh_command": "ssh dev@magic_hawk.devservers.io",
+            "launched_at": "2026-06-01T00:00:00+00:00",
+            "expires_at": "2026-06-02T00:00:00+00:00",
+        }
+        # Pre-create the per-reservation SSH config so the alias display branch is hit.
+        gpu_dev_dir = tmp_path / ".gpu-dev"
+        gpu_dev_dir.mkdir()
+        (gpu_dev_dir / "404e4039-sshconfig").write_text("Host gpu-dev-404e4039\n")
+
+        console = self._rec_console()
+        with patch("gpu_dev_cli.cli.console", console), \
+             patch("pathlib.Path.home", return_value=tmp_path), \
+             patch("gpu_dev_cli.cli.is_ssh_include_enabled", return_value=True):
+            cli_mod._show_single_reservation(conn)
+        out = _clean(console.export_text())
+        assert "ssh gpu-dev-404e4039" in out
+        assert "ssh-remote+gpu-dev-404e4039" in out
+        # pod name must NOT be used as the ssh alias
+        assert "ssh gpu-dev-h100-1e3f9c" not in out
+        # but the informational Pod Name line is still shown
+        assert "gpu-dev-h100-1e3f9c" in out
+
+    def test_show_direct_success_warm_claim(self, tmp_path):
+        """_show_direct_success (the warm-pool instant-claim block) shows the
+        resid-based ssh/vscode/cursor commands, not the pod name."""
+        from gpu_dev_cli import cli as cli_mod
+        rid = "404e4039-44a5-4562-9d4a-deadbeefcafe"
+        res = {
+            "reservation_id": rid,
+            "pod_name": "gpu-dev-h100-1e3f9c",
+            "fqdn": "magic_hawk.devservers.io",
+            "ssh_command": "ssh dev@magic_hawk.devservers.io",
+            "expires_at": "2026-06-02T00:00:00+00:00",
+        }
+        console = self._rec_console()
+        with patch("gpu_dev_cli.cli.rprint", lambda *a, **k: console.print(*a, **k)), \
+             patch("pathlib.Path.home", return_value=tmp_path), \
+             patch("gpu_dev_cli.reservations._ensure_ssh_config_includes_devgpu", return_value=True):
+            cli_mod._show_direct_success(res, 0.5)
+        out = _clean(console.export_text())
+        assert "ssh gpu-dev-404e4039" in out
+        assert "ssh-remote+gpu-dev-404e4039" in out
+        assert "gpu-dev-h100-1e3f9c" not in out


### PR DESCRIPTION
Warm-claimed pods keep their pool pod name (`gpu-dev-h100-1e3f9c`), so the SSH `Host` alias — which was pod-name-based — became `gpu-dev-h100-…` and `ssh gpu-dev-<resid>` / the copy-pasteable SSH/VS Code/Cursor commands broke for them. Cold pods only ever worked because `pod_name == gpu-dev-<resid8>` by coincidence.

**Safe because routing is via `HostName` (the FQDN):** the ProxyCommand `gpu-dev-ssh-proxy %h %p` receives `%h` = the HostName (FQDN, matched by `.devservers.io` in ssh_proxy.py), never the `Host` alias. So the alias is a purely local label and renaming it can't affect connectivity. Routing/proxy/HostName/lambda untouched.

**Change:** alias is now always `gpu-dev-<reservation_id[:8]>` — in the generated config, `connect`/`show`/`list`/direct-success display, the multinode master ssh/rsync invocation, and `get-ssh-config`. The real k8s pod name stays as an info-only "Pod Name:" field.

**Tests:** `tests/unit/cli/test_ssh_alias.py` — warm `pod_name` doesn't leak into the alias, cold pod unchanged, filename stays `<short_id>-sshconfig`, displayed commands are resid-based. Full suite: 1147 passed (3 pre-existing unrelated xfails).