### PR TITLE
fix(spot): disable warm pool on spot cluster + keep spot warm 25m after use

### DIFF
--- a/terraform-gpu-devservers/availability.tf
+++ b/terraform-gpu-devservers/availability.tf
@@ -130,7 +130,8 @@ resource "aws_iam_role_policy" "availability_updater_policy" {
         Effect = "Allow"
         Action = [
           "autoscaling:DescribeAutoScalingGroups",
-          "autoscaling:SetDesiredCapacity"
+          "autoscaling:SetDesiredCapacity",
+          "autoscaling:CreateOrUpdateTags"
         ]
         Resource = "*"
       },

--- a/terraform-gpu-devservers/lambda.tf
+++ b/terraform-gpu-devservers/lambda.tf
@@ -205,10 +205,16 @@ resource "aws_lambda_function" "reservation_processor" {
       # Warm-pool tier counts per workspace (JSON object). Staging is the "default"
       # workspace (us-west-1, environment=test) and only has t4 + cpu nodes, so
       # scope warm pods to those — the in-code default (h100/b200/MIG) would create
-      # unschedulable Pending pods here. Empty -> lambda falls back to
-      # _DEFAULT_WARM_TARGETS (prod keeps its h100/b200/cpu/MIG warm pool).
+      # unschedulable Pending pods here. prod-east1 is the SPOT cluster (scale-to-
+      # zero ASGs), where a warm pool is actively harmful: the warm pods can never
+      # schedule (no idle nodes), pile up Pending for hours, then grab the spot node
+      # the instant a real --spot reservation launches one — starving the
+      # reservation. So give it an EMPTY pool ("{}" -> no warm pods; note "" would
+      # fall back to the in-code default). Empty string -> _DEFAULT_WARM_TARGETS
+      # (prod us-east-2 keeps its h100/b200/cpu/MIG warm pool).
       WARM_POOL_TARGETS = lookup({
-        "default" = jsonencode({ t4 = 2, "cpu-x86" = 2, "cpu-arm" = 2 })
+        "default"    = jsonencode({ t4 = 2, "cpu-x86" = 2, "cpu-arm" = 2 })
+        "prod-east1" = jsonencode({})
       }, terraform.workspace, "")
       DISK_CONTENTS_BUCKET = aws_s3_bucket.disk_contents.bucket
       OPERATIONS_TABLE     = aws_dynamodb_table.operations.name

--- a/terraform-gpu-devservers/lambda/availability_updater/index.py
+++ b/terraform-gpu-devservers/lambda/availability_updater/index.py
@@ -6,6 +6,7 @@ Updates GPU availability table when ASG instances launch/terminate
 import json
 import logging
 import os
+import time
 from typing import Dict, Any
 
 import boto3
@@ -28,6 +29,12 @@ GPU_INSTANCE_TYPES = {
     "cpu-x86": "c7i.8xlarge", "cpu-arm": "c7g.8xlarge",
 }
 SPOT_GPU_TYPES = os.environ.get("SPOT_GPU_TYPES", "")
+# Keep an idle spot node warm this long after its last active reservation ended,
+# so back-to-back reservations reuse it instead of paying a cold spot re-launch
+# (which can also hit "no spot capacity"). Tracked via an ASG tag stamped each
+# tick a reservation is active.
+SPOT_KEEPALIVE_MINUTES = float(os.environ.get("SPOT_KEEPALIVE_MINUTES", "25"))
+SPOT_LAST_ACTIVE_TAG = "gpu-dev/spot-last-active"
 
 
 def get_spot_price_info(gpu_type: str) -> dict:
@@ -190,12 +197,41 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                                 break
                         if has_active:
                             break
-                    if not has_active:
+                    if has_active:
+                        # Stamp the ASG so we keep it warm for a grace period after
+                        # this reservation ends (see SPOT_KEEPALIVE_MINUTES).
+                        try:
+                            autoscaling.create_or_update_tags(Tags=[{
+                                "ResourceId": asg,
+                                "ResourceType": "auto-scaling-group",
+                                "Key": SPOT_LAST_ACTIVE_TAG,
+                                "Value": str(int(time.time())),
+                                "PropagateAtLaunch": False,
+                            }])
+                        except Exception as tag_err:
+                            logger.warning(f"could not stamp {SPOT_LAST_ACTIVE_TAG} on {asg}: {tag_err}")
+                    else:
                         resp = autoscaling.describe_auto_scaling_groups(AutoScalingGroupNames=[asg])
                         groups = resp.get("AutoScalingGroups", [])
                         if groups and groups[0]["DesiredCapacity"] > 0:
-                            logger.info(f"Scaling down idle spot ASG {asg} to 0")
-                            autoscaling.set_desired_capacity(AutoScalingGroupName=asg, DesiredCapacity=0)
+                            # Honor the keep-alive grace period: only scale to 0 once it's
+                            # been idle SPOT_KEEPALIVE_MINUTES past the last active reservation.
+                            last_active = 0
+                            for tag in groups[0].get("Tags", []):
+                                if tag.get("Key") == SPOT_LAST_ACTIVE_TAG:
+                                    try:
+                                        last_active = int(tag.get("Value") or 0)
+                                    except (ValueError, TypeError):
+                                        last_active = 0
+                                    break
+                            idle_for = time.time() - last_active if last_active else None
+                            if idle_for is not None and idle_for < SPOT_KEEPALIVE_MINUTES * 60:
+                                logger.info(
+                                    f"Spot ASG {asg} idle {int(idle_for)}s < grace "
+                                    f"{SPOT_KEEPALIVE_MINUTES}m — keeping warm")
+                            else:
+                                logger.info(f"Scaling down idle spot ASG {asg} to 0 (grace elapsed)")
+                                autoscaling.set_desired_capacity(AutoScalingGroupName=asg, DesiredCapacity=0)
                         else:
                             logger.debug(f"Spot ASG {asg} already at 0 or not found")
                 except Exception as sd_err:


### PR DESCRIPTION
## Why `--spot` B200/B300 never works (root cause)

Debugged live. Two things, neither is spot reclamation:

**1. A warm pool is running on the spot cluster (the real blocker).** `WARM_POOL_TARGETS` (lambda.tf) only special-cased the `default`/staging workspace; **`prod-east1` (the SPOT cluster, scale-to-zero ASGs) fell through to the in-code default `{h100, b200, MIG, cpu}` warm pool.** On scale-to-zero spot those warm pods can never schedule, so they **pile up Pending for hours** (found 24 warm pods, 18 Pending, some 9h old) and then **grab the spot node the instant a real `--spot` reservation launches one** — the reservation stays `queued` forever.

Confirmed: a `--spot b200` node came up Ready (8 GPUs, `GpuType=b200`, no taints) but was taken by `gpu-dev-b200-7bbc85` (`warm-state=ready`), not the reservation. After manually clearing the warm pods, `gpu-dev-51ac7e70` (a real `--spot b200`) scheduled and went **Running** — proving spot works once the warm pool isn't stealing nodes.

Fix: `WARM_POOL_TARGETS = jsonencode({})` for `prod-east1`.

**2. Spot keep-alive (requested).** `availability_updater` scaled idle spot ASGs to 0 the moment no reservation referenced them, so back-to-back reservations paid a cold spot re-launch (which can hit "no spot capacity"). Now it stamps an ASG tag while a reservation is active and only scales to 0 once idle past `SPOT_KEEPALIVE_MINUTES` (default **25m**). Adds `autoscaling:CreateOrUpdateTags`.

## Also confirmed (not in this PR)
- **On-demand B200 (us-east-2)** is capacity-blocked, not misconfig-fixable from here: all ASGs are pinned to AZ us-east-2b (cr3/cr4 hold 1 each; AWS has no more b200 in 2b — a/c have capacity but the ASGs/CRs are 2b-locked), and `b200-cr1`'s capacity reservation is `not valid` (expired).
- Spot capacity **is** available right now (a manual 0→2 scale-up launched 2 B200s Healthy; the demand-controller then scaled back to 0 since nothing referenced them — *not* a reclaim).

## Tests / deploy
44 availability unit tests pass. Needs `tofu apply` on **prod-east1** (the warm-pool env) and us-east-2 prod (the keep-alive). After the warm-pool fix, `--spot b200/b300` reservations get their nodes reliably.