### PR TITLE
fix(warm): free DNS name on recycle + rotate stale-image warm pods + unify pod name

### DIFF
--- a/terraform-gpu-devservers/docker/bashrc
+++ b/terraform-gpu-devservers/docker/bashrc
@@ -20,3 +20,11 @@ alias gpu-watch='watch -n 1 nvidia-smi'
 alias ll='ls -alF'
 alias la='ls -A'
 alias l='ls -CF'
+
+# On warm-claimed pods the kernel hostname is the warm-pool name, not
+# gpu-dev-<reservation>. Show the reservation-based label (== the SSH alias) in
+# the prompt instead. Cold pods leave GPU_DEV_HOSTLABEL unset -> default \h, which
+# is already gpu-dev-<reservation>.
+if [ -n "$GPU_DEV_HOSTLABEL" ]; then
+    PS1="\[\e[32m\]\u@${GPU_DEV_HOSTLABEL}\[\e[0m\]:\[\e[34m\]\w\[\e[0m\]\$ "
+fi

--- a/terraform-gpu-devservers/docker/zshrc
+++ b/terraform-gpu-devservers/docker/zshrc
@@ -54,5 +54,8 @@ alias ll='ls -alF'
 alias la='ls -A'
 alias l='ls -CF'
 
-# Custom prompt to show full path (no time) - override theme prompt
-PROMPT='%{$fg[green]%}%n@%m%{$reset_color%}:%{$fg[blue]%}%~%{$reset_color%}$ '
+# Custom prompt to show full path (no time) - override theme prompt.
+# Host segment prefers $GPU_DEV_HOSTLABEL (set on warm-claimed pods to
+# gpu-dev-<reservation>, since their kernel hostname is the warm-pool name);
+# falls back to %m (the real hostname, already gpu-dev-<reservation> for cold pods).
+PROMPT='%{$fg[green]%}%n@'"${GPU_DEV_HOSTLABEL:-%m}"'%{$reset_color%}:%{$fg[blue]%}%~%{$reset_color%}$ '

--- a/terraform-gpu-devservers/lambda.tf
+++ b/terraform-gpu-devservers/lambda.tf
@@ -151,6 +151,7 @@ resource "aws_iam_role_policy" "reservation_processor_policy" {
         Effect = "Allow"
         Action = [
           "ecr:DescribeRepositories",
+          "ecr:DescribeImages",
           "ecr:CreateRepository",
           "ecr:GetAuthorizationToken"
         ]

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -17,7 +17,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Any
+from typing import Any, Optional
 
 import boto3
 import botocore.exceptions
@@ -1488,11 +1488,15 @@ def _provision_warm_pod(v1, pod) -> None:
     if get_dns_enabled():
         try:
             domain_name = generate_unique_name()
-            # Placeholder mapping (reservation_id='warm', far expiry); the claim
-            # rebinds it to the real reservation.
+            # Placeholder mapping (reservation_id='warm'); the claim rebinds it to
+            # the real reservation. Expiry tracks the pod's own max age (+2h slack)
+            # so a leaked mapping (recycle that missed the delete) self-cleans via
+            # DynamoDB TTL within hours instead of lingering for days and bloating
+            # the name pool that generate_unique_name() collides against.
             store_domain_mapping(
                 domain_name, node_private_ip or node_public_ip,
-                node_port, "warm", int(time.time()) + 7 * 24 * 3600)
+                node_port, "warm",
+                int(time.time()) + int(WARM_POD_MAX_AGE_HOURS * 3600) + 2 * 3600)
         except Exception as e:
             logger.warning(f"warm provision mapping failed for {pod_name}: {e}")
             domain_name = "-"
@@ -1506,17 +1510,63 @@ def _provision_warm_pod(v1, pod) -> None:
 
 
 def _recycle_warm_pod(v1, p) -> bool:
