### PR TITLE
fix(ondemand): wait_for_rollout=false on the build worker (stop apply failing on its cold image pull)

### DIFF
--- a/terraform-gpu-devservers/pytorch-ondemand.tf
+++ b/terraform-gpu-devservers/pytorch-ondemand.tf
@@ -19,6 +19,14 @@
 
 resource "kubernetes_deployment_v1" "pytorch_ondemand" {
   depends_on = [kubernetes_namespace.management, null_resource.docker_build_and_push]
+  # Don't block (or fail) the apply on this background worker's rollout. It's a
+  # Recreate-strategy deployment on the build node (no image-prepuller), so on
+  # every image change it cold-pulls the ~28GB image (~6min) with 0 replicas Ready
+  # in the gap — which exceeds the default wait_for_rollout window and errors the
+  # apply even though it converges seconds later. The worker isn't user-facing;
+  # requesters fall through to in-pod builds while it's down. (Same as the
+  # pytorch-snapshot DaemonSet in git-cache.tf.)
+  wait_for_rollout = false
   metadata {
     name      = "pytorch-ondemand-builder"
     namespace = "management"


### PR DESCRIPTION
## Symptom

`tofu apply` errors on:
```
Error: Waiting for rollout to finish: 1 replicas wanted; 0 replicas Ready
  with kubernetes_deployment_v1.pytorch_ondemand
```
…but the deployment is actually healthy right after (revision converges, pod `1/1 Running`).

## Cause

The on-demand build worker is a **Recreate**-strategy Deployment pinned to the **build node, which has no image-prepuller**. On every image change it tears down the old pod first, then cold-pulls the **~28 GB** image (measured 5m42s) with **0 replicas Ready** in the gap. That exceeds terraform's default `wait_for_rollout` window → the apply fails, even though the rollout finishes seconds/minutes later. This will recur on *every* image rebuild.

## Fix

`wait_for_rollout = false` on this resource. It's a background worker (requesters fall through to in-pod builds while it's restarting), so the apply shouldn't block or fail on it. Mirrors the existing `pytorch-snapshot` DaemonSet (git-cache.tf:55).

tf-only, doesn't touch the docker image hash.