### PR TITLE
fix(repro): zsh-safe remote + world-writable build-queue/by-sha

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -1584,7 +1584,8 @@ def repro(ctx, ref, test_args, gpu_type, gpus, hours, no_connect, keep):
         "git config --global --add safe.directory /home/dev/pytorch 2>/dev/null || true; "
         "BYSHA=/ccache_shared/prebuilt/by-sha; QUEUE=/ccache_shared/prebuilt/build-queue; HIT=; "
         # bs <sha>: stage a fully-built by-sha tree into /home/dev/pytorch (zero build); 0 on success.
-        "bs() { local s=\"$1\" tb; tb=$(ls \"$BYSHA/$s.tar.\"* 2>/dev/null | head -1); [ -n \"$tb\" ] || return 1; "
+        # explicit ext check, not a glob: the pod login shell is zsh, where an unmatched glob is a hard error.
+        "bs() { local s=\"$1\" tb=; for e in zst gz; do [ -f \"$BYSHA/$s.tar.$e\" ] && { tb=\"$BYSHA/$s.tar.$e\"; break; }; done; [ -n \"$tb\" ] || return 1; "
         "rm -rf /home/dev/pytorch.new; mkdir -p /home/dev/pytorch.new; "
         "case \"$tb\" in *.zst) zstd -dc \"$tb\" 2>/dev/null | tar -C /home/dev/pytorch.new --strip-components=1 -xf - 2>/dev/null ;; "
         "*) tar -C /home/dev/pytorch.new --strip-components=1 -xzf \"$tb\" 2>/dev/null ;; esac; "
@@ -1605,12 +1606,12 @@ def repro(ctx, ref, test_args, gpu_type, gpus, hours, no_connect, keep):
         "echo \"[repro] HEAD $(git rev-parse --short HEAD)\"; "
         "git -c protocol.file.allow=always submodule update --init --recursive --jobs 8 >/dev/null 2>&1 || true; "
         "if ! PYTHONPATH=/home/dev/pytorch python -c 'import torch' 2>/dev/null; then "
-        # mold -run routes the libtorch_cuda.so relink through mold (~15s vs minutes);
-        # guarded so it no-ops until the image ships mold.
-        "M=; command -v mold >/dev/null 2>&1 && M='mold -run'; "
         "echo \"[repro] prebuilt torch != this commit -> rebuilding (ccache-accelerated, but the further this commit is from viable/strict, the more recompiles). checked-out: $(git log -1 --format='%h %ci')\"; "
-        # -v streams the cmake/ninja [x/N] progress instead of pip's blind 'still running...' spinner.
-        "$M pip install --break-system-packages -e . --no-build-isolation -v; fi; "
+        # mold -run routes the libtorch_cuda.so relink through mold (~15s vs minutes); guarded.
+        # Explicit if/else (not `$M pip`): the pod login shell is zsh, which doesn't word-split
+        # unquoted vars. -v streams the cmake/ninja [x/N] progress instead of pip's blind spinner.
+        "if command -v mold >/dev/null 2>&1; then mold -run pip install --break-system-packages -e . --no-build-isolation -v; "
+        "else pip install --break-system-packages -e . --no-build-isolation -v; fi; fi; "
         # cache this build for the next dev (detached so it survives the ssh session)
         "SHA=$(git rev-parse HEAD 2>/dev/null); "
         "if command -v publish-pytorch-build >/dev/null 2>&1 && [ -n \"$SHA\" ] && [ ! -f \"$BYSHA/$SHA.sha\" ]; then "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.7.6"
+version = "0.7.7"
 description = "CLI + Python SDK for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"

--- a/terraform-gpu-devservers/pytorch-ondemand.tf
+++ b/terraform-gpu-devservers/pytorch-ondemand.tf
@@ -54,6 +54,9 @@ resource "kubernetes_deployment_v1" "pytorch_ondemand" {
             BYSHA="$PREBUILT/by-sha"
             GH=https://github.com/pytorch/pytorch.git
             mkdir -p "$QUEUE" "$BYSHA"
+            # world-writable (sticky, like /tmp): dev-user pods enqueue <sha>.req here
+            # and publish their own builds to by-sha; the worker runs as root.
+            chmod 1777 "$QUEUE" "$BYSHA" 2>/dev/null || true
 
             # --- toolchain (matches the cron, so ccache entries are identical) ---
             export PATH=/usr/local/cuda-13.2/bin:$PATH

--- a/terraform-gpu-devservers/pytorch-prebuild.tf
+++ b/terraform-gpu-devservers/pytorch-prebuild.tf
@@ -182,6 +182,7 @@ resource "kubernetes_cron_job_v1" "pytorch_prebuild" {
                 # .sha marker is written LAST = the completion gate stage-pytorch polls.
                 BYSHA="$PREBUILT/by-sha"
                 mkdir -p "$BYSHA"
+                chmod 1777 "$BYSHA" 2>/dev/null || true   # dev-user pods publish here too
                 EXT="$${PUBFILE##*.}"   # zst or gz, whichever we published
                 BYSHA_FILE="$BYSHA/$TARGET.tar.$EXT"
                 if [ ! -f "$BYSHA_FILE" ]; then


### PR DESCRIPTION
Two bugs hit when running `gpu-dev repro` from a **zsh** login (the pod's `dev` shell), seen live: `bs: no matches found`, `command not found: mold -run`, `exit 127`, and "off-pod build unavailable."

**1. The in-pod remote ran under zsh** (`ssh host '<cmd>'` uses the login shell). Two bash-only bits broke:
- `bs()`'s `ls …tar.*` — zsh aborts on an unmatched glob (`no matches found`) instead of treating it as empty.
- `M='mold -run'; $M pip install` — bash word-splits `$M`; **zsh does not split unquoted vars**, so it ran a command literally named `mold -run` → not found → the build never ran → `exit 127`.

Fix: explicit `.tar.{zst,gz}` checks (no glob) and an explicit `if command -v mold; then mold -run pip… else pip…` (no word-split reliance). Now correct under both shells.

**2. The `build-queue` + `by-sha` dirs on the shared EFS were root-owned 755**, so the pod's `dev` user couldn't write a `<sha>.req` (→ off-pod build never requested) or publish a usage-fill build. The worker + cron now `chmod 1777` them (sticky, like /tmp). The existing prod dirs are already chmod'd live.

Bump 0.7.7. CLI is installed editable, so `git pull` on main makes the fix live (no reinstall). `tofu validate` + repro tests pass.