### PR TITLE
feat(repro): on-demand farm builds PR /merge refs (not just reachable shas)

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -1566,13 +1566,15 @@ def repro(ctx, ref, test_args, gpu_type, gpus, hours, no_connect, keep):
     if prnum:
         fetch = (f"git fetch origin pull/{prnum}/merge 2>/dev/null && git checkout -f FETCH_HEAD || "
                  f"{{ echo '[repro] no /merge ref, using /head'; git fetch origin pull/{prnum}/head && git checkout -f FETCH_HEAD; }}")
-        # resolve to a concrete SHA up front so we can check the by-sha artifact cache
-        resolve = (f"WANT=$(timeout 15 git ls-remote {gh} pull/{prnum}/merge 2>/dev/null | head -1 | cut -f1); "
-                   f"[ -n \"$WANT\" ] || WANT=$(timeout 15 git ls-remote {gh} pull/{prnum}/head 2>/dev/null | head -1 | cut -f1); ")
+        # resolve to a concrete SHA up front (for the by-sha cache lookup) AND keep the
+        # fetch ref FREF — the build farm needs the ref (a pull/N/merge sha isn't
+        # fetchable by sha alone), it's enqueued so the worker can fetch it.
+        resolve = (f"FREF=pull/{prnum}/merge; WANT=$(timeout 15 git ls-remote {gh} $FREF 2>/dev/null | head -1 | cut -f1); "
+                   f"[ -n \"$WANT\" ] || {{ FREF=pull/{prnum}/head; WANT=$(timeout 15 git ls-remote {gh} $FREF 2>/dev/null | head -1 | cut -f1); }}; ")
     else:
         rq = shlex.quote(r)
         fetch = f"git fetch origin {rq} 2>/dev/null && git checkout -f FETCH_HEAD || git checkout -f {rq}"
