### PR TITLE
perf(build): mold linker (Phase 4) — drop the relink floor

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -1598,9 +1598,12 @@ def repro(ctx, ref, test_args, gpu_type, gpus, hours, no_connect, keep):
         "echo \"[repro] HEAD $(git rev-parse --short HEAD)\"; "
         "git -c protocol.file.allow=always submodule update --init --recursive --jobs 8 >/dev/null 2>&1 || true; "
         "if ! PYTHONPATH=/home/dev/pytorch python -c 'import torch' 2>/dev/null; then "
+        # mold -run routes the libtorch_cuda.so relink through mold (~15s vs minutes);
+        # guarded so it no-ops until the image ships mold.
+        "M=; command -v mold >/dev/null 2>&1 && M='mold -run'; "
         "echo \"[repro] prebuilt torch != this commit -> rebuilding (ccache-accelerated, but the further this commit is from viable/strict, the more recompiles). checked-out: $(git log -1 --format='%h %ci')\"; "
         # -v streams the cmake/ninja [x/N] progress instead of pip's blind 'still running...' spinner.
-        "pip install --break-system-packages -e . --no-build-isolation -v; fi; "
+        "$M pip install --break-system-packages -e . --no-build-isolation -v; fi; "
         # cache this build for the next dev (detached so it survives the ssh session)
         "SHA=$(git rev-parse HEAD 2>/dev/null); "
         "if command -v publish-pytorch-build >/dev/null 2>&1 && [ -n \"$SHA\" ] && [ ! -f \"$BYSHA/$SHA.sha\" ]; then "

--- a/terraform-gpu-devservers/docker/Dockerfile
+++ b/terraform-gpu-devservers/docker/Dockerfile
@@ -39,7 +39,8 @@ RUN for attempt in 1 2 3; do \
         tree \
         rsync \
         zstd \
-        pigz
+        pigz \
+        mold
 # Install Node.js 20 from NodeSource (required for Claude CLI)
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs

--- a/terraform-gpu-devservers/pytorch-prebuild.tf
+++ b/terraform-gpu-devservers/pytorch-prebuild.tf
@@ -123,8 +123,13 @@ resource "kubernetes_cron_job_v1" "pytorch_prebuild" {
 
                 # --- build (incremental; build/ persists on hostPath) ---
                 pip install --break-system-packages -r requirements.txt 2>&1 | tail -2 || true
+                # mold links libtorch_cuda.so in ~15s vs ~1-3min for ld -> the relink
+                # floor that otherwise dominates an incremental build. mold -run wraps
+                # the whole build so every link goes through it. Guarded: no-op until
+                # the image ships mold.
+                MOLD=""; command -v mold >/dev/null 2>&1 && { MOLD="mold -run"; echo "[prebuild] using mold linker"; }
                 T0=$(date +%s)
-                python -m pip install --break-system-packages -e . --no-build-isolation || { echo "[prebuild] BUILD FAILED"; exit 1; }
+                $MOLD python -m pip install --break-system-packages -e . --no-build-isolation || { echo "[prebuild] BUILD FAILED"; exit 1; }
                 echo "[prebuild] build took $(( $(date +%s) - T0 ))s"
 
                 # --- verify importable + correct archs ---

--- a/tests/unit/cli/test_repro.py
+++ b/tests/unit/cli/test_repro.py
@@ -212,6 +212,14 @@ def test_bysha_resolve_for_branch_uses_lsremote_of_ref(cli_runner):
     assert "/ccache_shared/prebuilt/by-sha" in cmd
 
 
+def test_remote_uses_mold_linker_when_available(cli_runner):
+    res, rm, run = _run(cli_runner, ["pr/1", "test/foo.py"], claim_result=WARM)
+    cmd = _remote_str(run)
+    # guarded mold -run wrapper on the rebuild (no-op until the image ships mold)
+    assert "command -v mold" in cmd
+    assert "mold -run" in cmd
+
+
 def test_test_args_are_shlex_quoted(cli_runner):
     res, rm, run = _run(
         cli_runner,


### PR DESCRIPTION
Phase 4 of the fast-repro redesign (`docs/FAST_REPRO_DESIGN.md`). The `libtorch_cuda.so` relink (~1–3 min with `ld`) is what dominates an otherwise-incremental build — the main thing between us and sub-2 min repros. **mold links it in ~15 s.**

- **Dockerfile:** install `mold`.
- **prebuild cron + in-pod `repro` build:** wrap the build in `mold -run` so every link goes through mold. **Guarded** on `command -v mold` → no-op until the rebuilt image reaches the node (prod currently runs a stale image), then it activates with zero further change.

cuDNN fidelity (`USE_CUDNN=1`) is **deferred** — forcing it can fail the build if cuDNN isn't found under cuda-13.2, which needs prod e2e to confirm; separate change.

Test: `test_repro` asserts the guarded mold wrapper is present. Full suite green.

Deploy: image rebuild + `rollout restart daemonset gpu-dev-image-prepuller` (per CLAUDE.md) so nodes pull the mold-equipped image; then it's automatic.