### PR TITLE
fix(jupyter): launch jupyter-lab via PATH not dead /opt/conda path (fixes 503)

### DIFF
--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -6328,7 +6328,7 @@ EOF
                             # Only start Jupyter if enabled at creation time
                             if [ "$JUPYTER_ENABLED" = "true" ]; then
                                 echo "[STARTUP] Starting Jupyter Lab in background..."
-                                nohup su - dev -c "cd /workspace && /opt/conda/bin/jupyter-lab --config=/home/dev/.jupyter/jupyter_lab_config.py" > /tmp/jupyter.log 2>&1 &
+                                nohup su - dev -c "cd /workspace && $(command -v jupyter-lab || echo /usr/local/bin/jupyter-lab) --config=/home/dev/.jupyter/jupyter_lab_config.py" > /tmp/jupyter.log 2>&1 &
                                 echo "[STARTUP] Jupyter Lab started (check /tmp/jupyter.log for details)"
                             else
                                 echo "[STARTUP] Jupyter Lab configured but not started (use 'gpu-dev edit --enable-jupyter' to enable)"
@@ -9296,7 +9296,7 @@ def enable_jupyter_in_pod(
 
             # Start Jupyter as dev user in background (config already exists)
             echo "Starting Jupyter Lab with existing config..."
-            nohup su - dev -c "cd /workspace && /opt/conda/bin/jupyter-lab --config=/home/dev/.jupyter/jupyter_lab_config.py" > /tmp/jupyter.log 2>&1 &
+            nohup su - dev -c "cd /workspace && $(command -v jupyter-lab || echo /usr/local/bin/jupyter-lab) --config=/home/dev/.jupyter/jupyter_lab_config.py" > /tmp/jupyter.log 2>&1 &
 
             # Wait for startup
             sleep 3


### PR DESCRIPTION
New base image (pytorch 2.12.0-cuda13.2) moved Python /opt/conda → /usr/local, so `jupyter-lab` is at `/usr/local/bin/jupyter-lab`. The startup hard-coded `/opt/conda/bin/jupyter-lab` → launch fails, nothing binds :8888, ALB returns **503** for every Jupyter URL (hit on mystic_dingo-2 / wdvr + xmfan). Fix: resolve via PATH at both launch sites. Verified: after launching the right binary the URL returns 302. Live pods monkey-patched separately.