### PR TITLE
fix(submit): --ref staging gate + torch rebuild (no root-owned tree / import mismatch)

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -1724,6 +1724,47 @@ _SUBMIT_GPU_TYPES = ["b300", "b200", "b200-mig-1g", "b200-mig-2g", "b200-mig-3g"
                      "a10g", "t4", "l4", "t4-small", "cpu-arm", "cpu-x86", "cpu-spot"]
 
 
+def _build_submit_remote_script(workdir: str, remote_cmd: str, ref: Optional[str],
+                                no_build: bool) -> str:
+    """Build the remote shell script `submit` runs over SSH (under `bash -lc`).
+
+    Without --ref this is just `cd <workdir> && <cmd>`. With --ref the pytorch
+    tree is staged in the *background* in-pod (stage-pytorch &), and the tree is
+    only chowned to dev + the ref fully checked out at the very end. Running the
+    user command before that finishes is the footgun Driss hit: a root-owned tree
+    (git "dubious ownership") and a source/installed-torch mismatch (the ref is
+    checked out but the prebuilt .so is the stale base build -> `import torch`
+    fails). So with --ref we prepend a preamble that:
+      1. waits for staging to finish (`.pytorch-staging` marker removed at end),
+      2. marks /home/dev/pytorch a git safe.directory for the dev user,
+      3. unless --no-build, rebuilds incrementally so installed torch == the
+         checked-out source (warm build/ -> ~tens of seconds; a rebuild failure
+         exits 90 before the user command runs).
+    The rebuild/safe.directory only touch pytorch when staging actually ran
+    (`.pytorch-ready` present), so --disk reservations (ref ignored, no staging)
+    are unaffected.
+    """
+    import shlex
+    cd_run = f"cd {shlex.quote(workdir)} && {remote_cmd}"
+    if not ref:
+        return cd_run
+    lines = [
+        'if [ -e /home/dev/.pytorch-staging ]; then',
+        '  echo "[gpu-dev] waiting for background pytorch --ref staging to finish…"',
+        '  for _i in $(seq 1 3600); do [ -e /home/dev/.pytorch-staging ] || break; sleep 1; done',
+        'fi',
+        'if [ -f /home/dev/.pytorch-ready ]; then',
+        '  git config --global --add safe.directory /home/dev/pytorch 2>/dev/null || true',
+    ]
+    if not no_build:
+        lines += [
+            '  echo "[gpu-dev] rebuilding torch to match --ref (pip install -e . --no-build-isolation)…"',
+            '  ( cd /home/dev/pytorch && pip install -e . --no-build-isolation ) || { echo "[gpu-dev] torch rebuild failed"; exit 90; }',
+        ]
+    lines += ['fi', cd_run]
+    return "\n".join(lines)
+
+
 @main.command(context_settings={"ignore_unknown_options": True})
 @click.option("--gpu-type", type=click.Choice(_SUBMIT_GPU_TYPES, case_sensitive=False), default="a100", show_default=True)
 @click.option("--gpus", type=int, default=1, show_default=True, help="GPU count (multinode if > per-node max).")
