### PR TITLE
feat(repro): by-SHA artifact cache — zero-build repro of cached commits

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -1562,17 +1562,38 @@ def repro(ctx, ref, test_args, gpu_type, gpus, hours, no_connect, keep):
     if r.startswith("pr/"): prnum = r[3:]
     elif r.startswith("#"): prnum = r[1:]
     elif r.isdigit(): prnum = r
+    gh = "https://github.com/pytorch/pytorch.git"
     if prnum:
         fetch = (f"git fetch origin pull/{prnum}/merge 2>/dev/null && git checkout -f FETCH_HEAD || "
                  f"{{ echo '[repro] no /merge ref, using /head'; git fetch origin pull/{prnum}/head && git checkout -f FETCH_HEAD; }}")
+        # resolve to a concrete SHA up front so we can check the by-sha artifact cache
+        resolve = (f"WANT=$(timeout 15 git ls-remote {gh} pull/{prnum}/merge 2>/dev/null | head -1 | cut -f1); "
+                   f"[ -n \"$WANT\" ] || WANT=$(timeout 15 git ls-remote {gh} pull/{prnum}/head 2>/dev/null | head -1 | cut -f1); ")
     else:
         rq = shlex.quote(r)
         fetch = f"git fetch origin {rq} 2>/dev/null && git checkout -f FETCH_HEAD || git checkout -f {rq}"
+        resolve = (f"WANT=$(timeout 15 git ls-remote {gh} {rq} 2>/dev/null | head -1 | cut -f1); "
+                   f"[ -n \"$WANT\" ] || case {rq} in *[!0-9a-fA-F]*) WANT= ;; *) WANT={rq} ;; esac; ")
 
     testcmd = " ".join(shlex.quote(a) for a in test_args)
+    # by-sha artifact cache: if a fully-built tree for the resolved SHA already exists
+    # (shared EFS, seeded by the build node + prior repros), stage it -> ZERO build.
+    # Otherwise build, then publish the result so the next dev (anyone) gets it instant.
     remote = (
         "set -e; cd /home/dev/pytorch; "
         "git config --global --add safe.directory /home/dev/pytorch 2>/dev/null || true; "
+        "BYSHA=/ccache_shared/prebuilt/by-sha; HIT=; "
+        + resolve +
+        "echo \"[repro] target ${WANT:-?}\"; "
+        "if [ -n \"$WANT\" ] && [ -f \"$BYSHA/$WANT.sha\" ]; then "
+        "TB=$(ls \"$BYSHA/$WANT.tar.\"* 2>/dev/null | head -1); "
+        "if [ -n \"$TB\" ]; then echo '[repro] by-sha cache HIT -> staging prebuilt tree (zero build)'; "
+        "rm -rf /home/dev/pytorch.new; mkdir -p /home/dev/pytorch.new; "
+        "case \"$TB\" in *.zst) zstd -dc \"$TB\" 2>/dev/null | tar -C /home/dev/pytorch.new --strip-components=1 -xf - 2>/dev/null ;; "
+        "*) tar -C /home/dev/pytorch.new --strip-components=1 -xzf \"$TB\" 2>/dev/null ;; esac; "
+        "if [ -d /home/dev/pytorch.new/.git ]; then rm -rf /home/dev/pytorch; mv /home/dev/pytorch.new /home/dev/pytorch; cd /home/dev/pytorch; HIT=1; "
+        "else rm -rf /home/dev/pytorch.new; echo '[repro] by-sha extract failed, building from source'; fi; fi; fi; "
+        "if [ -z \"$HIT\" ]; then "
         f"echo '[repro] checkout {r}'; {fetch}; "
         "echo \"[repro] HEAD $(git rev-parse --short HEAD)\"; "
         "git -c protocol.file.allow=always submodule update --init --recursive --jobs 8 >/dev/null 2>&1 || true; "
@@ -1580,6 +1601,12 @@ def repro(ctx, ref, test_args, gpu_type, gpus, hours, no_connect, keep):
         "echo \"[repro] prebuilt torch != this commit -> rebuilding (ccache-accelerated, but the further this commit is from viable/strict, the more recompiles). checked-out: $(git log -1 --format='%h %ci')\"; "
         # -v streams the cmake/ninja [x/N] progress instead of pip's blind 'still running...' spinner.
         "pip install --break-system-packages -e . --no-build-isolation -v; fi; "
+        # cache this build for the next dev (detached so it survives the ssh session)
+        "SHA=$(git rev-parse HEAD 2>/dev/null); "
+        "if command -v publish-pytorch-build >/dev/null 2>&1 && [ -n \"$SHA\" ] && [ ! -f \"$BYSHA/$SHA.sha\" ]; then "
+        "echo '[repro] caching this build (by-sha) for next time…'; "
+        "setsid publish-pytorch-build \"$SHA\" >/dev/null 2>&1 < /dev/null & fi; "
+        "fi; "
         f"echo '[repro] running: python {testcmd}'; "
         f"PYTHONPATH=/home/dev/pytorch python {testcmd}"
     )

