### PR TITLE
feat(repro): off-pod on-demand build worker (Phase 1b)

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -1582,17 +1582,24 @@ def repro(ctx, ref, test_args, gpu_type, gpus, hours, no_connect, keep):
     remote = (
         "set -e; cd /home/dev/pytorch; "
         "git config --global --add safe.directory /home/dev/pytorch 2>/dev/null || true; "
-        "BYSHA=/ccache_shared/prebuilt/by-sha; HIT=; "
+        "BYSHA=/ccache_shared/prebuilt/by-sha; QUEUE=/ccache_shared/prebuilt/build-queue; HIT=; "
+        # bs <sha>: stage a fully-built by-sha tree into /home/dev/pytorch (zero build); 0 on success.
+        "bs() { local s=\"$1\" tb; tb=$(ls \"$BYSHA/$s.tar.\"* 2>/dev/null | head -1); [ -n \"$tb\" ] || return 1; "
+        "rm -rf /home/dev/pytorch.new; mkdir -p /home/dev/pytorch.new; "
+        "case \"$tb\" in *.zst) zstd -dc \"$tb\" 2>/dev/null | tar -C /home/dev/pytorch.new --strip-components=1 -xf - 2>/dev/null ;; "
+        "*) tar -C /home/dev/pytorch.new --strip-components=1 -xzf \"$tb\" 2>/dev/null ;; esac; "
+        "[ -d /home/dev/pytorch.new/.git ] || { rm -rf /home/dev/pytorch.new; return 1; }; "
+        "rm -rf /home/dev/pytorch; mv /home/dev/pytorch.new /home/dev/pytorch; return 0; }; "
         + resolve +
         "echo \"[repro] target ${WANT:-?}\"; "
-        "if [ -n \"$WANT\" ] && [ -f \"$BYSHA/$WANT.sha\" ]; then "
-        "TB=$(ls \"$BYSHA/$WANT.tar.\"* 2>/dev/null | head -1); "
-        "if [ -n \"$TB\" ]; then echo '[repro] by-sha cache HIT -> staging prebuilt tree (zero build)'; "
-        "rm -rf /home/dev/pytorch.new; mkdir -p /home/dev/pytorch.new; "
-        "case \"$TB\" in *.zst) zstd -dc \"$TB\" 2>/dev/null | tar -C /home/dev/pytorch.new --strip-components=1 -xf - 2>/dev/null ;; "
-        "*) tar -C /home/dev/pytorch.new --strip-components=1 -xzf \"$TB\" 2>/dev/null ;; esac; "
-        "if [ -d /home/dev/pytorch.new/.git ]; then rm -rf /home/dev/pytorch; mv /home/dev/pytorch.new /home/dev/pytorch; cd /home/dev/pytorch; HIT=1; "
-        "else rm -rf /home/dev/pytorch.new; echo '[repro] by-sha extract failed, building from source'; fi; fi; fi; "
+        # 1) already cached -> stage it (zero build)
+        "if [ -n \"$WANT\" ] && bs \"$WANT\"; then cd /home/dev/pytorch; HIT=1; echo '[repro] by-sha cache HIT -> staged prebuilt tree (zero build)'; fi; "
+        # 2) not cached, build farm alive -> request an off-pod build, wait, then stage
+        "if [ -z \"$HIT\" ] && [ -n \"$WANT\" ] && [ -n \"$(find \"$QUEUE/.worker-alive\" -mmin -2 2>/dev/null)\" ]; then "
+        "echo \"[repro] no cached build; requesting off-pod build of $WANT (build farm)…\"; touch \"$QUEUE/$WANT.req\" 2>/dev/null || true; "
+        "i=0; while [ $i -lt 180 ]; do [ -f \"$BYSHA/$WANT.sha\" ] && break; [ -f \"$QUEUE/$WANT.req\" ] || break; sleep 2; i=$((i+1)); done; "
+        "if bs \"$WANT\"; then cd /home/dev/pytorch; HIT=1; echo '[repro] off-pod build ready -> staged (zero build)'; else echo '[repro] off-pod build unavailable, building locally'; fi; fi; "
+        # 3) fall back to in-pod fetch + build (+ cache the result for the next dev)
         "if [ -z \"$HIT\" ]; then "
         f"echo '[repro] checkout {r}'; {fetch}; "
         "echo \"[repro] HEAD $(git rev-parse --short HEAD)\"; "

--- a/terraform-gpu-devservers/pytorch-ondemand.tf
+++ b/terraform-gpu-devservers/pytorch-ondemand.tf
@@ -1,0 +1,147 @@
+# On-demand PyTorch build worker (Phase 1b — first repro of an uncached commit fast).
+#
+# An always-on worker on the build node that drains a queue on the shared EFS:
+# requesters (gpu-dev repro / stage-pytorch) drop a `<sha>.req` marker into
+# /ccache_shared/prebuilt/build-queue/ and poll for the by-sha artifact to appear.
+# The worker builds the requested SHA incrementally (its own persistent tree, warm
+# ccache, mold) and publishes by-sha/<sha> — exactly the artifact the consume side
+# already knows how to stage with zero build.
+#
+# Coordination is entirely via the shared EFS both sides already mount — no new
+# networking, RBAC, or lambda changes. The worker writes a `.worker-alive`
+# heartbeat each loop; requesters only wait when it's fresh, so if the worker isn't
+# deployed they fall straight through to the in-pod build (zero regression).
+#
+# Builds at /home/dev/pytorch (same absolute path as the cron + dev pods) so the
+# build/ CMake cache paths are pod-compatible — a staged tree stays incrementally
+# rebuildable in the pod. Own hostPath (/mnt/ondemand-build) so it never collides
+# with the hourly cron's tree; shared ccache is concurrency-safe.
+
+resource "kubernetes_deployment_v1" "pytorch_ondemand" {
+  depends_on = [kubernetes_namespace.management]
+  metadata {
+    name      = "pytorch-ondemand-builder"
+    namespace = "management"
+    labels    = { app = "pytorch-ondemand-builder" }
+  }
+
+  spec {
+    replicas = 1
+    strategy { type = "Recreate" } # single persistent tree; never two at once
+    selector { match_labels = { app = "pytorch-ondemand-builder" } }
+
+    template {
+      metadata { labels = { app = "pytorch-ondemand-builder" } }
+      spec {
+        node_selector  = { NodeType = "build" }
+        restart_policy = "Always"
+
+        container {
+          name              = "builder"
+          image             = local.latest_image_uri
+          image_pull_policy = "IfNotPresent"
+          command           = ["/bin/bash", "-lc"]
+          args = [<<-EOT
+            set -uo pipefail
+            SRC=/home/dev/pytorch
+            PREBUILT=/ccache_shared/prebuilt
+            QUEUE="$PREBUILT/build-queue"
+            BYSHA="$PREBUILT/by-sha"
+            GH=https://github.com/pytorch/pytorch.git
+            mkdir -p "$QUEUE" "$BYSHA"
+
+            # --- toolchain (matches the cron, so ccache entries are identical) ---
+            export PATH=/usr/local/cuda-13.2/bin:$PATH
+            export CUDA_HOME=/usr/local/cuda-13.2
+            export CUDACXX=/usr/local/cuda-13.2/bin/nvcc
+            export CMAKE_CUDA_COMPILER=/usr/local/cuda-13.2/bin/nvcc
+            export USE_CUDA=1
+            export TORCH_CUDA_ARCH_LIST="9.0;10.0"
+            export BUILD_TEST=0
+            export MAX_JOBS=96
+            export CCACHE_DIR=/ccache_shared
+            export CCACHE_MAXSIZE=250G
+            export CMAKE_C_COMPILER_LAUNCHER=ccache
+            export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+            export CMAKE_CUDA_COMPILER_LAUNCHER=ccache
+            MOLD=""; command -v mold >/dev/null 2>&1 && MOLD="mold -run"
+            mkdir -p "$CCACHE_DIR"
+
+            if [ ! -d "$SRC/.git" ]; then
+              echo "[ondemand] fresh clone into $SRC"
+              git clone "$GH" "$SRC" || true
+            fi
+            git config --global --add safe.directory "$SRC" 2>/dev/null || true
+
+            build_sha() {
+              local sha="$1"
+              cd "$SRC" || return 1
+              git fetch --force origin "$sha" 2>/dev/null || git fetch --force origin 2>/dev/null || true
+              git checkout -f "$sha" 2>/dev/null || { echo "[ondemand] checkout $sha failed"; return 1; }
+              git -c protocol.file.allow=always submodule update --init --recursive --jobs 8 2>/dev/null || true
+              pip install --break-system-packages -r requirements.txt 2>&1 | tail -1 || true
+              $MOLD python -m pip install --break-system-packages -e . --no-build-isolation || { echo "[ondemand] build $sha FAILED"; return 1; }
+              local zb; zb=$(command -v zstd 2>/dev/null || true)
+              if [ -n "$zb" ]; then
+                tar -C /home/dev -cf - pytorch | "$zb" -3 -T0 -q -o "$BYSHA/$sha.tar.zst.tmp" && mv "$BYSHA/$sha.tar.zst.tmp" "$BYSHA/$sha.tar.zst" || return 1
+              else
+                tar -C /home/dev -cf - pytorch | gzip -1 > "$BYSHA/$sha.tar.gz.tmp" && mv "$BYSHA/$sha.tar.gz.tmp" "$BYSHA/$sha.tar.gz" || return 1
+              fi
+              echo "$sha" > "$BYSHA/$sha.sha"
+              return 0
+            }
+
+            echo "[ondemand] worker up; draining $QUEUE"
+            while true; do
+              touch "$QUEUE/.worker-alive" 2>/dev/null || true
+              REQ=$(ls -1tr "$QUEUE"/*.req 2>/dev/null | head -1)
+              if [ -n "$REQ" ]; then
+                SHA=$(basename "$REQ" .req)
+                if [ -f "$BYSHA/$SHA.sha" ]; then rm -f "$REQ"; continue; fi
+                echo "[ondemand] building $SHA"
+                T0=$(date +%s)
+                if build_sha "$SHA"; then echo "[ondemand] published $SHA in $(( $(date +%s) - T0 ))s"; else echo "[ondemand] $SHA build failed"; fi
+                rm -f "$REQ"
+              else
+                sleep 5
+              fi
+            done
+          EOT
+          ]
+
+          resources {
+            requests = {
+              cpu    = "16"
+              memory = "32Gi"
+            }
+          }
+
+          volume_mount {
+            name       = "ondemand-build"
+            mount_path = "/home/dev/pytorch"
+          }
+          volume_mount {
+            name       = "ccache-shared"
+            mount_path = "/ccache_shared"
+          }
+        }
+
+        volume {
+          name = "ondemand-build"
+          host_path {
+            path = "/mnt/ondemand-build"
+            type = "DirectoryOrCreate"
+          }
+        }
+        volume {
+          name = "ccache-shared"
+          nfs {
+            server    = local.ccache_efs_dns
+            path      = "/"
+            read_only = false
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/unit/cli/test_repro.py
+++ b/tests/unit/cli/test_repro.py
@@ -220,6 +220,18 @@ def test_remote_uses_mold_linker_when_available(cli_runner):
     assert "mold -run" in cmd
 
 
+def test_remote_requests_offpod_build_heartbeat_guarded(cli_runner):
+    res, rm, run = _run(cli_runner, ["pr/1", "test/foo.py"], claim_result=WARM)
+    cmd = _remote_str(run)
+    # heartbeat-guarded on-demand request to the build farm + shared bs() staging
+    assert "build-queue" in cmd
+    assert ".worker-alive" in cmd
+    assert "$WANT.req" in cmd
+    assert "bs()" in cmd
+    # on-demand is gated behind a cache miss, before the in-pod build
+    assert 'if [ -z "$HIT" ]' in cmd
+
+
 def test_test_args_are_shlex_quoted(cli_runner):
     res, rm, run = _run(
         cli_runner,


### PR DESCRIPTION
Final core piece of the fast-repro redesign — makes the **first** repro of an uncached commit fast too (not the slow in-pod build).

## Design (EFS-queue worker — the option you picked)
- **New always-on build-worker** on the build node (`pytorch-ondemand.tf`): drains a queue on the shared EFS (`prebuilt/build-queue/<sha>.req`), builds each requested SHA **incrementally** (own persistent tree at `/home/dev/pytorch` via its own hostPath so it never collides with the hourly cron; warm ccache, mold, `BUILD_TEST=0`, arch `9.0;10.0`), and publishes `by-sha/<sha>` — the exact artifact the consume side already stages with zero build. Writes a `.worker-alive` heartbeat each loop.
- **`gpu-dev repro`:** on a by-SHA miss, *if the worker heartbeat is fresh*, enqueue a `.req` and poll for the artifact → stage it (zero build); otherwise fall straight through to the in-pod build. **Zero regression** if the worker isn't deployed. The by-SHA staging is now a single `bs()` helper reused by the cache-hit and on-demand paths.

Coordination is **entirely via the shared EFS** both sides already mount — no new networking, RBAC, or lambda changes.

## Tests
Asserts the heartbeat-guarded enqueue + `bs()` helper + that on-demand is gated behind a cache miss. **1152 passed.** `tofu validate` + `py_compile` pass.

## Deploy + e2e (prod)
`tofu apply` brings up the worker Deployment (+ the by-sha cron/retention/mold already merged). Then:
```
# uncached commit, FIRST repro: '[repro] requesting off-pod build … (build farm)' then 'staged (zero build)'
gpu-dev repro <fresh-sha> test/test_foo.py::test_bar --gpu-type h100 --no-connect
```
Watch the worker: `kubectl -n management logs deploy/pytorch-ondemand-builder -f`.

## Follow-up
Wire the same on-demand path into `stage-pytorch` (cold `--ref` reserve) — it already has the by-SHA consume from #186; this PR does the `repro` path (the primary one).