@@ -1743,6 +1784,8 @@ _SUBMIT_GPU_TYPES = ["b300", "b200", "b200-mig-1g", "b200-mig-2g", "b200-mig-3g"
 @click.option("--runtime", type=click.Path(exists=True, file_okay=False, resolve_path=True), default=None,
               help="Local directory to rsync to /workspace/submit-<id>/ on master node before run.")
 @click.option("--no-pull", is_flag=True, help="Skip syncing the remote workspace back to --runtime after the job finishes.")
+@click.option("--no-build", is_flag=True,
+              help="With --ref, skip the incremental torch rebuild before the command (Python-only PRs / quick checks). Default: rebuild so `import torch` reflects the ref.")
 @click.option("--keep-alive", is_flag=True, help="Don't cancel the reservation when the job exits.")
 @click.option("--name", type=str, default=None, help="Reservation name.")
 @click.option("--timeout", type=int, default=24 * 60, show_default=True,
@@ -1750,7 +1793,7 @@ _SUBMIT_GPU_TYPES = ["b300", "b200", "b200-mig-1g", "b200-mig-2g", "b200-mig-3g"
 @click.argument("command", nargs=-1, required=True)
 @click.pass_context
 def submit(ctx, gpu_type, gpus, hours, disk, ref, no_persistent_disk, spot, dockerfile, dockerimage, preserve_entrypoint,
-           runtime, no_pull, keep_alive, name, timeout, command):
+           runtime, no_pull, no_build, keep_alive, name, timeout, command):
     """Submit a job: reserve, sync code, run, sync results back, auto-cancel.
 
     \b
@@ -1961,11 +2004,15 @@ def submit(ctx, gpu_type, gpus, hours, disk, ref, no_persistent_disk, spot, dock
         else:
             workdir = "/home/dev"
 
-        # Run remote command via login shell so MULTINODE_* etc. are loaded
+        # Run remote command via login shell so MULTINODE_* etc. are loaded. With
+        # --ref, the script first waits for background pytorch staging + rebuilds
+        # so `import torch` matches the checked-out ref (see helper docstring).
         remote_cmd = " ".join(shlex.quote(c) for c in command)
         rprint(f"[cyan]🚀 Running on {ssh_alias}: {remote_cmd}[/cyan]\n")
-        ssh_run = ssh_base + [ssh_alias,
-                              f"cd {shlex.quote(workdir)} && bash -lc {shlex.quote(remote_cmd)}"]
+        if ref and not no_build:
+            rprint("[dim]   (--ref: will wait for staging + rebuild torch first; pass --no-build to skip)[/dim]")
+        remote_script = _build_submit_remote_script(workdir, remote_cmd, ref, no_build)
+        ssh_run = ssh_base + [ssh_alias, f"bash -lc {shlex.quote(remote_script)}"]
         rc = subprocess.call(ssh_run)
         rprint(f"\n[dim]Job exited with code {rc}[/dim]")
 

--- a/docs/GPU_DEV_SUBMIT.md
+++ b/docs/GPU_DEV_SUBMIT.md
@@ -1,0 +1,89 @@
+# `gpu-dev submit` — guide & footguns
+
+`gpu-dev submit` reserves a box, (optionally) rsyncs a local dir up, runs your
+command over SSH, syncs results back, and auto-cancels. It's the non-interactive
+sibling of `gpu-dev reserve` — good for CI-style validation, one-shot test runs,
+and scripted repros.
+
+```bash
+# run a script in a local dir on 1x H100, sync results back, auto-cancel
+gpu-dev submit --runtime ./ --gpu-type h100 -- bash run.sh
+
+# validate a PyTorch PR's tests on H100 (stages + builds the PR for you)
+gpu-dev submit --gpu-type h100 --no-persistent-disk --ref pr/186015 -- \
+    python test/test_foo.py -k some_test
+
+# keep the box after the job (debug a failure interactively)
+gpu-dev submit --keep-alive --gpu-type h100 -- pytest test/test_x.py
+```
+
+Exit code = your command's exit code (so it composes in scripts/CI).
+
+---
+
+## Footguns (read before your first `--ref` run)
+
+### 1. `--ref` stages PyTorch in the background — `submit` now waits for it
+With `--ref`, the in-pod startup checks out your ref into `/home/dev/pytorch`
+**in the background** and only chowns the tree to `dev` + finishes the checkout
+at the very end. Historically `submit` could SSH in and run your command before
+that finished, so you'd hit:
+- a **root-owned** `/home/dev/pytorch` (git: *"detected dubious ownership"*), and
+- a **source/installed-torch mismatch** → `import torch` fails (the ref source is
+  checked out but the importable `.so` is still the stale prebuilt base).
+
+`submit` now **waits for staging to complete**, marks the tree a git
+`safe.directory`, and (by default) **rebuilds incrementally** so the installed
+torch matches the checked-out ref before your command runs. You don't need the
+`sudo chown` / `safe.directory` workaround anymore.
+
+### 2. `--ref` rebuilds torch by default — use `--no-build` to skip
+The dropped-in `build/` + `.so` come from the **base** tree, not your ref. To make
+`import torch` reflect your ref's compiled (C++/CUDA) changes, `submit --ref`
+runs `pip install -e . --no-build-isolation` (incremental, warm `build/` →
+typically tens of seconds; a cold/cross-arch build is much longer).
+
+- Pass **`--no-build`** for Python-only PRs or quick checks — skips the rebuild
+  (import still works; it just won't include compiled changes).
+- A rebuild failure exits **90** *before* your command runs (so a broken build
+  doesn't masquerade as a test failure).
+
+### 3. Prebuilt fast path is **prod-arch only** (H100 / B200)
+The by-SHA / viable-strict prebuilt trees are compiled for `sm_90;sm_100`
+(H100/B200). On other GPU types (t4, a100, l4, …) or staging there's no matching
+prebuilt, so `--ref` falls back to a **full from-scratch build** — slow. Validate
+ref-based jobs on `--gpu-type h100` (or `b200`).
+
+### 4. `--ref` is ignored with `--disk`
+A persistent disk brings its own `/home/dev/pytorch`; `--ref` does **not** stage
+onto a `--disk` reservation (and `submit` won't rebuild it). Use
+`--no-persistent-disk` (or omit `--disk`) when you want a ref staged.
+
+### 5. `--preserve-entrypoint` needs SSH
+`submit` runs your command over SSH, so a custom image with
+`--preserve-entrypoint` must still expose the SSH harness or `submit` can't reach
+it. For pure entrypoint containers, use `reserve`, not `submit`.
+
+### 6. Results sync-back is best-effort
+With `--runtime`, output is rsync'd back to your local dir when the job exits
+(unless `--no-pull`). If the box dies mid-job (spot reclaim, expiry) the sync-back
+may be partial — you'll see a warning. For long jobs prefer `--keep-alive` and
+pull manually, or write important artifacts to `/shared-personal` (persists
+across reservations).
+
+### 7. `--hours` is a ceiling, not the runtime
+It's the reservation lifetime cap; the job auto-cancels as soon as your command
+exits (unless `--keep-alive`). Set it high enough that queueing + build + run fit.
+
+---
+
+## Finding footguns early
+
+- `gpu-dev submit --keep-alive … -- true` then `gpu-dev connect <id>` — get a
+  box in the exact submit state and poke around before committing a real run.
+- With `--ref`, watch staging directly: `tail -f /home/dev/.pytorch-staging.log`
+  in the pod; `.pytorch-ready` (HEAD sha) is written when staging is done.
+- `python -c "import torch; print(torch.__file__, torch.version.git_version)"`
+  confirms which torch you're actually importing vs. the ref you asked for.
+
+Found a new one? Add it here and ping `oncall:pytorch_release_engineering`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.7.11"
+version = "0.7.12"
 description = "CLI + Python SDK for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"

--- a/tests/unit/cli/test_submit.py
+++ b/tests/unit/cli/test_submit.py
@@ -19,10 +19,56 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from gpu_dev_cli.cli import main
+from gpu_dev_cli.cli import main, _build_submit_remote_script
 
 
 USER_INFO = {"user_id": "u-123", "github_user": "octocat"}
+
+
+# ---------------------------------------------------------------------------
+# _build_submit_remote_script — the --ref staging-gate + rebuild preamble
+# (regression for Driss's footguns: root-owned tree + source/installed mismatch)
+# ---------------------------------------------------------------------------
+def test_remote_script_no_ref_is_plain_cd_run():
+    s = _build_submit_remote_script("/workspace/x", "python a.py", ref=None, no_build=False)
+    assert s == "cd /workspace/x && python a.py"
+    assert "pytorch-staging" not in s
+    assert "no-build-isolation" not in s
+
+
+def test_remote_script_with_ref_waits_and_rebuilds():
+    s = _build_submit_remote_script("/home/dev", "pytest q.py", ref="pr/123", no_build=False)
+    # waits for the background staging marker
+    assert "/home/dev/.pytorch-staging" in s
+    # only acts once staging actually completed
+    assert "/home/dev/.pytorch-ready" in s
+    # marks safe.directory for the dev user (fixes git "dubious ownership")
+    assert "safe.directory /home/dev/pytorch" in s
+    # rebuilds so installed torch matches the checked-out ref
+    assert "pip install -e . --no-build-isolation" in s
+    # user command still runs last, in the workdir
+    assert s.rstrip().endswith("cd /home/dev && pytest q.py")
+
+
+def test_remote_script_ref_no_build_skips_rebuild():
+    s = _build_submit_remote_script("/home/dev", "pytest q.py", ref="pr/123", no_build=True)
+    assert "/home/dev/.pytorch-staging" in s          # still waits for staging
+    assert "safe.directory /home/dev/pytorch" in s     # still fixes ownership
+    assert "no-build-isolation" not in s               # but no rebuild
+    assert s.rstrip().endswith("cd /home/dev && pytest q.py")
+
+
+def test_remote_script_quotes_workdir():
+    s = _build_submit_remote_script("/work space/x", "echo hi", ref=None, no_build=False)
+    assert "'/work space/x'" in s
+
+
+def test_no_build_flag_threaded_and_defaults_false(cli_runner):
+    # --no-build is accepted; with --ref it changes the rebuild preamble. Here we
+    # just assert the flag parses (reservation returns None -> exit 2).
+    res, rm = _run(cli_runner, ["--ref", "pr/1", "--no-build", "--", "x"])
+    assert res.exit_code == 2
+    rm.create_reservation.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem (reported by drisspg validating `gpu-dev submit` on H100)

`gpu-dev submit --ref …` hit two footguns:

1. **`import torch` failed** — the ref is checked out into `/home/dev/pytorch`, but the dropped-in `.so` is the stale prebuilt **base** tree. `stage-pytorch` only sets PYTHONPATH / leaves the build alone when **no** ref is applied (`index.py:6021`); with a ref it just prints a *"rebuild: pip install -e ."* hint. So source ≠ installed torch.
2. **`/home/dev/pytorch` root-owned** (git *"detected dubious ownership"*) — `stage-pytorch` runs in the **background** (`index.py:6063`) and only `chown`s to dev at the very end, but `submit` SSHed in and ran the command before staging finished. Nothing waited on it (grep: no `.pytorch-ready` gate anywhere).

Driss worked around it with `sudo chown` + `git config safe.directory` baked into his local gpu-dev skill, and asked for a footguns list to catch these early.

## Fix (CLI-only)

`submit` now builds its remote command via `_build_submit_remote_script()`. With `--ref` it prepends a preamble that:
1. **waits** for the background staging marker (`/home/dev/.pytorch-staging`) to clear,
2. marks `/home/dev/pytorch` a git `safe.directory` for `dev`,
3. unless **`--no-build`**, **rebuilds incrementally** (`pip install -e . --no-build-isolation`) so installed torch matches the checked-out ref.

Guarded on `.pytorch-ready` so `--disk` reservations (ref ignored, no staging) are untouched. A rebuild failure exits **90** before the user command runs (so a broken build isn't mistaken for a test failure). No more manual `chown`/`safe.directory`.

- New **`--no-build`** flag (Python-only PRs / quick checks).
- **docs/GPU_DEV_SUBMIT.md** — user-facing guide + footguns list (the "find footguns early" ask).

## Tests

- `_build_submit_remote_script` unit tests: no-ref → plain `cd && cmd`; `--ref` → staging wait + safe.directory + rebuild; `--no-build` → no rebuild; workdir quoting; `--no-build` flag threading.
- Full unit suite: **1174 passed**.

## Notes

- Version bumped **0.7.11 → 0.7.12** — needs a tag/PyPI release for users (incl. Driss) to get it. CLI-only; **no `tofu apply`** required.
- Out of scope (flagged separately): `pytorch_ref` isn't persisted to the reservation record (`list` shows no ref); interactive `reserve --ref` still leaves the rebuild to the user by design.