### PR TITLE
chore(image): re-fetch latest Claude Code (native, validated 2.1.170)

### DIFF
--- a/terraform-gpu-devservers/docker/Dockerfile
+++ b/terraform-gpu-devservers/docker/Dockerfile
@@ -148,12 +148,13 @@ COPY ssh_config /etc/ssh/sshd_config
 # Bump CLAUDE_CODE_BUILD to bust the layer cache and re-fetch the latest Claude Code
 # (the installer always grabs latest; without a bump Docker reuses the cached layer).
 USER root
-ARG CLAUDE_CODE_BUILD=2026-05-29
+ARG CLAUDE_CODE_BUILD=2026-06-09
 RUN echo "Claude Code build marker: $CLAUDE_CODE_BUILD" && \
     curl -fsSL https://claude.ai/install.sh | HOME=/opt/claude bash || echo "Claude native install failed (non-fatal at build time)"
 RUN if [ -e /opt/claude/.local/bin/claude ]; then \
         ln -sf /opt/claude/.local/bin/claude /usr/local/bin/claude; \
         chmod -R a+rX /opt/claude; \
+        echo "Installed Claude Code (native): $(/usr/local/bin/claude --version 2>/dev/null || echo unknown)"; \
     fi
 
 # Set up npm global directory for dev user (kept for ad-hoc dev-installed CLIs).


### PR DESCRIPTION
Bump `CLAUDE_CODE_BUILD` 2026-05-29 → 2026-06-09 so the next image build re-runs the **native** installer (`claude.ai/install.sh` → `/opt/claude`, **not** npm) and picks up the latest release.

- **Validated** latest = **2.1.170** today via `downloads.claude.ai/claude-code-releases/latest` (what `install.sh` resolves).
- **Not pinned** — still 'use latest'; the marker only busts the Docker layer cache.
- Added a build-time `claude --version` echo so each rebuild logs exactly what it got.

Image-only — no PyPI/version bump, no code. **Needs an image rebuild to take effect** (and, after that, the prepuller restart + warm-pod recycle so running nodes pick up the new `:latest`).