--- a/docs/FAST_REPRO_DESIGN.md
+++ b/docs/FAST_REPRO_DESIGN.md
@@ -1,0 +1,141 @@
+# Fast repro design — any commit from the last 72h, ready in < 2 min
+
+**Goal:** `gpu-dev repro <ref>` for *any* pytorch/pytorch commit (or PR) from the
+trailing ~72 h lands the developer in a pod with that ref built + importable in
+**under 2 minutes**, then the in-pod edit→rebuild loop stays in the tens of seconds.
+
+This is the design note for getting there. Status: proposal — nothing here is built
+yet beyond the existing viable/strict prebuild.
+
+---
+
+## Where we are today (and why it's slow)
+
+Measured on a live repro (`gpu-dev-h100-1e3f9c`, 1× H100, commit `3e3b83dd`):
+- The pod builds the ref **in-pod**, capped at **36 cores** (`min(192, 192·(1/8)·1.5)`
+  for a 1-GPU box) while ~156 cores on the node sit idle.
+- ccache was **~95 % miss** (live: +4 hits / +75 misses over 30 s) because:
+  1. the requested commit wasn't the one we'd warmed (the `pull/N/merge` SHA had
+     drifted onto newer trunk), and
+  2. the shared ccache is still small/cold (10 GB, just un-capped to 250 G).
+- So: full cores unused, cache cold → a ~30–40 min cold compile.
+
+Two structural problems: **the build runs on the wrong machine** (a GPU-share-capped
+pod) and **we only cache one point** (viable/strict), so any other commit is a large,
+mostly-uncached delta.
+
+## Rejected: just lift the pod CPU limit ("CPU burst")
+
+Letting a 1-GPU pod burst into the node's idle cores would speed the compile, but
+**more parallel compiles = more concurrent RAM** (nvcc/cutlass TUs are memory-hungry);
+against the pod's memory limit that risks **OOM-killing the build**. And it only helps
+the *cold* path — it does nothing about caching. So we don't go this way.
+
+## Chosen shape: build off-pod on a beefy node, stage the result
+
+Three moving parts:
+
+1. **Build farm** — the existing always-on build node (m7i.48xlarge, 192 vCPU /
+   768 GB). Big RAM means we can run 128–192-way without OOM. (Bigger instances exist
+   — `m7i.metal-48xl`, `c7i.48xlarge`, `hpc7a` — but beyond ~128 jobs PyTorch hits
+   serial points: codegen, cmake configure, the final link. So "biggest box" is a
+   marginal lever; **caching + linker are the real levers**, below.)
+2. **Two-tier cache:**
+   - **ccache** (`/ccache_shared`, 250 G EFS) — object cache, already shared by build
+     node + all pods. Makes per-TU recompiles cheap.
+   - **Artifact cache** (`/ccache_shared/prebuilt/by-sha/<sha>.tar.zst`, NEW) — whole
+     *built trees* keyed by commit SHA. An exact hit means **no build at all**, just
+     stage.
+3. **Stage into the pod** — reflink-copy the built tree onto the pod's `/home/dev/pytorch`
+   (same path the build used, so CMake's absolute paths stay valid → in-pod incremental
+   rebuilds keep working). Reflink is ~instant when the node NVMe and the pod emptyDir
+   are the same filesystem (warm pods already satisfy this).
+
+### Request flow for `gpu-dev repro <ref>`
+
+```
+resolve ref → concrete SHA          (pr/N → pull/N/merge resolved to a pinned SHA NOW,
+                                      so it can't drift; cache is keyed by that SHA)
+claim a warm pod                     (~1 s, instant)
+artifact cache has <sha>?
+  ├─ yes → pod pulls by-sha/<sha>.tar.zst → reflink to /home/dev/pytorch   (~30–60 s)
+  │         import torch works, ZERO build. Total ≈ claim + stage < ~90 s.
+  └─ no  → build node builds <sha> incrementally from the nearest snapshot, publishes
+            by-sha/<sha>.tar.zst, pod stages it.                            (build + stage)
+run the test → drop the user in the box
+```
+
+### How we keep the "no" branch fast for *any* last-72h commit
+
+The on-demand build must be a **small** delta, or it blows the 2-min budget. So we
+pre-seed a **snapshot ladder** across the window:
+
+- A cron builds PyTorch at a cadence across the trailing 72 h — every viable/strict
+  bump (already happens) **plus** a fixed cadence (say every ~2 h, ~24–36 snapshots),
+  each published to the artifact cache. Each snapshot is incremental from the previous
+  one, so the ladder is cheap to maintain once warm.
+- An on-demand request for commit `C` starts from the **nearest snapshot's build tree**
+  (≤ ~2 h / a few hundred commits away), `git checkout C`, incremental build. Small
+  dirty set + warm ccache → the compile is seconds, and the **link** becomes the floor.
+
+### Killing the link floor (critical for < 2 min)
+
+Even a 1-file delta relinks `libtorch_cuda.so` — normally ~1–3 min, which alone busts
+the budget. Fix: **use a fast linker (mold, or lld)** for the build-node + in-pod
+builds (`-fuse-ld=mold`). mold links libtorch in ~10–20 s. This is the single most
+important build-speed change after caching.
+
+### Staging speed
+
+- Warm pods: node NVMe ↔ pod emptyDir same FS → reflink, near-instant. Verify node
+  bootstrap puts kubelet emptyDir on `/mnt/nvme` (see the open item in CLAUDE.md).
+- The by-sha tarball (~7–10 GB zstd) is pulled to node NVMe once per node and reflinked
+  per pod; a DaemonSet can pre-pull the most-recently-requested SHAs.
+- Arch: built trees are `sm_90;sm_100` (H100/B200). This whole fast path is **prod
+  (H100/B200) only**; t4/staging would need a separate `sm_75` ladder (out of scope —
+  staging is for plumbing tests, not perf).
+
+---
+
+## Storage budget
+
+- Snapshot ladder: ~30 trees × ~7–10 GB zstd ≈ **250–300 GB**.
+- On-demand built trees: LRU, keep last ~N requested SHAs (~50–100 GB).
+- ccache: 250 G.
+- Total on `ccache_shared` EFS: ~**500–650 GB**. EFS is elastic (no provisioning) +
+  30-day IA lifecycle, so cost ≈ stored-GB only (~$0.30/GB-mo ⇒ ~$150–200/mo). Prune
+  the ladder to the 72 h window so it doesn't grow unbounded.
+
+## Phasing
+
+- **Phase 1 — off-pod build + artifact cache.** `repro`/`--ref` build the SHA on the
+  build node (192-way, warm ccache) instead of in-pod; publish `by-sha/<sha>`; pod
+  stages it. Removes the 36-core + OOM problem. Reuses the existing prebuild machinery.
+  *Biggest single win; do this first.*
+- **Phase 2 — exact-SHA direct stage.** On an artifact-cache hit, skip the build
+  entirely; just pull + reflink. Every repro populates the cache for the next dev.
+- **Phase 3 — snapshot ladder + nearest-snapshot delta builds** across 72 h, so the
+  cold "no" branch stays small. Tune cadence vs storage.
+- **Phase 4 — mold/lld linker** (drop the link floor) and **cuDNN fidelity**
+  (`USE_CUDNN=1`, add libcudnn to the image — see CLAUDE.md todo) so prebuilt matches CI.
+- **Phase 5 — scale:** 2–3 build nodes + a small dispatch/queue so concurrent repros of
+  uncached SHAs don't serialize behind one flock. Optionally pre-build **CI-red commits**
+  (via the treehugger/HUD MCP) — those are exactly the commits people repro, so a red
+  commit is in the artifact cache before anyone asks.
+
+## Open decisions (need your call)
+
+1. **Snapshot cadence vs storage** — every 2 h (~30 trees, ~300 GB) vs tighter (smaller
+   deltas, more storage). Recommendation: start at viable/strict-bumps + every 2 h.
+2. **Storage ceiling** — OK to let `ccache_shared` grow to ~500–650 GB? (elastic, ~$150–
+   200/mo.)
+3. **Build nodes** — keep 1 for now (Phases 1–4), add the dispatch/queue only at Phase 5?
+4. **Pre-build CI-red commits** via HUD — worth it (targets real repro demand) or skip
+   for v1?
+
+## Edit→rebuild loop (unchanged, already good)
+
+Once staged, in-pod iteration stays as-is: Python edits need no rebuild
+(`PYTHONPATH=~/pytorch`); a C++/CUDA edit is `pip install -e . --no-build-isolation`,
+an incremental build on the warm `build/` + ccache (~40 s, or ~15 s with mold). The
+off-pod path is only for the *initial* "get me to ref X" jump.

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -5793,6 +5793,65 @@ SRC=/nvme-pytorch
 
 if ! command -v git >/dev/null 2>&1; then echo "[pytorch] git unavailable, skipping"; exit 0; fi
 
