### PR TITLE
fix(connect): verify proxy TLS via certifi (fix macOS CERTIFICATE_VERIFY_FAILED)

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/ssh_proxy.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/ssh_proxy.py
@@ -55,11 +55,23 @@ async def tunnel_ssh(target_host: str, target_port: int):
     # WebSocket URL - wss:// for secure WebSocket
     ws_url = f"wss://{proxy_host}/tunnel/{target_host}"
 
+    # Verify TLS against certifi's CA bundle. The default SSL context uses the OS
+    # trust store, which on macOS python.org builds is often empty
+    # ("unable to get local issuer certificate" / CERTIFICATE_VERIFY_FAILED).
+    # certifi ships the Mozilla bundle, so this works without the manual
+    # "Install Certificates.command" step.
+    ssl_ctx = ssl_module.create_default_context()
+    try:
+        import certifi
+        ssl_ctx.load_verify_locations(certifi.where())
+    except Exception:
+        pass  # fall back to the default trust store
+
     last_exc = None
     for attempt in range(MAX_RETRIES):
         try:
             async with websockets.connect(
-                ws_url, open_timeout=20,
+                ws_url, ssl=ssl_ctx, open_timeout=20,
                 ping_interval=30, ping_timeout=10,
             ) as websocket:
                 # Set up stdin/stdout for SSH

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.7.10"
+version = "0.7.11"
 description = "CLI + Python SDK for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"


### PR DESCRIPTION
`gpu-dev connect` tunnels SSH through `wss://ssh.devservers.io`, but `ssh_proxy.py` used the default SSL context (OS trust store). On macOS python.org builds that store is often empty → **`unable to get local issuer certificate` / CERTIFICATE_VERIFY_FAILED**, so connect fails (hit by tushar00jain from their Mac). Fix: load **certifi**'s Mozilla CA bundle into the SSL context (certifi is already a dependency) and pass it to `websockets.connect` — no manual `Install Certificates.command` needed. Bumps 0.7.10 → 0.7.11 for release.