### PR TITLE
fix(build): build-node workloads use hash-tagged image (auto-pick-up rebuilds)

### DIFF
--- a/terraform-gpu-devservers/pytorch-ondemand.tf
+++ b/terraform-gpu-devservers/pytorch-ondemand.tf
@@ -18,7 +18,7 @@
 # with the hourly cron's tree; shared ccache is concurrency-safe.
 
 resource "kubernetes_deployment_v1" "pytorch_ondemand" {
-  depends_on = [kubernetes_namespace.management]
+  depends_on = [kubernetes_namespace.management, null_resource.docker_build_and_push]
   metadata {
     name      = "pytorch-ondemand-builder"
     namespace = "management"
@@ -37,8 +37,13 @@ resource "kubernetes_deployment_v1" "pytorch_ondemand" {
         restart_policy = "Always"
 
         container {
-          name              = "builder"
-          image             = local.latest_image_uri
+          name = "builder"
+          # Hash-tagged (not :latest): a rebuilt image = a new tag, so this
+          # Deployment's template changes and k8s rolls it automatically, and
+          # IfNotPresent pulls the new tag (it's "not present") — no Always, no
+          # manual recycle. The build node has no image-prepuller, so :latest would
+          # stay stale here.
+          image             = local.full_image_uri
           image_pull_policy = "IfNotPresent"
           command           = ["/bin/bash", "-lc"]
           args = [<<-EOT

--- a/terraform-gpu-devservers/pytorch-prebuild.tf
+++ b/terraform-gpu-devservers/pytorch-prebuild.tf
@@ -35,7 +35,7 @@ locals {
 }
 
 resource "kubernetes_cron_job_v1" "pytorch_prebuild" {
-  depends_on = [kubernetes_namespace.management]
+  depends_on = [kubernetes_namespace.management, null_resource.docker_build_and_push]
   metadata {
     name      = "pytorch-prebuild"
     namespace = "management"
@@ -66,8 +66,11 @@ resource "kubernetes_cron_job_v1" "pytorch_prebuild" {
             restart_policy = "Never"
 
             container {
-              name              = "build"
-              image             = local.latest_image_uri # same image users run
+              name = "build"
+              # Hash-tagged (not :latest): a rebuilt image = a new tag, so each cron
+              # job pulls it (IfNotPresent -> "not present"). The build node has no
+              # image-prepuller, so :latest would stay stale here (no mold/zstd).
+              image             = local.full_image_uri
               image_pull_policy = "IfNotPresent"
               command           = ["/bin/bash", "-lc"]
               args = [<<-EOT


### PR DESCRIPTION
The image-prepuller only refreshes **GPU** nodes, so the **build node's** cached `:latest` stays stale — the prebuild cron + on-demand worker kept running the old image (gzip, no mold) until a manual `kubectl rollout restart`.

**Fix:** point those two build-node workloads at `local.full_image_uri` (the `:latest-<hash>` tag) instead of `:latest`. A rebuilt image is a new tag, so:
- the **worker** Deployment's pod template changes → k8s rolls it natively;
- each **cron** job pulls the new tag (`IfNotPresent` → 'not present' → pulls).

Keeps `IfNotPresent` (the intentional, resilient choice) — **no `Always`, no kubectl, no race.** `depends_on docker_build_and_push` so the tag exists in ECR before the workloads reference it.

User-facing dev/warm pods are unchanged (still `:latest` + `IfNotPresent`, refreshed by the GPU image-prepuller, which keeps its existing auto-rollout).

Caveat: the 5-image ECR lifecycle could prune a very old hash tag, but every image rebuild happens via `tofu apply`, which also updates these workloads to the newest tag — so they're always on a current (un-pruned) tag. `tofu validate` passes.