### PR TITLE
feat(repro): merged PR → trunk land commit (not /merge); by-sha .sha gate

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -1557,25 +1557,33 @@ def repro(ctx, ref, test_args, gpu_type, gpus, hours, no_connect, keep):
     except RuntimeError as e:
         rprint(f"[red]❌ {str(e)}[/red]"); return
 
-    # ref -> in-pod fetch+checkout (PRs prefer /merge = CI's view, fall back to /head)
+    # Resolve the ref in-pod -> WANT (sha, for the by-sha cache) + FREF (fetch ref).
+    # A MERGED pr/N reproduces the actual squash/merge commit on main (the real trunk
+    # state that was red) — NOT pull/N/merge (the PR re-applied onto *current* trunk,
+    # which goes green once the fix lands). Open PRs keep pull/N/merge (= CI's view).
     r = ref.strip(); prnum = None
     if r.startswith("pr/"): prnum = r[3:]
     elif r.startswith("#"): prnum = r[1:]
     elif r.isdigit(): prnum = r
     gh = "https://github.com/pytorch/pytorch.git"
     if prnum:
-        fetch = (f"git fetch origin pull/{prnum}/merge 2>/dev/null && git checkout -f FETCH_HEAD || "
-                 f"{{ echo '[repro] no /merge ref, using /head'; git fetch origin pull/{prnum}/head && git checkout -f FETCH_HEAD; }}")
-        # resolve to a concrete SHA up front (for the by-sha cache lookup) AND keep the
-        # fetch ref FREF — the build farm needs the ref (a pull/N/merge sha isn't
-        # fetchable by sha alone), it's enqueued so the worker can fetch it.
-        resolve = (f"FREF=pull/{prnum}/merge; WANT=$(timeout 15 git ls-remote {gh} $FREF 2>/dev/null | head -1 | cut -f1); "
-                   f"[ -n \"$WANT\" ] || {{ FREF=pull/{prnum}/head; WANT=$(timeout 15 git ls-remote {gh} $FREF 2>/dev/null | head -1 | cut -f1); }}; ")
+        api = f"https://api.github.com/repos/pytorch/pytorch/pulls/{prnum}"
+        resolve = (
+            f"PRJSON=$(curl -s -m 10 -H 'Accept: application/vnd.github+json' -H 'User-Agent: gpu-dev' {api} 2>/dev/null); "
+            "MCS=$(printf '%s' \"$PRJSON\" | grep -oE '\"merge_commit_sha\": *\"[0-9a-f]+\"' | head -1 | cut -d'\"' -f4); "
+            "if printf '%s' \"$PRJSON\" | grep -q '\"merged\": *true' && [ -n \"$MCS\" ]; then "
+            f"WANT=\"$MCS\"; FREF=\"$MCS\"; echo \"[repro] pr/{prnum} is merged -> reproducing trunk commit $MCS\"; "
+            f"else FREF=pull/{prnum}/merge; WANT=$(timeout 15 git ls-remote {gh} $FREF 2>/dev/null | head -1 | cut -f1); "
+            f"[ -n \"$WANT\" ] || {{ FREF=pull/{prnum}/head; WANT=$(timeout 15 git ls-remote {gh} $FREF 2>/dev/null | head -1 | cut -f1); echo '[repro] open PR, no /merge -> /head'; }}; fi; ")
     else:
         rq = shlex.quote(r)
-        fetch = f"git fetch origin {rq} 2>/dev/null && git checkout -f FETCH_HEAD || git checkout -f {rq}"
         resolve = (f"FREF={rq}; WANT=$(timeout 15 git ls-remote {gh} {rq} 2>/dev/null | head -1 | cut -f1); "
                    f"[ -n \"$WANT\" ] || case {rq} in *[!0-9a-fA-F]*) WANT= ;; *) WANT={rq} ;; esac; ")
