### PR TITLE
fix(spot): avail --spot In-Use column + correct spot-reclaim message

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -3453,15 +3453,22 @@ def _show_availability(show_spot: bool = False) -> None:
                 spot_table = Table(title="⚡ Spot Instances (us-east-1, ~70% cheaper)")
                 spot_table.add_column("GPU Type", style="cyan")
                 spot_table.add_column("Avail\nNow", style="green")
+                spot_table.add_column("In\nUse", style="yellow")
                 spot_table.add_column("Per\nNode", style="bright_green")
                 spot_table.add_column("Status", style="magenta")
                 spot_table.add_column("Spot Discount", style="dim")
                 _on_demand = {"b300": 95, "b200": 95, "h200": 55, "h100": 98, "a100": 32, "t4": 4.5, "l4": 7}
                 for gt, info in sorted(spot_region_info.items()):
                     avail = info.get("available", 0)
+                    total = info.get("total", 0)
+                    in_use = max(0, total - avail)  # GPUs on up spot nodes already taken
                     per_node = spot_gpus_per_node.get(gt, 8)
                     avail_display = f"[green]{avail}[/green]" if avail > 0 else f"[dim]0[/dim]"
-                    status = "[green]Node up[/green]" if avail > 0 else "Spins up on reserve (~10 min)"
+                    in_use_display = f"[yellow]{in_use}[/yellow]" if in_use > 0 else f"[dim]0[/dim]"
+                    if in_use > 0:
+                        status = "[yellow]Node up (in use)[/yellow]" if avail == 0 else "[green]Node up[/green]"
+                    else:
+                        status = "[green]Node up[/green]" if avail > 0 else "Spins up on reserve (~10 min)"
                     si = info.get("spot_info", {}) or {}
                     sp = si.get("spot_price", "") if isinstance(si, dict) else ""
                     if not sp or (isinstance(si, dict) and "No spot data" in str(si.get("spot_signal", ""))):
@@ -3473,7 +3480,7 @@ def _show_availability(show_spot: bool = False) -> None:
                             avail_signal = f"[green]{pct}% off on-demand[/green]" if pct > 0 else "[dim]At on-demand price[/dim]"
                         except (ValueError, TypeError):
                             avail_signal = "[yellow]Unknown[/yellow]"
-                    spot_table.add_row(f"{gt.upper()} *", avail_display, str(per_node), status, avail_signal)
+                    spot_table.add_row(f"{gt.upper()} *", avail_display, in_use_display, str(per_node), status, avail_signal)
                 console.print(spot_table)
                 rprint("[dim]* = spot: ~70% cheaper, AWS can reclaim with 2-min notice, fulfillment not guaranteed.[/dim]")
                 rprint("[dim]  Separate cluster (us-east-1) with separate disks. Select via gpu-dev reserve (interactive).[/dim]")

--- a/terraform-gpu-devservers/availability.tf
+++ b/terraform-gpu-devservers/availability.tf
@@ -130,7 +130,8 @@ resource "aws_iam_role_policy" "availability_updater_policy" {
         Effect = "Allow"
         Action = [
           "autoscaling:DescribeAutoScalingGroups",
-          "autoscaling:SetDesiredCapacity"
+          "autoscaling:SetDesiredCapacity",
+          "autoscaling:CreateOrUpdateTags"
         ]
         Resource = "*"
       },

