### PR TITLE
feat(repro): stream off-pod build progress (no more silent hang)

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -1599,8 +1599,12 @@ def repro(ctx, ref, test_args, gpu_type, gpus, hours, no_connect, keep):
         "if [ -n \"$WANT\" ] && bs \"$WANT\"; then cd /home/dev/pytorch; HIT=1; echo '[repro] by-sha cache HIT -> staged prebuilt tree (zero build)'; fi; "
         # 2) not cached, build farm alive -> request an off-pod build, wait, then stage
         "if [ -z \"$HIT\" ] && [ -n \"$WANT\" ] && [ -n \"$(find \"$QUEUE/.worker-alive\" -mmin -2 2>/dev/null)\" ]; then "
-        "echo \"[repro] no cached build; requesting off-pod build of $WANT (build farm)…\"; printf '%s\\n' \"$FREF\" > \"$QUEUE/$WANT.req\" 2>/dev/null || true; "
-        "i=0; while [ $i -lt 180 ]; do [ -f \"$BYSHA/$WANT.sha\" ] && break; [ -f \"$QUEUE/$WANT.req\" ] || break; sleep 2; i=$((i+1)); done; "
+        "echo \"[repro] no cached build; requesting off-pod build of $WANT (build farm; streaming progress)…\"; printf '%s\\n' \"$FREF\" > \"$QUEUE/$WANT.req\" 2>/dev/null || true; "
+        # poll for the artifact; meanwhile tail the farm's build log (ninja [x/N]) so it's not a silent hang.
+        "i=0; LL=0; while [ $i -lt 400 ]; do [ -f \"$BYSHA/$WANT.sha\" ] && break; [ -f \"$QUEUE/$WANT.req\" ] || break; "
+        "if [ -f \"$QUEUE/$WANT.log\" ]; then NL=$(wc -l < \"$QUEUE/$WANT.log\" 2>/dev/null || echo 0); "
+        "if [ \"$NL\" -gt \"$LL\" ]; then tail -n +$((LL+1)) \"$QUEUE/$WANT.log\" 2>/dev/null | grep -aE '\\[[0-9]+/[0-9]+\\]|Building wheel|Successfully built|error' | tail -1 | sed 's/^/  [farm] /'; LL=$NL; fi; fi; "
+        "sleep 3; i=$((i+1)); done; "
         "if bs \"$WANT\"; then cd /home/dev/pytorch; HIT=1; echo '[repro] off-pod build ready -> staged (zero build)'; else echo '[repro] off-pod build unavailable, building locally'; fi; fi; "
         # 3) fall back to in-pod fetch + build (+ cache the result for the next dev)
         "if [ -z \"$HIT\" ]; then "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.7.8"
+version = "0.7.9"
 description = "CLI + Python SDK for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"

--- a/terraform-gpu-devservers/pytorch-ondemand.tf
+++ b/terraform-gpu-devservers/pytorch-ondemand.tf
@@ -97,7 +97,10 @@ resource "kubernetes_deployment_v1" "pytorch_ondemand" {
               fi
               git -c protocol.file.allow=always submodule update --init --recursive --jobs 8 2>/dev/null || true
               pip install --break-system-packages -r requirements.txt 2>&1 | tail -1 || true
-              $MOLD python -m pip install --break-system-packages -e . --no-build-isolation || { echo "[ondemand] build $fref FAILED"; return 1; }
+              # Stream the build (-v = ninja [x/N] progress) to a log on the shared EFS,
+              # keyed by the REQUESTED sha, so the requester can tail it live.
+              local log="$QUEUE/$want.log"; : > "$log"
+              if ! $MOLD python -m pip install --break-system-packages -e . --no-build-isolation -v > "$log" 2>&1; then echo "[ondemand] build $fref FAILED"; tail -8 "$log"; return 1; fi
               actual=$(git rev-parse HEAD 2>/dev/null); [ -n "$actual" ] || return 1
               zb=$(command -v zstd 2>/dev/null || true)
               if [ -n "$zb" ]; then
@@ -121,7 +124,7 @@ resource "kubernetes_deployment_v1" "pytorch_ondemand" {
                 echo "[ondemand] building $SHA (ref $FREF)"
                 T0=$(date +%s)
                 if build_ref "$FREF" "$SHA"; then echo "[ondemand] done in $(( $(date +%s) - T0 ))s"; else echo "[ondemand] $SHA build failed"; fi
-                rm -f "$REQ"
+                rm -f "$REQ" "$QUEUE/$SHA.log"
               else
                 sleep 5
               fi


### PR DESCRIPTION
The on-demand farm build was a **silent wait** (~100 s+ — you reported the hang). Now:
- the **worker** writes its build output (`-v` → ninja `[x/N]`) to a log on the shared EFS keyed by the requested sha;
- the **repro poll** tails it live, printing the latest line as `  [farm] [x/N] …`.

Worker removes the log after the build; poll window widened to ~20 min (it's no longer blind). Bump 0.7.9.

Validated live: the farm built `pr/185264` (via `pull/185264/merge`) in **104 s** with mold + zstd. CLI is editable (`git pull` = live); the worker log change needs a `tofu apply`. `tofu validate` + repro tests pass.