-    """Delete a warm pod + its SSH service. Returns True on pod delete success."""
+    """Delete a warm pod + its SSH service + its placeholder domain mapping.
+
+    The mapping cleanup matters: an unclaimed warm pod holds a 'warm' placeholder
+    name in the SSH mappings table, and generate_unique_name() counts every
+    non-expired mapping as taken. Dropping the pod but leaving the mapping leaks
+    the name until its TTL — orphans then pile up and manufacture '-2' suffixes on
+    fresh reservations. Freeing it here keeps the name pool ~= the live pod count.
+    Returns True on pod delete success.
+    """
     try:
+        dom = (p.metadata.annotations or {}).get("warm-domain")
         v1.delete_namespaced_pod(p.metadata.name, "gpu-dev")
         try:
             v1.delete_namespaced_service(f"{p.metadata.name}-ssh", "gpu-dev")
         except Exception:
             pass
+        if dom and dom != "-":
+            try:
+                delete_domain_mapping(dom)
+            except Exception as me:
+                logger.warning(f"warm recycle domain cleanup failed for {dom}: {me}")
         return True
     except Exception as de:
         logger.warning(f"warm recycle delete failed for {p.metadata.name}: {de}")
         return False
+
+
+def _current_image_digest() -> Optional[str]:
+    """Resolve the digest the pod image tag (`:latest`) currently points to in ECR.
+    Used to rotate warm pods off a stale image after a rebuild. None on any error
+    (callers then skip rotation — fail-safe, never recycle on uncertainty)."""
+    try:
+        img = GPU_DEV_CONTAINER_IMAGE
+        if "/" not in img or ".ecr." not in img:
+            return None
+        repo_and_tag = img.split("/", 1)[1]
+        repo, _, tag = repo_and_tag.partition(":")
+        tag = tag or "latest"
+        ecr = boto3.client("ecr")
+        resp = ecr.describe_images(
+            repositoryName=repo, imageIds=[{"imageTag": tag}])
+        return resp["imageDetails"][0]["imageDigest"]
+    except Exception as e:
+        logger.warning(f"could not resolve current image digest: {e}")
+        return None
+
+
+def _pod_image_digest(p) -> Optional[str]:
+    """The sha256 digest the gpu-dev container is actually running (from the pod's
+    container status imageID, e.g. '...repo@sha256:abc'). None if not reported."""
+    try:
+        for cs in (p.status.container_statuses or []):
+            if cs.name == "gpu-dev" and cs.image_id and "@" in cs.image_id:
+                return cs.image_id.split("@", 1)[1]
+    except Exception:
+        pass
+    return None
 
 
 def reconcile_warm_pool() -> dict:
@@ -1524,6 +1574,11 @@ def reconcile_warm_pool() -> dict:
     v1 = client.CoreV1Api(get_k8s_client())
     created = recycled = 0
     max_age_s = WARM_POD_MAX_AGE_HOURS * 3600
+    # Rotate idle warm pods off a stale image after a rebuild. Resolved once per
+    # reconcile; rotation is capped at 1 pod per type per tick so the pool drains
+    # gradually (never all at once) and only ever touches warm-state=ready pods —
+    # claimed pods (real reservations) are never recycled here.
+    desired_digest = _current_image_digest()
     for gpu_type, target in WARM_POOL_TARGETS.items():
         try:
             pods = _list_warm_pods(v1, gpu_type=gpu_type)
@@ -1553,6 +1608,18 @@ def reconcile_warm_pool() -> dict:
                     if _recycle_warm_pod(v1, p):
                         recycled += 1
                 live = live[:int(target)]
+            # Rotate ONE stale-image ready pod out (the deficit backfill below then
+            # recreates it on the fresh image). Capped at 1/type/tick = gradual.
+            if desired_digest:
+                for p in live:
+                    if (p.metadata.labels or {}).get("warm-state") != "ready":
+                        continue
+                    rd = _pod_image_digest(p)
+                    if rd and rd != desired_digest:
+                        if _recycle_warm_pod(v1, p):
+                            recycled += 1
+                            live.remove(p)
+                        break
             # Backfill connection details on ready pods so claims stay fast.
             for p in live:
                 if (p.metadata.labels or {}).get("warm-state") == "ready":