--- a/terraform-gpu-devservers/lambda.tf
+++ b/terraform-gpu-devservers/lambda.tf
@@ -205,10 +205,16 @@ resource "aws_lambda_function" "reservation_processor" {
       # Warm-pool tier counts per workspace (JSON object). Staging is the "default"
       # workspace (us-west-1, environment=test) and only has t4 + cpu nodes, so
       # scope warm pods to those — the in-code default (h100/b200/MIG) would create
-      # unschedulable Pending pods here. Empty -> lambda falls back to
-      # _DEFAULT_WARM_TARGETS (prod keeps its h100/b200/cpu/MIG warm pool).
+      # unschedulable Pending pods here. prod-east1 is the SPOT cluster (scale-to-
+      # zero ASGs), where a warm pool is actively harmful: the warm pods can never
+      # schedule (no idle nodes), pile up Pending for hours, then grab the spot node
+      # the instant a real --spot reservation launches one — starving the
+      # reservation. So give it an EMPTY pool ("{}" -> no warm pods; note "" would
+      # fall back to the in-code default). Empty string -> _DEFAULT_WARM_TARGETS
+      # (prod us-east-2 keeps its h100/b200/cpu/MIG warm pool).
       WARM_POOL_TARGETS = lookup({
-        "default" = jsonencode({ t4 = 2, "cpu-x86" = 2, "cpu-arm" = 2 })
+        "default"    = jsonencode({ t4 = 2, "cpu-x86" = 2, "cpu-arm" = 2 })
+        "prod-east1" = jsonencode({})
       }, terraform.workspace, "")
       DISK_CONTENTS_BUCKET = aws_s3_bucket.disk_contents.bucket
       OPERATIONS_TABLE     = aws_dynamodb_table.operations.name

--- a/terraform-gpu-devservers/lambda/availability_updater/index.py
+++ b/terraform-gpu-devservers/lambda/availability_updater/index.py
@@ -6,6 +6,7 @@ Updates GPU availability table when ASG instances launch/terminate
 import json
 import logging
 import os
+import time
 from typing import Dict, Any
 
 import boto3
@@ -28,6 +29,12 @@ GPU_INSTANCE_TYPES = {
     "cpu-x86": "c7i.8xlarge", "cpu-arm": "c7g.8xlarge",
 }
 SPOT_GPU_TYPES = os.environ.get("SPOT_GPU_TYPES", "")
+# Keep an idle spot node warm this long after its last active reservation ended,
+# so back-to-back reservations reuse it instead of paying a cold spot re-launch
+# (which can also hit "no spot capacity"). Tracked via an ASG tag stamped each
+# tick a reservation is active.
+SPOT_KEEPALIVE_MINUTES = float(os.environ.get("SPOT_KEEPALIVE_MINUTES", "25"))
+SPOT_LAST_ACTIVE_TAG = "gpu-dev/spot-last-active"
 
 
 def get_spot_price_info(gpu_type: str) -> dict:
@@ -190,12 +197,41 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                                 break
                         if has_active:
                             break
-                    if not has_active:
+                    if has_active:
+                        # Stamp the ASG so we keep it warm for a grace period after
+                        # this reservation ends (see SPOT_KEEPALIVE_MINUTES).
+                        try:
+                            autoscaling.create_or_update_tags(Tags=[{
+                                "ResourceId": asg,
+                                "ResourceType": "auto-scaling-group",
+                                "Key": SPOT_LAST_ACTIVE_TAG,
+                                "Value": str(int(time.time())),
+                                "PropagateAtLaunch": False,
+                            }])
+                        except Exception as tag_err:
+                            logger.warning(f"could not stamp {SPOT_LAST_ACTIVE_TAG} on {asg}: {tag_err}")
+                    else:
                         resp = autoscaling.describe_auto_scaling_groups(AutoScalingGroupNames=[asg])
                         groups = resp.get("AutoScalingGroups", [])
                         if groups and groups[0]["DesiredCapacity"] > 0:
-                            logger.info(f"Scaling down idle spot ASG {asg} to 0")
-                            autoscaling.set_desired_capacity(AutoScalingGroupName=asg, DesiredCapacity=0)
+                            # Honor the keep-alive grace period: only scale to 0 once it's
+                            # been idle SPOT_KEEPALIVE_MINUTES past the last active reservation.
+                            last_active = 0
+                            for tag in groups[0].get("Tags", []):
+                                if tag.get("Key") == SPOT_LAST_ACTIVE_TAG:
+                                    try:
+                                        last_active = int(tag.get("Value") or 0)
+                                    except (ValueError, TypeError):
+                                        last_active = 0
+                                    break
+                            idle_for = time.time() - last_active if last_active else None
+                            if idle_for is not None and idle_for < SPOT_KEEPALIVE_MINUTES * 60:
+                                logger.info(
+                                    f"Spot ASG {asg} idle {int(idle_for)}s < grace "
+                                    f"{SPOT_KEEPALIVE_MINUTES}m — keeping warm")
+                            else:
+                                logger.info(f"Scaling down idle spot ASG {asg} to 0 (grace elapsed)")
+                                autoscaling.set_desired_capacity(AutoScalingGroupName=asg, DesiredCapacity=0)
                         else:
                             logger.debug(f"Spot ASG {asg} already at 0 or not found")
                 except Exception as sd_err:

--- a/terraform-gpu-devservers/lambda/reservation_expiry/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_expiry/index.py
@@ -1293,13 +1293,24 @@ def expire_reservation_due_to_missing_pod(reservation: dict[str, Any]) -> None:
 
         reason = "Pod was removed outside of reservation system"
         if is_spot:
+            # A spot reservation losing its pod is almost always an AWS spot
+            # reclaim — default to a spot-aware message and refine via EC2 if the
+            # node is still describable. (node_ip is the node's PUBLIC ip on the
+            # spot path, so the old private-ip-only lookup never matched and it
+            # fell back to the generic message.)
+            reason = f"Spot instance reclaimed by AWS ({gpu_type.upper()})"
             node_ip = reservation.get("node_ip", "")
             if node_ip:
                 try:
                     ec2 = boto3.client("ec2", region_name=os.environ.get("REGION", "us-east-1"))
+                    # node_ip may be public or private depending on the path — try both.
                     instances = ec2.describe_instances(
                         Filters=[{"Name": "private-ip-address", "Values": [node_ip]}]
                     ).get("Reservations", [])
+                    if not instances:
+                        instances = ec2.describe_instances(
+                            Filters=[{"Name": "ip-address", "Values": [node_ip]}]
+                        ).get("Reservations", [])
                     for r in instances:
                         for inst in r.get("Instances", []):
                             state_reason = inst.get("StateTransitionReason", "")


### PR DESCRIPTION
Two spot UX fixes found while debugging a B200 spot reclaim (51ac7e70).

**1. `avail --spot` In-Use column.** The spot table only had `Avail Now`, so a spot node that's up but fully reserved looked like nothing existed. Added an **In Use** column (`total - available`) and a `Node up (in use)` status. Now a live-but-taken spot node is visible.

**2. Spot-reclaim message was generic.** When AWS reclaims a spot node, the reservation showed `failure_reason = "Pod was removed outside of reservation system"`. The detection logic existed but looked up the EC2 instance by **private-ip-address** — and `node_ip` on the spot path is the node's **public** IP, so it never matched and fell back to the generic message. Fix: default a spot reservation's missing-pod reason to **`Spot instance reclaimed by AWS (<TYPE>)`**, and try both `private-ip-address` and `ip-address` filters to refine from EC2 state.

Confirmed live: `51ac7e70`'s B200 was reclaimed (`Server.SpotInstanceTermination` at 20:53:16Z) but the reservation showed the generic message; CLI already surfaces `failure_reason`, so this makes it read correctly.

Deploy: CLI change is immediate (editable install); the message fix needs `tofu apply` on prod-east1 (spot expiry lambda).