+    # in-pod fallback checkout (by-sha miss + farm unavailable): fetch the resolved ref,
+    # else check out the sha directly (reachable for a merged-PR land commit / trunk).
+    checkout = ("git fetch origin \"$FREF\" 2>/dev/null && git checkout -f FETCH_HEAD "
+                "|| git checkout -f \"$WANT\" 2>/dev/null "
+                "|| { git fetch --force origin 2>/dev/null && git checkout -f \"$WANT\"; }")
 
     testcmd = " ".join(shlex.quote(a) for a in test_args)
     # by-sha artifact cache: if a fully-built tree for the resolved SHA already exists
@@ -1587,7 +1595,8 @@ def repro(ctx, ref, test_args, gpu_type, gpus, hours, no_connect, keep):
         "BYSHA=/ccache_shared/prebuilt/by-sha; QUEUE=/ccache_shared/prebuilt/build-queue; HIT=; "
         # bs <sha>: stage a fully-built by-sha tree into /home/dev/pytorch (zero build); 0 on success.
         # explicit ext check, not a glob: the pod login shell is zsh, where an unmatched glob is a hard error.
-        "bs() { local s=\"$1\" tb=; for e in zst gz; do [ -f \"$BYSHA/$s.tar.$e\" ] && { tb=\"$BYSHA/$s.tar.$e\"; break; }; done; [ -n \"$tb\" ] || return 1; "
+        # require the .sha completion gate (written last) so we never stage a half-published tarball.
+        "bs() { local s=\"$1\" tb=; [ -f \"$BYSHA/$s.sha\" ] || return 1; for e in zst gz; do [ -f \"$BYSHA/$s.tar.$e\" ] && { tb=\"$BYSHA/$s.tar.$e\"; break; }; done; [ -n \"$tb\" ] || return 1; "
         "rm -rf /home/dev/pytorch.new; mkdir -p /home/dev/pytorch.new; "
         "case \"$tb\" in *.zst) zstd -dc \"$tb\" 2>/dev/null | tar -C /home/dev/pytorch.new --strip-components=1 -xf - 2>/dev/null ;; "
         "*) tar -C /home/dev/pytorch.new --strip-components=1 -xzf \"$tb\" 2>/dev/null ;; esac; "
@@ -1608,7 +1617,7 @@ def repro(ctx, ref, test_args, gpu_type, gpus, hours, no_connect, keep):
         "if bs \"$WANT\"; then cd /home/dev/pytorch; HIT=1; echo '[repro] off-pod build ready -> staged (zero build)'; else echo '[repro] off-pod build unavailable, building locally'; fi; fi; "
         # 3) fall back to in-pod fetch + build (+ cache the result for the next dev)
         "if [ -z \"$HIT\" ]; then "
-        f"echo '[repro] checkout {r}'; {fetch}; "
+        "echo \"[repro] checking out $FREF\"; " + checkout + "; "
         "echo \"[repro] HEAD $(git rev-parse --short HEAD)\"; "
         "git -c protocol.file.allow=always submodule update --init --recursive --jobs 8 >/dev/null 2>&1 || true; "
         "if ! PYTHONPATH=/home/dev/pytorch python -c 'import torch' 2>/dev/null; then "