@@ -1659,6 +1726,7 @@ def try_claim_warm_pod(body: dict) -> bool:
         )
         record_trace_event(trace_data, "warm_pod_labeled")
 
+        resid8 = (reservation_id or "")[:8]
         inject_cmd = (
             "mkdir -p /home/dev/.ssh && touch /home/dev/.ssh/authorized_keys\n"
             "while IFS= read -r k; do [ -n \"$k\" ] && ! grep -Fq \"$k\" /home/dev/.ssh/authorized_keys && echo \"$k\" >> /home/dev/.ssh/authorized_keys; done <<'KEOF'\n"
@@ -1670,11 +1738,18 @@ def try_claim_warm_pod(body: dict) -> bool:
             # (cancel/list/...) authenticates as the user and IRSA assumes the right
             # session. The user connects AFTER the claim, so their login shell picks
             # these up. Also record the reservation id for `gpu-dev cancel`.
+            # A warm pod's kernel hostname is the pool name (gpu-dev-<type>-<hex>),
+            # so the shell prompt would show that instead of anything tied to the
+            # reservation. Stamp GPU_DEV_HOSTLABEL=gpu-dev-<resid8> (== the SSH alias
+            # from #185); the image prompt prefers it over %m/\\h, so warm pods show
+            # the same handle you connect with. Cold pods leave it unset (their
+            # hostname already IS gpu-dev-<resid8>).
             "for f in /home/dev/.bashrc_ext /home/dev/.zshrc_ext; do [ -f \"$f\" ] || continue\n"
             f"  sed -i -e 's|^export GPU_DEV_USER_ID=.*|export GPU_DEV_USER_ID=\"{user_id}\"|'"
             f" -e 's|^export GPU_DEV_GITHUB_USER=.*|export GPU_DEV_GITHUB_USER=\"{github_user}\"|'"
             f" -e 's|^export AWS_ROLE_SESSION_NAME=.*|export AWS_ROLE_SESSION_NAME=\"{user_id}\"|' \"$f\"\n"
             f"  grep -q '^export GPU_DEV_RESERVATION_ID=' \"$f\" && sed -i 's|^export GPU_DEV_RESERVATION_ID=.*|export GPU_DEV_RESERVATION_ID=\"{reservation_id}\"|' \"$f\" || echo 'export GPU_DEV_RESERVATION_ID=\"{reservation_id}\"' >> \"$f\"\n"
+            f"  grep -q '^export GPU_DEV_HOSTLABEL=' \"$f\" && sed -i 's|^export GPU_DEV_HOSTLABEL=.*|export GPU_DEV_HOSTLABEL=\"gpu-dev-{resid8}\"|' \"$f\" || echo 'export GPU_DEV_HOSTLABEL=\"gpu-dev-{resid8}\"' >> \"$f\"\n"
             "done"
         )
         stream(

--- a/tests/unit/lambda_fn/test_claim.py
+++ b/tests/unit/lambda_fn/test_claim.py
@@ -240,6 +240,9 @@ def test_inject_cmd_stamps_identity(lambda_index, aws_mocks):
         assert 'GPU_DEV_GITHUB_USER="octocat"' in script
         assert 'AWS_ROLE_SESSION_NAME="octocat-uid"' in script
         assert 'GPU_DEV_RESERVATION_ID="res-123"' in script
+        # prompt host label tied to the reservation (== the SSH alias), so a
+        # warm pod's prompt shows gpu-dev-<resid8>, not the warm-pool hostname
+        assert 'GPU_DEV_HOSTLABEL="gpu-dev-res-123"' in script
 
 
 def test_inject_cmd_targets_claimed_pod(lambda_index, aws_mocks):

--- a/tests/unit/lambda_fn/test_warm_pool.py
+++ b/tests/unit/lambda_fn/test_warm_pool.py
@@ -28,7 +28,8 @@ import pytest
 
 def _make_pod(name, *, warm_state="ready", phase="Running", node="node-a",
               gpu_type="h100", resource="nvidia.com/gpu", gpu_held=1,
-              app="gpu-dev-warm", creation_ts=None, annotations=None):
+              app="gpu-dev-warm", creation_ts=None, annotations=None,
+              image_id=None):
     """A stand-in for a kubernetes V1Pod with just the attrs the code reads."""
     labels = {"app": app, "warm-gpu-type": gpu_type}
     if warm_state is not None:
