### PR TITLE
fix(image): pin dev/warm pods + prepuller to immutable hash tag (stop stale :latest serving + warm thrash)

### DIFF
--- a/terraform-gpu-devservers/kubernetes.tf
+++ b/terraform-gpu-devservers/kubernetes.tf
@@ -430,8 +430,13 @@ resource "kubernetes_daemonset" "image_prepuller" {
         }
 
         init_container {
-          name              = "pull-gpu-dev-image"
-          image             = local.latest_image_uri
+          name = "pull-gpu-dev-image"
+          # Pre-warm the SAME immutable hash tag the dev/warm pods use (see
+          # GPU_DEV_CONTAINER_IMAGE in lambda.tf). On a new hash this DS template
+          # changes -> rolls -> pulls the new tag onto every node, so by the time a
+          # pod referencing that tag is created, IfNotPresent finds it present (no
+          # per-pod 27GB pull, no stale :latest cache).
+          image             = local.full_image_uri
           image_pull_policy = "Always"
           command           = ["/bin/sh", "-c", "echo 'GPU dev image pulled successfully'"]
         }

--- a/terraform-gpu-devservers/lambda.tf
+++ b/terraform-gpu-devservers/lambda.tf
@@ -184,7 +184,7 @@ resource "aws_lambda_function" "reservation_processor" {
       QUEUE_URL                          = aws_sqs_queue.gpu_reservation_queue.url
       AVAILABILITY_UPDATER_FUNCTION_NAME = aws_lambda_function.availability_updater.function_name
       PRIMARY_AVAILABILITY_ZONE          = data.aws_availability_zones.available.names[0]
-      GPU_DEV_CONTAINER_IMAGE            = local.latest_image_uri # Use stable 'latest' tag so pods can restart after OOM
+      GPU_DEV_CONTAINER_IMAGE            = local.full_image_uri # Immutable hash tag (latest-<hash>): each rebuild = a tag the node hasn't seen, so IfNotPresent pulls the NEW image instead of serving a stale cached :latest. Fixes images (codex etc.) not reaching pods and stops the warm-rotation thrash (recycled pods come up on the new image, not the old cache). Tag is still stable/restartable (OOM-safe).
       EFS_SECURITY_GROUP_ID              = aws_security_group.efs_sg.id
       EFS_SUBNET_IDS                     = join(",", concat([aws_subnet.gpu_dev_subnet.id, aws_subnet.gpu_dev_subnet_secondary.id], length(aws_subnet.gpu_dev_subnet_tertiary) > 0 ? [aws_subnet.gpu_dev_subnet_tertiary[0].id] : []))
       CCACHE_SHARED_EFS_ID               = aws_efs_file_system.ccache_shared.id


### PR DESCRIPTION
## Root cause (the '3 hours and codex still hangs' bug)

Pods used **`:latest` + `imagePullPolicy: IfNotPresent`**. Images are cached **per node**. After a rebuild, a node that already has an old `:latest` cached **does not re-pull** — the kubelet serves the stale image to every new pod until the prepuller finishes re-pulling the **27 GB** image (~5–6 min × 24 nodes). 

Consequences observed live this session:
- A fresh cold reserve in that window got the **old (broken-codex)** image.
- The #199 warm rotation recycled old-image pods that **instantly came back on the cached old `:latest`** → recycled again → **thrash** (pods recreated every 1–2 s, none ever on the new image).

Verified: `:latest` digest was the new image, but **0 pods** were running it; all 24 prepuller pods were still mid-pull (`Init:0/1`).

## Fix

Pin dev + warm pods (`GPU_DEV_CONTAINER_IMAGE`) and the prepuller to the **immutable hash tag** `latest-<context-hash>` (`local.full_image_uri`) — the exact pattern #191 already uses for the build/ondemand jobs. Each rebuild = a tag the node has never seen, so `IfNotPresent` **pulls the new image** → guaranteed-correct, no stale window, and the warm rotation **converges** (a recycled pod can't come up on the old cache — it must pull the new tag). Prepuller pinned to the same tag so it pre-warms the exact ref.

- Tag is immutable/stable → OOM-restart still works (the original reason `:latest` was used).
- `ami-baker`/`eks` user-data keep `:latest` (boot-time **layer** prewarm; same digest → pod pull is manifest-only/fast). Correctness now comes from the hash tag, not the prewarm.
- **No docker files changed → no image rebuild on apply.** This is a lambda-env + prepuller-DS change only (fast apply).