--- a/docs/POST_DRAFT.md
+++ b/docs/POST_DRAFT.md
@@ -41,10 +41,16 @@ gpu-dev repro pr/185264 test/inductor/test_flex_attention.py \
   TestFlexAttentionCUDA.test_large_kv_int64_pointer_math_cuda --gpu-type h100
 ```
 
-Reserves a box, checks out the ref (PRs use `pull/N/merge` — what CI actually tests),
-runs the test, prints the verdict, then **drops you into the box** at `~/pytorch` with
-the ref checked out so you can fix and re-run. `--no-connect` = CI mode (run, auto-cancel,
-exit code = test result).
+Reserves a box, checks out the ref, runs the test, prints the verdict, then **drops you
+into the box** at `~/pytorch` with the ref checked out so you can fix and re-run.
+`--no-connect` = CI mode (run, auto-cancel, exit code = test result).
+
+- **Merged PR → the actual land commit on `main`** (the real trunk state that was red).
+  **Open PR → `pull/N/merge`** (what CI tests), falling back to `/head`. Also takes a
+  branch or commit sha.
+- The build is **off-pod**: the box requests it from an always-on build farm (192-core
+  node, mold linker, shared ccache) and stages the result — so a never-before-built
+  commit lands in ~100 s, and any commit built once is then **zero-build** for everyone.
 
 ## 4. `gpu-dev submit` — run a job, get results back
 
@@ -59,13 +65,17 @@ code mirrors the remote command. Multinode wires `RANK`/`SIZE`/`MASTER_ADDR`/…
 
 ## Caching — why builds are fast
 
-Two layers, so you almost never pay for a cold compile:
+Three layers, so you almost never pay for a cold compile:
 
 1. **Prebuilt tree.** Every box gets PyTorch already built at `viable/strict` and staged
    at `~/pytorch` → `import torch` works with **zero build**.
-2. **Shared ccache** (`/ccache_shared`, one EFS mounted in every pod *and* the build node)
-   → all C++/CUDA object compiles are cached and shared across users. Checking out a ref
-   past `viable/strict`, or editing C++, reuses those objects instead of recompiling.
+2. **By-SHA artifact cache.** Whole *built* trees are cached by commit SHA on the shared
+   EFS (every viable/strict bump + every repro fills it, kept for ~72 h). Repro a commit
+   anyone has built → it's staged with **zero build**. A cache miss is built **off-pod**
+   on an always-on build farm (192-core node, mold linker), then it's cached too.
+3. **Shared ccache** (`/ccache_shared`, one EFS mounted in every pod *and* the build node)
+   → all C++/CUDA object compiles are cached and shared, so even a from-scratch build is
+   incremental, and the farm's per-commit builds are ~100 s, not ~30 min.
 
 Expected timings (CUDA 13.2):
 
@@ -73,10 +83,11 @@ Expected timings (CUDA 13.2):
 |---|---|
 | warm claim → active | ~1–2 s |
 | `import torch` (prebuilt) | 0 s |
+| repro a **cached** commit (by-SHA hit) | **0 build** — just stage the prebuilt tree |
+| repro an **uncached** commit (build farm) | **~100 s** off-pod (mold + ccache), then cached for everyone |
 | Python-only edit | 0 s (no rebuild — `PYTHONPATH=~/pytorch`) |
-| edit one C++/CUDA file → rebuild | ~40 s (incremental: warm `build/` + ccache) |
-| build a ref near `viable/strict` | a few min (mostly cache hits) |
-| cold build (far ref / empty cache) | ~20–40 min (one-time; fills the cache for everyone) |
+| edit one C++/CUDA file → rebuild | ~15–40 s (incremental: warm `build/` + ccache + mold) |
+| true cold build (empty cache) | ~20–40 min (rare; one-time) |
 
 ## PyTorch is fully editable
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.7.9"
+version = "0.7.10"
 description = "CLI + Python SDK for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"

--- a/tests/unit/cli/test_repro.py
+++ b/tests/unit/cli/test_repro.py
@@ -105,13 +105,17 @@ def _remote_str(run_mock):
 WARM = {"reservation_id": "warm0001abcd", "ssh_command": "ssh -p 30022 dev@1.2.3.4"}
 
 
-def test_ref_pr_slash_uses_merge_with_head_fallback(cli_runner):
+def test_ref_pr_merged_uses_land_commit_else_merge_then_head(cli_runner):
     res, rm, run = _run(cli_runner, ["pr/185264", "test/foo.py"], claim_result=WARM)
     cmd = _remote_str(run)
-    assert "git fetch origin pull/185264/merge" in cmd
-    assert "no /merge ref, using /head" in cmd
-    assert "git fetch origin pull/185264/head" in cmd
-    # checkout of FETCH_HEAD is the merge/head strategy, not a literal ref checkout
+    # merged PR -> the GitHub API merge_commit_sha (the actual trunk commit)
+    assert "api.github.com/repos/pytorch/pytorch/pulls/185264" in cmd
+    assert "merge_commit_sha" in cmd
+    assert '"merged"' in cmd
+    # open PR fallback: pull/N/merge then /head
+    assert "pull/185264/merge" in cmd
+    assert "pull/185264/head" in cmd
+    # checkout uses the resolved fetch ref / sha (FETCH_HEAD strategy)
     assert "git checkout -f FETCH_HEAD" in cmd
 
 
@@ -129,23 +133,24 @@ def test_ref_bare_number_is_treated_as_pr(cli_runner):
     assert "pull/42/head" in cmd
 
 
-def test_ref_branch_uses_generic_fetch_checkout(cli_runner):
+def test_ref_branch_resolves_via_lsremote_no_pr_path(cli_runner):
     res, rm, run = _run(cli_runner, ["my-feature-branch", "test/foo.py"], claim_result=WARM)
     cmd = _remote_str(run)
-    # branch path: generic fetch of the ref, fall back to literal checkout
-    assert "git fetch origin my-feature-branch" in cmd
-    assert "git checkout -f my-feature-branch" in cmd
-    # not a PR path
-    assert "pull/" not in cmd
+    # branch path: resolve via ls-remote of the ref, fetch the resolved FREF
+    assert "git ls-remote" in cmd and "my-feature-branch" in cmd
+    assert "FREF=my-feature-branch" in cmd
+    assert "git fetch origin \"$FREF\"" in cmd
+    # not a PR path (no GitHub PR API / pull refs)
+    assert "pull/" not in cmd and "api.github.com" not in cmd
 
 
-def test_ref_sha_uses_generic_fetch_checkout(cli_runner):
+def test_ref_sha_resolves_to_itself_no_pr_path(cli_runner):
     sha = "abc123def456"
     res, rm, run = _run(cli_runner, [sha, "test/foo.py"], claim_result=WARM)
     cmd = _remote_str(run)
-    assert f"git fetch origin {sha}" in cmd
-    assert f"git checkout -f {sha}" in cmd
-    assert "pull/" not in cmd
+    assert sha in cmd
+    assert "git fetch origin \"$FREF\"" in cmd
+    assert "pull/" not in cmd and "api.github.com" not in cmd
 
 
 def test_ref_with_shell_metachars_is_quoted(cli_runner):


### PR DESCRIPTION
**Why:** `pr/N` resolved to `pull/N/merge` = the PR re-applied onto *current* trunk, so once the fix lands the tree is green and the repro **falsely passes** (you hit this on pr/185264). 

**Fix:** for a **merged** PR, reproduce the actual **squash/merge commit on `main`** (the real trunk state that was red), via the GitHub API (`merge_commit_sha` + `merged`). **Open** PRs keep `pull/N/merge` → `/head`. The fallback checkout, by-SHA lookup, and farm enqueue all key off the resolved `WANT`/`FREF`, so the farm builds the land commit (reachable on `main`) directly.

**Cleanup (you asked):** `bs()` now requires the `.sha` completion gate before staging, so the step-1 cache check reliably short-circuits to the HIT path on a fully-published artifact — no more spurious `no cached build` + off-pod round-trip when it was actually cached (that was bs matching a tarball before its `.sha` marker).

**Docs:** `POST_DRAFT.md` refreshed with validated numbers (zero-build cached repro; ~100 s off-pod farm build) + the merged-vs-open semantics.

Tests updated for the new resolve; **1152 passed**. Bump 0.7.10. CLI is editable (`git pull` = live); the resolve is client-injected so **no worker/lambda/tofu change** needed for this one.