+# --- by-SHA artifact cache fast path (Phase 2) ---
+# If the requested ref resolves to a SHA we already have a fully-built tree for,
+# drop THAT tree in -> "import torch" works with ZERO build (the .so matches the
+# source). On any miss we fall through to the normal drop-in + checkout below.
+BYSHA_DIR=/ccache_shared/prebuilt/by-sha
+GH=https://github.com/pytorch/pytorch.git
+WANT_SHA=""
+case "$REF" in
+    ""|master|main|MASTER|MAIN) : ;;
+    *)
+        PRN=""
+        case "$REF" in
+            pr/*) PRN=$(echo "$REF" | sed 's|^pr/||') ;;
+            '#'*) PRN=$(echo "$REF" | sed 's|^#||') ;;
+            *[!0-9]*) : ;;
+            *) PRN="$REF" ;;
+        esac
+        if [ -n "$PRN" ]; then
+            WANT_SHA=$(timeout 15 git ls-remote "$GH" "pull/$PRN/merge" 2>/dev/null | head -1 | cut -f1)
+            [ -z "$WANT_SHA" ] && WANT_SHA=$(timeout 15 git ls-remote "$GH" "pull/$PRN/head" 2>/dev/null | head -1 | cut -f1)
+        else
+            WANT_SHA=$(timeout 15 git ls-remote "$GH" "$REF" 2>/dev/null | head -1 | cut -f1)
+            if [ -z "$WANT_SHA" ]; then
+                case "$REF" in *[!0-9a-fA-F]*) : ;; *) WANT_SHA="$REF" ;; esac
+            fi
+        fi ;;
+esac
+
+if [ -n "$WANT_SHA" ] && [ ! -d "$DEST/.git" ] && [ -f "$BYSHA_DIR/$WANT_SHA.sha" ]; then
+    BYSHA_TB=""
+    if command -v zstd >/dev/null 2>&1 && [ -f "$BYSHA_DIR/$WANT_SHA.tar.zst" ]; then
+        BYSHA_TB="$BYSHA_DIR/$WANT_SHA.tar.zst"
+    elif [ -f "$BYSHA_DIR/$WANT_SHA.tar.gz" ]; then
+        BYSHA_TB="$BYSHA_DIR/$WANT_SHA.tar.gz"
+    fi
+    if [ -n "$BYSHA_TB" ]; then
+        echo "[pytorch] by-sha cache HIT for $WANT_SHA -> staging prebuilt tree (zero build)"
+        mkdir -p /home/dev
+        rm -rf "$DEST"
+        case "$BYSHA_TB" in
+            *.zst) zstd -dc "$BYSHA_TB" 2>/dev/null | tar -C /home/dev -xf - 2>/dev/null ;;
+            *)     tar -C /home/dev -xzf "$BYSHA_TB" 2>/dev/null ;;
+        esac
+        if [ -d "$DEST/.git" ]; then
+            git config --global --add safe.directory "$DEST" 2>/dev/null || true
+            printf 'export PYTHONPATH="/home/dev/pytorch:$PYTHONPATH"\n' > /etc/profile.d/zz-pytorch.sh 2>/dev/null || true
+            for ext in /home/dev/.bashrc_ext /home/dev/.zshrc_ext; do
+                grep -q 'home/dev/pytorch' "$ext" 2>/dev/null || printf 'export PYTHONPATH="/home/dev/pytorch:$PYTHONPATH"\n' >> "$ext"
+            done
+            chown -R 1081:1081 "$DEST" 2>/dev/null || true
+            echo "$WANT_SHA" > /home/dev/.pytorch-ready
+            echo "[pytorch] Ready at $DEST ($WANT_SHA) - by-sha, no build needed"
+            exit 0
+        fi
+        echo "[pytorch] by-sha extract failed; falling back to normal staging"
+        rm -rf "$DEST"
+    fi
+fi
+
 PREBUILT_DROPPED=no
 if [ -d "$DEST/.git" ]; then
     echo "[pytorch] $DEST already present, skipping drop-in"
@@ -5876,6 +5935,29 @@ git rev-parse HEAD 2>/dev/null > /home/dev/.pytorch-ready || echo unknown > /hom
 echo "[pytorch] Ready at $DEST ($(cat /home/dev/.pytorch-ready))"
 STAGEPYTORCH
                         chmod +x /usr/local/bin/stage-pytorch
+
+                        # publish-pytorch-build [sha] — tar /home/dev/pytorch into the
+                        # by-SHA artifact cache so the next repro of this commit stages
+                        # it with ZERO build. Best-effort; .sha is written LAST = the
+                        # completion gate (a partial tar has no marker -> ignored).
+                        cat > /usr/local/bin/publish-pytorch-build << 'PUBPYTORCH'
+#!/bin/bash
+SHA="$1"
+BYSHA=/ccache_shared/prebuilt/by-sha
+[ -n "$SHA" ] || SHA=$(git -C /home/dev/pytorch rev-parse HEAD 2>/dev/null)
+[ -n "$SHA" ] || exit 0
+[ -d /ccache_shared ] || exit 0
+[ -f "$BYSHA/$SHA.sha" ] && exit 0
+[ -d /home/dev/pytorch/.git ] || exit 0
+mkdir -p "$BYSHA" || exit 0
+TMP="$BYSHA/$SHA.tar.gz.tmp.$$"
+if tar -C /home/dev -czf "$TMP" pytorch 2>/dev/null; then
+    mv "$TMP" "$BYSHA/$SHA.tar.gz" && echo "$SHA" > "$BYSHA/$SHA.sha"
+else
+    rm -f "$TMP"
+fi
+PUBPYTORCH
+                        chmod +x /usr/local/bin/publish-pytorch-build
 
                         if [ "{stage_flag}" = "true" ]; then
                             echo "[STARTUP] Staging pytorch (ref={pytorch_ref}) in background..."

--- a/terraform-gpu-devservers/pytorch-prebuild.tf
+++ b/terraform-gpu-devservers/pytorch-prebuild.tf
@@ -153,6 +153,20 @@ resource "kubernetes_cron_job_v1" "pytorch_prebuild" {
                 fi
                 echo "$TARGET" > "$PUB.sha"
                 echo "[prebuild] published $(du -sh "$PUBFILE" | cut -f1) @ $TARGET"
+
+                # --- also seed the by-SHA artifact cache (Phase 1) ---
+                # Same bytes, hardlinked (no extra EFS space) so a repro that resolves
+                # to exactly this SHA stages a fully-built tree with ZERO build. The
+                # .sha marker is written LAST = the completion gate stage-pytorch polls.
+                BYSHA="$PREBUILT/by-sha"
+                mkdir -p "$BYSHA"
+                EXT="$${PUBFILE##*.}"   # zst or gz, whichever we published
+                BYSHA_FILE="$BYSHA/$TARGET.tar.$EXT"
+                if [ ! -f "$BYSHA_FILE" ]; then
+                  ln -f "$PUBFILE" "$BYSHA_FILE" 2>/dev/null || cp "$PUBFILE" "$BYSHA_FILE"
+                  echo "$TARGET" > "$BYSHA/$TARGET.sha"
+                  echo "[prebuild] seeded by-sha cache: $TARGET.tar.$EXT"
+                fi
                 ccache -s 2>/dev/null | grep -iE 'hits|misses' | head
                 echo "[prebuild] DONE $TARGET"
               EOT

--- a/tests/unit/cli/test_repro.py
+++ b/tests/unit/cli/test_repro.py
@@ -183,6 +183,35 @@ def test_remote_command_structure(cli_runner):
     assert "PYTHONPATH=/home/dev/pytorch python test/inductor/test_flex_attention.py TestX.test_y" in cmd
 
 
+# ---------------------------------------------------------------------------
+# by-sha artifact cache (Phase 1/2): consume on hit, fill after a build
+# ---------------------------------------------------------------------------
+def test_remote_checks_bysha_cache_before_building(cli_runner):
+    res, rm, run = _run(cli_runner, ["pr/185264", "test/foo.py"], claim_result=WARM)
+    cmd = _remote_str(run)
+    # resolves the ref to a concrete SHA, then probes the shared by-sha cache
+    assert "git ls-remote" in cmd and "pull/185264/merge" in cmd
+    assert "/ccache_shared/prebuilt/by-sha" in cmd
+    assert "by-sha cache HIT" in cmd
+    # the from-source fetch+build path is gated behind a cache miss
+    assert 'if [ -z "$HIT" ]' in cmd
+
+
+def test_remote_publishes_build_to_bysha(cli_runner):
+    res, rm, run = _run(cli_runner, ["pr/1", "test/foo.py"], claim_result=WARM)
+    cmd = _remote_str(run)
+    # after a from-source build, publish the tree for the next dev (detached)
+    assert "publish-pytorch-build" in cmd
+    assert "setsid" in cmd
+
+
+def test_bysha_resolve_for_branch_uses_lsremote_of_ref(cli_runner):
+    res, rm, run = _run(cli_runner, ["my-feature-branch", "test/foo.py"], claim_result=WARM)
+    cmd = _remote_str(run)
+    assert "git ls-remote" in cmd and "my-feature-branch" in cmd
+    assert "/ccache_shared/prebuilt/by-sha" in cmd
+
+
 def test_test_args_are_shlex_quoted(cli_runner):
     res, rm, run = _run(
         cli_runner,


### PR DESCRIPTION
Foundation for the fast-repro redesign (see `docs/FAST_REPRO_DESIGN.md`, **Phases 1–2**). Goal: any recently-built commit repros with **zero build** because we cache whole *built* trees keyed by commit SHA on the shared EFS.

## What this does
- **Publish (cron):** every viable/strict prebuild also lands `/ccache_shared/prebuilt/by-sha/<sha>.tar.<ext>` — a **hardlink** of the tarball (same bytes, no extra EFS space). The `.sha` marker is written **last** = the completion gate (partial tars are ignored).
- **Consume (cold `--ref`):** `stage-pytorch` resolves the ref → concrete SHA (timeout-bounded `ls-remote`), and on a by-sha hit extracts that fully-built tree + sets `PYTHONPATH` → `import torch` works, **no build**. Safe fallback to the current drop-in + checkout on any miss.
- **Consume + fill (`gpu-dev repro`):** the warm-claim path checks out in-pod, so the by-sha consume lives in the remote command too; after a from-source build it **publishes** the tree (new `publish-pytorch-build` helper, detached) so the next dev — anyone, shared EFS — gets it instant. The fetch/build path is unchanged, just gated behind a cache miss.

## Safety / blast radius
- Every new path has a **safe fallback** to current behavior; `ls-remote` is `timeout 15` so it can't hang staging.
- Embedded bash is brace-free (the lambda string is format-interpolated). `py_compile` + `tofu validate` pass.

## Tests
3 new in `test_repro.py` (consume probes by-sha before building; publishes after build; branch refs resolve via `ls-remote`). **1150 passed**, 3 pre-existing xfails.

## Deploy + e2e (prod — by-sha trees are `sm_90;sm_100`)
`tofu apply` (lambda + cron; `publish-pytorch-build` is written at pod startup, no image rebuild). Then on prod:
```
# first repro of a recent commit: builds + publishes (look for 'caching this build (by-sha)')
gpu-dev repro <recent-sha> test/test_foo.py::test_bar --gpu-type h100 --no-connect
# second repro of the SAME sha: 'by-sha cache HIT -> staging prebuilt tree (zero build)'
gpu-dev repro <recent-sha> test/test_foo.py::test_bar --gpu-type h100 --no-connect
```

## Next (this redesign)
Phase 3 = snapshot ladder cron (so *any* 72h commit is a small delta); Phase 4 = mold linker + cuDNN; plus off-pod on-demand build so the **first** repro of an uncached commit is fast too.