@@ -41,13 +42,16 @@ def _make_pod(name, *, warm_state="ready", phase="Running", node="node-a",
     if creation_ts is not None:
         ts = SimpleNamespace(timestamp=lambda v=creation_ts: v)
 
+    container_statuses = (
+        [SimpleNamespace(name="gpu-dev", image_id=image_id)] if image_id else [])
+
     return SimpleNamespace(
         metadata=SimpleNamespace(
             name=name, labels=labels, annotations=annotations or {},
             creation_timestamp=ts,
         ),
         spec=SimpleNamespace(node_name=node, containers=[container]),
-        status=SimpleNamespace(phase=phase),
+        status=SimpleNamespace(phase=phase, container_statuses=container_statuses),
     )
 
 
@@ -144,12 +148,15 @@ def test_create_warm_pod_uses_unique_names(lambda_index):
 
 # --- reconcile_warm_pool ------------------------------------------------------
 
-def _reconcile_with(lambda_index, monkeypatch, *, pods_by_type, target_overrides=None):
+def _reconcile_with(lambda_index, monkeypatch, *, pods_by_type, target_overrides=None,
+                    desired_digest=None):
     """Run reconcile_warm_pool with a single fake CoreV1Api `v1`.
 
     pods_by_type: {gpu_type: [pods]} returned by _list_warm_pods for that type.
     Patches WARM_POOL_TARGETS to exactly the keys in target_overrides (so only
-    the types we care about are reconciled). Returns (v1, created_calls).
+    the types we care about are reconciled). `desired_digest` stubs
+    _current_image_digest (default None = image rotation disabled, so existing
+    tests never touch ECR). Returns (v1, created_calls, result).
     """
     v1 = MagicMock(name="v1")
 
@@ -172,6 +179,8 @@ def _reconcile_with(lambda_index, monkeypatch, *, pods_by_type, target_overrides
     monkeypatch.setattr(lambda_index, "_list_warm_pods", fake_list)
     monkeypatch.setattr(lambda_index, "_create_warm_pod", fake_create)
     monkeypatch.setattr(lambda_index, "_provision_warm_pod", lambda *_a, **_k: None)
+    monkeypatch.setattr(lambda_index, "_current_image_digest",
+                        lambda: desired_digest)
 
     result = lambda_index.reconcile_warm_pool()
     return v1, created_calls, result
@@ -311,6 +320,184 @@ def test_reconcile_per_type_failure_isolated(lambda_index, monkeypatch):
     # cpu-x86 still got topped up despite cpu-arm failing
     assert created.count("cpu-x86") == 2
     assert "cpu-arm" not in created
+
+
+# --- _recycle_warm_pod: domain-mapping cleanup (orphan-leak fix) --------------
+
+def test_recycle_deletes_domain_mapping(lambda_index, monkeypatch):
+    # The whole point of the fix: recycling a warm pod must also free its
+    # placeholder DNS name, else generate_unique_name() collides against orphans.
+    deleted = []
+    monkeypatch.setattr(lambda_index, "delete_domain_mapping",
+                        lambda d: deleted.append(d))
+    v1 = MagicMock()
+    pod = _make_pod("gpu-dev-h100-x", annotations={"warm-domain": "clever_fox"})
+    assert lambda_index._recycle_warm_pod(v1, pod) is True
+    v1.delete_namespaced_pod.assert_called_once()
+    assert deleted == ["clever_fox"]
+
+
+def test_recycle_no_mapping_delete_when_no_domain(lambda_index, monkeypatch):
+    deleted = []
+    monkeypatch.setattr(lambda_index, "delete_domain_mapping",
+                        lambda d: deleted.append(d))
+    v1 = MagicMock()
+    # placeholder "-" and absent annotation must both skip the mapping delete
+    for ann in ({"warm-domain": "-"}, {}):
+        pod = _make_pod("gpu-dev-h100-x", annotations=ann)
+        assert lambda_index._recycle_warm_pod(v1, pod) is True
+    assert deleted == []
+
+
+def test_recycle_swallows_mapping_delete_error(lambda_index, monkeypatch):
+    # A failed mapping cleanup must not fail the recycle (pod is already gone).
+    monkeypatch.setattr(lambda_index, "delete_domain_mapping",
+                        lambda d: (_ for _ in ()).throw(RuntimeError("ddb down")))
+    v1 = MagicMock()
+    pod = _make_pod("gpu-dev-h100-x", annotations={"warm-domain": "clever_fox"})
+    assert lambda_index._recycle_warm_pod(v1, pod) is True
+
+
+# --- _provision_warm_pod: placeholder mapping expiry --------------------------
+
+def test_provision_uses_short_placeholder_expiry(lambda_index, monkeypatch):
+    # The placeholder must expire on the pod's own timescale (max_age + 2h), NOT
+    # the old 7 days — that long TTL is what let orphans pile up.
+    monkeypatch.setattr(lambda_index, "WARM_POD_MAX_AGE_HOURS", 12.0)
+    monkeypatch.setattr(lambda_index, "get_dns_enabled", lambda: True)
+    monkeypatch.setattr(lambda_index, "generate_unique_name", lambda: "brave_owl")
+    monkeypatch.setattr(lambda_index, "get_pod_node_public_ip", lambda _n: "1.2.3.4")
+    monkeypatch.setattr(lambda_index, "get_pod_node_private_ip", lambda _n: "10.0.0.1")
+    monkeypatch.setattr(lambda_index, "get_pod_internal_ip", lambda _n: "10.1.0.1")
+    captured = {}
+    monkeypatch.setattr(lambda_index, "store_domain_mapping",
+                        lambda *a: captured.setdefault("args", a))
+    v1 = MagicMock()
+    v1.read_namespaced_service.return_value = SimpleNamespace(
+        spec=SimpleNamespace(ports=[SimpleNamespace(node_port=30111)]))
+    pod = _make_pod("gpu-dev-h100-fresh", warm_state="ready")
+
+    before = time.time()
+    lambda_index._provision_warm_pod(v1, pod)
+    expires = captured["args"][4]
+    # (12h + 2h) ahead, well under the old 7-day (604800s) value
+    assert 13 * 3600 < (expires - before) < 15 * 3600
+
+
+# --- image digest helpers + rotation ------------------------------------------
+
+def test_pod_image_digest_parses_image_id(lambda_index):
+    pod = _make_pod("p", image_id="acct.dkr.ecr.us-east-2.amazonaws.com/repo@sha256:abc123")
+    assert lambda_index._pod_image_digest(pod) == "sha256:abc123"
+
+
+def test_pod_image_digest_none_when_absent(lambda_index):
+    assert lambda_index._pod_image_digest(_make_pod("p")) is None  # no statuses
+
+
+def test_current_image_digest_queries_ecr(lambda_index, monkeypatch):
+    fake_ecr = MagicMock()
+    fake_ecr.describe_images.return_value = {
+        "imageDetails": [{"imageDigest": "sha256:deadbeef"}]}
+    monkeypatch.setattr(lambda_index, "GPU_DEV_CONTAINER_IMAGE",
+                        "1234.dkr.ecr.us-east-2.amazonaws.com/gpu-dev:latest")
+    monkeypatch.setattr(lambda_index.boto3, "client", lambda svc: fake_ecr)
+    assert lambda_index._current_image_digest() == "sha256:deadbeef"
+    _, kw = fake_ecr.describe_images.call_args
+    assert kw["repositoryName"] == "gpu-dev"
+    assert kw["imageIds"] == [{"imageTag": "latest"}]
+
+
+def test_current_image_digest_none_for_non_ecr_image(lambda_index, monkeypatch):
+    monkeypatch.setattr(lambda_index, "GPU_DEV_CONTAINER_IMAGE",
+                        "pytorch/pytorch:2.11.0-cuda12.8-cudnn9-devel")
+    assert lambda_index._current_image_digest() is None
+
+
+def test_current_image_digest_swallows_ecr_error(lambda_index, monkeypatch):
+    def boom(_svc):
+        raise RuntimeError("no ecr")
+    monkeypatch.setattr(lambda_index, "GPU_DEV_CONTAINER_IMAGE",
+                        "1234.dkr.ecr.us-east-2.amazonaws.com/gpu-dev:latest")
+    monkeypatch.setattr(lambda_index.boto3, "client", boom)
+    assert lambda_index._current_image_digest() is None
+
+
+def test_reconcile_rotates_one_stale_image_pod(lambda_index, monkeypatch):
+    # Two ready pods at target=2: one on the desired digest, one stale. The stale
+    # one is recycled (and refilled); the current one is left alone.
+    cur = _make_pod("gpu-dev-h100-current", warm_state="ready", creation_ts=time.time(),
+                    image_id="r@sha256:NEW")
+    stale = _make_pod("gpu-dev-h100-stale", warm_state="ready", creation_ts=time.time(),
+                      image_id="r@sha256:OLD", annotations={"warm-domain": "old_fox"})
+    monkeypatch.setattr(lambda_index, "delete_domain_mapping", lambda d: None)
+    v1, created, _ = _reconcile_with(
+        lambda_index, monkeypatch,
+        pods_by_type={"h100": [cur, stale]},
+        target_overrides={"h100": 2},
+        desired_digest="sha256:NEW",
+    )
+    deleted = [c.args[0] for c in v1.delete_namespaced_pod.call_args_list]
+    assert "gpu-dev-h100-stale" in deleted
+    assert "gpu-dev-h100-current" not in deleted
+    assert created == [("h100", 1)]  # the rotated-out slot is refilled
+
+
+def test_reconcile_rotation_caps_one_per_tick(lambda_index, monkeypatch):
+    # Three stale ready pods, target=3: only ONE is rotated per reconcile (gradual).
+    stale = [_make_pod(f"gpu-dev-h100-s{i}", warm_state="ready", creation_ts=time.time(),
+                       image_id="r@sha256:OLD") for i in range(3)]
+    monkeypatch.setattr(lambda_index, "delete_domain_mapping", lambda d: None)
+    v1, created, _ = _reconcile_with(
+        lambda_index, monkeypatch,
+        pods_by_type={"h100": stale},
+        target_overrides={"h100": 3},
+        desired_digest="sha256:NEW",
+    )
+    deleted = [c.args[0] for c in v1.delete_namespaced_pod.call_args_list]
+    assert len(deleted) == 1
+    assert created == [("h100", 1)]
+
+
+def test_reconcile_no_rotation_when_digest_matches(lambda_index, monkeypatch):
+    p = _make_pod("gpu-dev-h100-ok", warm_state="ready", creation_ts=time.time(),
+                  image_id="r@sha256:NEW")
+    v1, created, _ = _reconcile_with(
+        lambda_index, monkeypatch,
+        pods_by_type={"h100": [p]},
+        target_overrides={"h100": 1},
+        desired_digest="sha256:NEW",
+    )
+    v1.delete_namespaced_pod.assert_not_called()
+    assert created == []
+
+
+def test_reconcile_skips_rotation_when_digest_unknown(lambda_index, monkeypatch):
+    # ECR lookup failed (None) -> never recycle on uncertainty.
+    p = _make_pod("gpu-dev-h100-x", warm_state="ready", creation_ts=time.time(),
+                  image_id="r@sha256:OLD")
+    v1, created, _ = _reconcile_with(
+        lambda_index, monkeypatch,
+        pods_by_type={"h100": [p]},
+        target_overrides={"h100": 1},
+        desired_digest=None,
+    )
+    v1.delete_namespaced_pod.assert_not_called()
+    assert created == []
+
+
+def test_reconcile_rotation_never_touches_claimed(lambda_index, monkeypatch):
+    # A claimed pod on a stale image is a real reservation — never rotate it.
+    claimed = _make_pod("gpu-dev-h100-claimed", warm_state="claimed",
+                        creation_ts=time.time(), image_id="r@sha256:OLD")
+    v1, created, _ = _reconcile_with(
+        lambda_index, monkeypatch,
+        pods_by_type={"h100": [claimed]},
+        target_overrides={"h100": 1},
+        desired_digest="sha256:NEW",
+    )
+    v1.delete_namespaced_pod.assert_not_called()
+    assert created == [("h100", 1)]  # claimed not counted; refill the standby slot
 
 
 # --- _evict_warm_for_capacity -------------------------------------------------


### PR DESCRIPTION
## Why

Diagnosing why fresh reservations kept getting `-2` suffixes (e.g. `bright_fox-2.devservers.io`). It's **not** the birthday paradox over the ~13.7k name pool — it's a leak.

A recycled warm pod (`_recycle_warm_pod`) deleted the pod + SSH service but **never deleted its placeholder domain mapping**, which is written with a **7-day** expiry and `reservation_id="warm"`. `generate_unique_name()` counts every non-expired mapping as taken, so the picker collides against a growing junk pile.

**Prod data at time of diagnosis: 449 non-expired mappings, every single one `reservation_id="warm"`, vs only ~24 live warm pods.** ~425 orphans, accumulating in 30–65-count bursts every ~12h (the warm-pool recycle cycles from image rebuilds), each holding a name for 7 days.

## What

1. **Free the name on recycle** — `_recycle_warm_pod` now `delete_domain_mapping(warm-domain)`. Placeholder expiry shortened 7d → `WARM_POD_MAX_AGE_HOURS + 2h`, so any orphan a missed-delete leaves self-cleans via DynamoDB TTL within hours, not days.
2. **Rotate stale-image warm pods after a rebuild** (the "rotate on apply, only if not in use" ask) — `reconcile_warm_pool` compares each **ready** pod's running digest to the `:latest` digest in ECR and recycles **at most one per type per tick** (gradual; the deficit backfill recreates it on the fresh image). Never touches `warm-state=claimed` pods. Needs `ecr:DescribeImages` on the processor role (added).
3. **Unify the pod name** — warm claim stamps `GPU_DEV_HOSTLABEL=gpu-dev-<resid8>` into the shell-ext files; the image prompt prefers it over `%m`/`\h`, so a warm-claimed pod's prompt shows the same handle you connect with (== the SSH alias from #185) instead of the warm-pool hostname `gpu-dev-b200-<hex>`. Cold pods leave it unset (their hostname already matches).

## Tests

+18 unit tests (recycle mapping cleanup + error swallow, digest parse/resolve helpers, rotation: rotates one / caps one-per-tick / skips on digest match / skips on unknown digest / never claimed, short placeholder expiry, HOSTLABEL stamp). Full suite: **1166 passed**.

## Deploy notes

- Needs `tofu apply` (prod) for the lambda + IAM. The image prompt change needs the image rebuild (rides the pending #198 rebuild).
- One-time cleanup of the existing 449 orphan mappings is separate (not in this PR) — safe to delete only the `warm` mappings not referenced by a live warm pod's `warm-domain` annotation.
- After this lands, future applies auto-rotate idle warm pods onto the new image (no manual warm-pod kill needed).