-        resolve = (f"WANT=$(timeout 15 git ls-remote {gh} {rq} 2>/dev/null | head -1 | cut -f1); "
+        resolve = (f"FREF={rq}; WANT=$(timeout 15 git ls-remote {gh} {rq} 2>/dev/null | head -1 | cut -f1); "
                    f"[ -n \"$WANT\" ] || case {rq} in *[!0-9a-fA-F]*) WANT= ;; *) WANT={rq} ;; esac; ")
 
     testcmd = " ".join(shlex.quote(a) for a in test_args)
@@ -1597,7 +1599,7 @@ def repro(ctx, ref, test_args, gpu_type, gpus, hours, no_connect, keep):
         "if [ -n \"$WANT\" ] && bs \"$WANT\"; then cd /home/dev/pytorch; HIT=1; echo '[repro] by-sha cache HIT -> staged prebuilt tree (zero build)'; fi; "
         # 2) not cached, build farm alive -> request an off-pod build, wait, then stage
         "if [ -z \"$HIT\" ] && [ -n \"$WANT\" ] && [ -n \"$(find \"$QUEUE/.worker-alive\" -mmin -2 2>/dev/null)\" ]; then "
-        "echo \"[repro] no cached build; requesting off-pod build of $WANT (build farm)…\"; touch \"$QUEUE/$WANT.req\" 2>/dev/null || true; "
+        "echo \"[repro] no cached build; requesting off-pod build of $WANT (build farm)…\"; printf '%s\\n' \"$FREF\" > \"$QUEUE/$WANT.req\" 2>/dev/null || true; "
         "i=0; while [ $i -lt 180 ]; do [ -f \"$BYSHA/$WANT.sha\" ] && break; [ -f \"$QUEUE/$WANT.req\" ] || break; sleep 2; i=$((i+1)); done; "
         "if bs \"$WANT\"; then cd /home/dev/pytorch; HIT=1; echo '[repro] off-pod build ready -> staged (zero build)'; else echo '[repro] off-pod build unavailable, building locally'; fi; fi; "
         # 3) fall back to in-pod fetch + build (+ cache the result for the next dev)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.7.7"
+version = "0.7.8"
 description = "CLI + Python SDK for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"

--- a/terraform-gpu-devservers/pytorch-ondemand.tf
+++ b/terraform-gpu-devservers/pytorch-ondemand.tf
@@ -81,21 +81,32 @@ resource "kubernetes_deployment_v1" "pytorch_ondemand" {
             fi
             git config --global --add safe.directory "$SRC" 2>/dev/null || true
 
-            build_sha() {
-              local sha="$1"
+            # build_ref <fetchref> <wantsha>: fetch the ref (pull/N/merge, a branch, or a
+            # sha — a synthetic merge sha isn't fetchable by sha alone, so we need the
+            # ref), build it, and publish by-sha under the ACTUAL built HEAD. The
+            # requester polls for <wantsha>; if the ref drifted, HEAD != wantsha and the
+            # requester just falls back to its in-pod build.
+            build_ref() {
+              local fref="$1" want="$2" actual zb
               cd "$SRC" || return 1
-              git fetch --force origin "$sha" 2>/dev/null || git fetch --force origin 2>/dev/null || true
-              git checkout -f "$sha" 2>/dev/null || { echo "[ondemand] checkout $sha failed"; return 1; }
+              if git fetch --force origin "$fref" 2>/dev/null; then
+                git checkout -f FETCH_HEAD 2>/dev/null || { echo "[ondemand] checkout FETCH_HEAD ($fref) failed"; return 1; }
+              else
+                git fetch --force origin 2>/dev/null || true
+                git checkout -f "$want" 2>/dev/null || { echo "[ondemand] checkout $want failed"; return 1; }
+              fi
               git -c protocol.file.allow=always submodule update --init --recursive --jobs 8 2>/dev/null || true
               pip install --break-system-packages -r requirements.txt 2>&1 | tail -1 || true
-              $MOLD python -m pip install --break-system-packages -e . --no-build-isolation || { echo "[ondemand] build $sha FAILED"; return 1; }
-              local zb; zb=$(command -v zstd 2>/dev/null || true)
+              $MOLD python -m pip install --break-system-packages -e . --no-build-isolation || { echo "[ondemand] build $fref FAILED"; return 1; }
+              actual=$(git rev-parse HEAD 2>/dev/null); [ -n "$actual" ] || return 1
+              zb=$(command -v zstd 2>/dev/null || true)
               if [ -n "$zb" ]; then
-                tar -C /home/dev -cf - pytorch | "$zb" -3 -T0 -q -o "$BYSHA/$sha.tar.zst.tmp" && mv "$BYSHA/$sha.tar.zst.tmp" "$BYSHA/$sha.tar.zst" || return 1
+                tar -C /home/dev -cf - pytorch | "$zb" -3 -T0 -q -o "$BYSHA/$actual.tar.zst.tmp" && mv "$BYSHA/$actual.tar.zst.tmp" "$BYSHA/$actual.tar.zst" || return 1
               else
-                tar -C /home/dev -cf - pytorch | gzip -1 > "$BYSHA/$sha.tar.gz.tmp" && mv "$BYSHA/$sha.tar.gz.tmp" "$BYSHA/$sha.tar.gz" || return 1
+                tar -C /home/dev -cf - pytorch | gzip -1 > "$BYSHA/$actual.tar.gz.tmp" && mv "$BYSHA/$actual.tar.gz.tmp" "$BYSHA/$actual.tar.gz" || return 1
               fi
-              echo "$sha" > "$BYSHA/$sha.sha"
+              echo "$actual" > "$BYSHA/$actual.sha"
+              echo "[ondemand] published $actual (req $want via $fref)"
               return 0
             }
 
@@ -106,9 +117,10 @@ resource "kubernetes_deployment_v1" "pytorch_ondemand" {
               if [ -n "$REQ" ]; then
                 SHA=$(basename "$REQ" .req)
                 if [ -f "$BYSHA/$SHA.sha" ]; then rm -f "$REQ"; continue; fi
-                echo "[ondemand] building $SHA"
+                FREF=$(head -1 "$REQ" 2>/dev/null); [ -n "$FREF" ] || FREF="$SHA"
+                echo "[ondemand] building $SHA (ref $FREF)"
                 T0=$(date +%s)
-                if build_sha "$SHA"; then echo "[ondemand] published $SHA in $(( $(date +%s) - T0 ))s"; else echo "[ondemand] $SHA build failed"; fi
+                if build_ref "$FREF" "$SHA"; then echo "[ondemand] done in $(( $(date +%s) - T0 ))s"; else echo "[ondemand] $SHA build failed"; fi
                 rm -f "$REQ"
               else
                 sleep 5


### PR DESCRIPTION
A `pull/N/merge` SHA is a synthetic merge commit that **isn't fetchable by sha alone** (GitHub won't serve arbitrary SHAs, and merge refs aren't reachable via a normal fetch), so the on-demand worker could only build *reachable* commit shas — **PR repros always fell back to the in-pod build.**

**Fix:** the requester writes the fetch ref (`pull/N/merge`, a branch, or a sha) **into** the `<sha>.req` file; the worker reads it, fetches that ref, builds `FETCH_HEAD`, and publishes by-sha under the **actual built HEAD**. The requester still polls for its resolved sha — if the ref drifted in between, `HEAD != sha` and it falls back to in-pod (never caches a mislabeled tree).

Now the farm handles PRs, branches, and commits. Bump 0.7.8.

**Activation:** CLI is editable (`git pull` = live); the worker change needs a `tofu apply` (rolls the `pytorch-ondemand-builder` Deployment). `tofu validate` + repro tests pass.