### PR TITLE
fix(expiry): clean up dead/evicted pods + give CPU pods a whole node

### DIFF
--- a/terraform-gpu-devservers/lambda/reservation_expiry/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_expiry/index.py
@@ -45,6 +45,9 @@ DISKS_TABLE = os.environ.get("DISKS_TABLE_NAME", "pytorch-gpu-dev-disks")
 EKS_CLUSTER_NAME = os.environ["EKS_CLUSTER_NAME"]
 REGION = os.environ["REGION"]
 
+# Name of the main dev container in every reservation pod (the one users SSH into).
+MAIN_CONTAINER = "gpu-dev"
+
 # Global Kubernetes client (reused across Lambda execution)
 _k8s_client = None
 
@@ -499,18 +502,36 @@ def handler(event, context):
                                 f"Could not parse launched_at for reservation {reservation_id}: {e}"
                             )
 
-                    if not skip_pod_check and not check_pod_exists(pod_name):
-                        logger.warning(
-                            f"Pod {pod_name} for active reservation {reservation_id} no longer exists - marking as expired"
-                        )
-                        try:
-                            expire_reservation_due_to_missing_pod(reservation)
-                            expired_count += 1
-                            continue  # Skip warning processing for this reservation
-                        except Exception as e:
-                            logger.error(
-                                f"Failed to expire reservation {reservation_id} due to missing pod: {e}"
+                    if not skip_pod_check:
+                        if not check_pod_exists(pod_name):
+                            logger.warning(
+                                f"Pod {pod_name} for active reservation {reservation_id} no longer exists - marking as expired"
                             )
+                            try:
+                                expire_reservation_due_to_missing_pod(reservation)
+                                expired_count += 1
+                                continue  # Skip warning processing for this reservation
+                            except Exception as e:
+                                logger.error(
+                                    f"Failed to expire reservation {reservation_id} due to missing pod: {e}"
+                                )
+                        else:
+                            # Pod exists but may have died in place (node-pressure
+                            # eviction / preemption). A container-level OOMKill is
+                            # recoverable (kubelet restarts it) and returns None here.
+                            dead_reason = check_pod_dead(pod_name)
+                            if dead_reason:
+                                logger.warning(
+                                    f"Pod {pod_name} for active reservation {reservation_id} is dead ({dead_reason}) - finalizing"
+                                )
+                                try:
+                                    expire_reservation_due_to_dead_pod(reservation, dead_reason)
+                                    expired_count += 1
+                                    continue  # Skip warning processing for this reservation
+                                except Exception as e:
+                                    logger.error(
+                                        f"Failed to finalize dead-pod reservation {reservation_id}: {e}"
+                                    )
 
                 minutes_until_expiry = (expires_at - current_time) // 60
                 warnings_sent = reservation.get("warnings_sent", {})
@@ -996,6 +1017,70 @@ def check_pod_oom_status(pod_name: str, namespace: str = "gpu-dev") -> dict:
         return result
 
 
+def check_pod_dead(pod_name: str, namespace: str = "gpu-dev") -> str | None:
+    """Return a human-readable reason if the pod is in a terminal, UNRECOVERABLE
+    state, else None.
+
+    The distinction that matters: a container-level OOMKill or crash is recoverable
+    — kubelet restarts the container in place (restartPolicy defaults to Always), so
+    SSH comes back and we must NOT clean these up. But a *pod-level* failure (node
+    memory/disk-pressure eviction, preemption, node loss) terminates the whole pod
+    and nothing recreates it (dev pods are bare V1Pods, not managed by a controller),
+    so the reservation would otherwise hang 'active' with a dead box until expiry.
+
+    Detected as dead:
+      - phase Failed/Succeeded (kubelet sets phase=Failed reason=Evicted on
+        node-pressure eviction)
+      - a DisruptionTarget condition (eviction/preemption) while the main container
+        is no longer running
+    Returns None for healthy, Pending, or merely-restarting pods.
+    """
+    try:
+        k8s_client = get_k8s_client()
+        v1 = client.CoreV1Api(k8s_client)
+        pod = v1.read_namespaced_pod(name=pod_name, namespace=namespace)
+    except client.exceptions.ApiException as e:
+        if e.status == 404:
+            return None  # missing pod is handled by the separate missing-pod path
+        logger.warning(f"Error reading pod {pod_name} for dead check: {e}")
+        return None
+    except Exception as e:
+        logger.warning(f"Error reading pod {pod_name} for dead check: {e}")
+        return None
+
+    status = pod.status
+    if not status:
+        return None
+
+    phase = status.phase or ""
+
+    def _short(msg: str) -> str:
+        msg = (msg or "").strip()
+        return msg.split("\n")[0][:300] if msg else ""
+
+    # Terminal phase: eviction (Failed/Evicted), node loss, or clean exit.
+    if phase in ("Failed", "Succeeded"):
+        reason = getattr(status, "reason", None) or phase
+        message = _short(getattr(status, "message", None))
+        return f"Pod {phase.lower()} ({reason}): {message}" if message else f"Pod {phase.lower()} ({reason})"
+
+    # Evicted/disrupted in place: the node flagged the pod for disruption and the
+    # main container is no longer running (kubelet would otherwise have restarted it).
+    conditions = {c.type: c for c in (status.conditions or [])}
+    disruption = conditions.get("DisruptionTarget")
+    if disruption is not None and getattr(disruption, "status", "") == "True":
+        main_running = any(
+            cs.name == MAIN_CONTAINER and cs.state and cs.state.running
+            for cs in (status.container_statuses or [])
+        )
+        if not main_running:
+            d_reason = getattr(disruption, "reason", None) or "Disrupted"
+            d_msg = _short(getattr(disruption, "message", None))
+            return f"Pod disrupted ({d_reason}): {d_msg}" if d_msg else f"Pod disrupted ({d_reason})"
+
+    return None
+
+
 def mark_disk_not_in_use(user_id: str, disk_name: str) -> None:
     """
     Mark a disk as not in use in the disks table.
@@ -1363,6 +1448,58 @@ def expire_reservation_due_to_missing_pod(reservation: dict[str, Any]) -> None:
         logger.error(
             f"Error marking reservation {reservation.get('reservation_id')} as expired: {str(e)}"
         )
+
+
+def expire_reservation_due_to_dead_pod(reservation: dict[str, Any], reason: str) -> None:
+    """Finalize an active reservation whose pod died in place (node-pressure
+    eviction / preemption / node loss). Snapshots the persistent disk so the user
+    keeps their data, cleans up the pod, marks the reservation 'failed' with a clear
+    reason (so the CLI surfaces *why* the box vanished), and frees the disk lock so
+    the user can immediately re-reserve and restore from the snapshot."""
+    reservation_id = reservation["reservation_id"]
+    logger.info(f"Finalizing reservation {reservation_id} as failed due to dead pod: {reason}")
+
+    now = datetime.utcnow().isoformat()
+    reservations_table = dynamodb.Table(RESERVATIONS_TABLE)
+
+    # Mark failed FIRST so the reservation leaves the active set even if cleanup
+    # partially fails (mirrors process_cancellation_request ordering).
+    reservations_table.update_item(
+        Key={"reservation_id": reservation_id},
+        UpdateExpression="SET #status = :status, failed_at = :failed_at, reservation_ended = :reservation_ended, failure_reason = :reason",
+        ExpressionAttributeNames={"#status": "status"},
+        ExpressionAttributeValues={
+            ":status": "failed",
+            ":failed_at": now,
+            ":reservation_ended": now,
+            ":reason": reason,
+        },
+    )
+
+    # Snapshot + delete the pod. cleanup_pod creates a shutdown snapshot of the EBS
+    # volume first (the volume still holds the user's data even though the container
+    # is dead; the kubectl-exec content capture just fails gracefully).
+    pod_name = reservation.get("pod_name")
+    if pod_name:
+        try:
+            cleanup_pod(pod_name, reservation.get("namespace", "gpu-dev"), reservation_data=reservation)
+            logger.info(f"Cleaned up dead pod {pod_name} for reservation {reservation_id}")
+        except Exception as cleanup_error:
+            logger.error(f"Pod cleanup failed for dead-pod reservation {reservation_id}: {cleanup_error}")
+
+    # Free the disk lock so the persistent disk can be reused right away.
+    user_id = reservation.get("user_id")
+    disk_name = reservation.get("disk_name")
+    if user_id and not disk_name:
+        disk_name = find_disk_by_reservation(user_id, reservation_id)
+    if user_id and disk_name:
+        try:
+            mark_disk_not_in_use(user_id, disk_name)
+            logger.info(f"Cleared disk lock for '{disk_name}' after dead-pod cleanup of {reservation_id[:8]}")
+        except Exception as e:
+            logger.warning(f"Failed to clear disk lock during dead-pod cleanup: {e}")
+
+    logger.info(f"Successfully finalized dead-pod reservation {reservation_id} as failed")
 
 
 def expire_stuck_preparing_reservation(reservation: dict[str, Any]) -> None:

--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -241,6 +241,15 @@ GPU_CONFIG = {
 }
 GPU_CONFIG_DEFAULT = {"instance_type": "g4dn.12xlarge", "max_gpus": 4, "cpus": 48, "memory_gb": 192, "efa_count": 0}
 
+# CPU dev pods get (nearly) a whole node each: request == limit, sized as a fraction
+# of nominal node capacity that stays under real allocatable (kube/system reserve
+# ~13% mem, ~12% cpu on c7i.8xlarge) yet is large enough that a second dev pod can't
+# co-schedule. This stops a co-tenant from triggering node-memory eviction — a CPU
+# pod that overruns its own limit gets a recoverable in-place OOMKill restart
+# instead of a terminal node eviction (matching GPU-pod behaviour).
+CPU_POD_CPU_FRACTION = 0.85
+CPU_POD_MEM_FRACTION = 0.80
+
 def get_gpu_resource_name(gpu_type: str) -> str:
     """Kubernetes resource name for this SKU (nvidia.com/gpu or nvidia.com/mig-*)."""
     return GPU_CONFIG.get(gpu_type, GPU_CONFIG_DEFAULT).get("k8s_resource", "nvidia.com/gpu")
@@ -4661,10 +4670,12 @@ def get_pod_resource_limits(gpu_count: int, gpu_type: str, is_multinode: bool = 
     max_gpus = config["max_gpus"]
 
     if gpu_type.startswith("cpu-"):
-        # CPU instances get reasonable limits for dedicated nodes
+        # CPU instances get a whole node each (request == limit, see
+        # get_pod_resource_requests + CPU_POD_*_FRACTION). Sized under node
+        # allocatable so the pod still schedules but a second dev pod cannot.
         limits.update({
-            "cpu": str(config["cpus"] - 2),  # Reserve some for system
-            "memory": f"{config['memory_gb'] - 2}Gi"
+            "cpu": str(int(config["cpus"] * CPU_POD_CPU_FRACTION)),
+            "memory": f"{int(config['memory_gb'] * CPU_POD_MEM_FRACTION)}Gi"
         })
     else:
         # GPU instances get proportional CPU/memory based on GPU allocation
@@ -4719,7 +4730,13 @@ def get_pod_resource_requests(gpu_count: int, gpu_type: str, is_multinode: bool 
     max_gpus = config["max_gpus"]
 
     if gpu_type.startswith("cpu-"):
-        requests.update({"cpu": "2", "memory": "4Gi"})
+        # Match the limits exactly so each CPU pod reserves (nearly) a whole node:
+        # request == limit keeps the main container off the node's eviction shortlist
+        # and the large request blocks co-tenants from packing on (1 dev pod/node).
+        requests.update({
+            "cpu": str(int(config["cpus"] * CPU_POD_CPU_FRACTION)),
+            "memory": f"{int(config['memory_gb'] * CPU_POD_MEM_FRACTION)}Gi"
+        })
     else:
         if gpu_count > 0:
             resource_name = config.get("k8s_resource", "nvidia.com/gpu")

--- a/tests/unit/lambda_fn/test_dead_pod_cleanup.py
+++ b/tests/unit/lambda_fn/test_dead_pod_cleanup.py
@@ -1,0 +1,177 @@
+"""Unit tests for dead-pod detection + cleanup in the reservation_expiry lambda.
+
+Covers the gap where a pod evicted in place (node memory/disk pressure) leaves its
+reservation stuck 'active' with a dead box until expiry. A container-level OOMKill
+is recoverable (kubelet restarts it) and must NOT be cleaned up; a pod-level
+eviction/failure must be finalized (snapshot + cleanup + free disk).
+"""
+import importlib.util
+import pathlib
+import types
+from unittest.mock import MagicMock
+
+import pytest
+from kubernetes.client.exceptions import ApiException
+
+_EXPIRY = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / "terraform-gpu-devservers" / "lambda" / "reservation_expiry" / "index.py"
+)
+
+
+@pytest.fixture
+def expiry():
+    """Load the reservation_expiry lambda under a distinct module name (the bare
+    name `index` is the reservation_processor)."""
+    spec = importlib.util.spec_from_file_location("expiry_index", _EXPIRY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _pod(phase=None, reason=None, message=None, conditions=None, container_statuses=None):
+    """Build a minimal duck-typed V1Pod-ish object for check_pod_dead."""
+    return types.SimpleNamespace(
+        status=types.SimpleNamespace(
+            phase=phase,
+            reason=reason,
+            message=message,
+            conditions=conditions,
+            container_statuses=container_statuses,
+        )
+    )
+
+
+def _cond(type_, status, reason=None, message=None):
+    return types.SimpleNamespace(type=type_, status=status, reason=reason, message=message)
+
+
+def _cstatus(name, running):
+    state = types.SimpleNamespace(running=object() if running else None)
+    return types.SimpleNamespace(name=name, state=state)
+
+
+def _patch_pod(expiry, monkeypatch, pod=None, exc=None):
+    """Make check_pod_dead's k8s read return `pod` (or raise `exc`)."""
+    api = MagicMock()
+    if exc is not None:
+        api.read_namespaced_pod.side_effect = exc
+    else:
+        api.read_namespaced_pod.return_value = pod
+    monkeypatch.setattr(expiry, "get_k8s_client", lambda: MagicMock())
+    monkeypatch.setattr(expiry.client, "CoreV1Api", lambda _c: api)
+
+
+class TestCheckPodDead:
+    def test_evicted_pod_is_dead_with_reason(self, expiry, monkeypatch):
+        pod = _pod(
+            phase="Failed",
+            reason="Evicted",
+            message="The node was low on resource: memory. Container gpu-dev was using 55Gi.",
+        )
+        _patch_pod(expiry, monkeypatch, pod)
+        reason = expiry.check_pod_dead("gpu-dev-abc")
+        assert reason is not None
+        assert "Evicted" in reason
+        assert "memory" in reason
+
+    def test_succeeded_pod_is_dead(self, expiry, monkeypatch):
+        _patch_pod(expiry, monkeypatch, _pod(phase="Succeeded", reason=None))
+        assert expiry.check_pod_dead("gpu-dev-abc") is not None
+
+    def test_running_healthy_pod_not_dead(self, expiry, monkeypatch):
+        pod = _pod(phase="Running", container_statuses=[_cstatus("gpu-dev", running=True)])
+        _patch_pod(expiry, monkeypatch, pod)
+        assert expiry.check_pod_dead("gpu-dev-abc") is None
+
+    def test_pending_pod_not_dead(self, expiry, monkeypatch):
+        _patch_pod(expiry, monkeypatch, _pod(phase="Pending"))
+        assert expiry.check_pod_dead("gpu-dev-abc") is None
+
+    def test_restarting_oom_container_not_dead(self, expiry, monkeypatch):
+        # Container OOMKilled then restarted by kubelet -> running again -> recoverable.
+        pod = _pod(phase="Running", container_statuses=[_cstatus("gpu-dev", running=True)])
+        _patch_pod(expiry, monkeypatch, pod)
+        assert expiry.check_pod_dead("gpu-dev-abc") is None
+
+    def test_disruption_target_with_dead_main_container_is_dead(self, expiry, monkeypatch):
+        pod = _pod(
+            phase="Running",
+            conditions=[_cond("DisruptionTarget", "True", reason="EvictionByEvictionAPI")],
+            container_statuses=[_cstatus("gpu-dev", running=False)],
+        )
+        _patch_pod(expiry, monkeypatch, pod)
+        reason = expiry.check_pod_dead("gpu-dev-abc")
+        assert reason is not None and "EvictionByEvictionAPI" in reason
+
+    def test_disruption_target_but_main_still_running_not_dead(self, expiry, monkeypatch):
+        pod = _pod(
+            phase="Running",
+            conditions=[_cond("DisruptionTarget", "True", reason="TerminationByKubelet")],
+            container_statuses=[_cstatus("gpu-dev", running=True)],
+        )
+        _patch_pod(expiry, monkeypatch, pod)
+        assert expiry.check_pod_dead("gpu-dev-abc") is None
+
+    def test_missing_pod_returns_none(self, expiry, monkeypatch):
+        # 404 is handled by the separate missing-pod path, not here.
+        _patch_pod(expiry, monkeypatch, exc=ApiException(status=404))
+        assert expiry.check_pod_dead("gpu-dev-abc") is None
+
+    def test_api_error_returns_none(self, expiry, monkeypatch):
+        _patch_pod(expiry, monkeypatch, exc=ApiException(status=500))
+        assert expiry.check_pod_dead("gpu-dev-abc") is None
+
+
+class TestFinalizeDeadPod:
+    def test_marks_failed_snapshots_and_frees_disk(self, expiry, monkeypatch):
+        table = MagicMock()
+        ddb = MagicMock()
+        ddb.Table.return_value = table
+        monkeypatch.setattr(expiry, "dynamodb", ddb)
+
+        cleanup = MagicMock()
+        monkeypatch.setattr(expiry, "cleanup_pod", cleanup)
+        freed = MagicMock()
+        monkeypatch.setattr(expiry, "mark_disk_not_in_use", freed)
+
+        reservation = {
+            "reservation_id": "9b1466cc-f272-40a6-90da-2bf0f4c1e599",
+            "user_id": "ezyang@meta.com",
+            "disk_name": "default",
+            "pod_name": "gpu-dev-9b1466cc",
+            "namespace": "gpu-dev",
+            "ebs_volume_id": "vol-123",
+        }
+        reason = "Pod failed (Evicted): The node was low on resource: memory."
+        expiry.expire_reservation_due_to_dead_pod(reservation, reason)
+
+        # status -> failed with the reason, BEFORE cleanup (leaves the active set first)
+        kwargs = table.update_item.call_args.kwargs
+        vals = kwargs["ExpressionAttributeValues"]
+        assert vals[":status"] == "failed"
+        assert vals[":reason"] == reason
+
+        # snapshot + delete the pod, then free the disk lock
+        cleanup.assert_called_once()
+        assert cleanup.call_args.args[0] == "gpu-dev-9b1466cc"
+        freed.assert_called_once_with("ezyang@meta.com", "default")
+
+    def test_disk_lock_freed_even_if_cleanup_fails(self, expiry, monkeypatch):
+        table = MagicMock()
+        ddb = MagicMock()
+        ddb.Table.return_value = table
+        monkeypatch.setattr(expiry, "dynamodb", ddb)
+        monkeypatch.setattr(expiry, "cleanup_pod", MagicMock(side_effect=RuntimeError("boom")))
+        freed = MagicMock()
+        monkeypatch.setattr(expiry, "mark_disk_not_in_use", freed)
+
+        reservation = {
+            "reservation_id": "res-1",
+            "user_id": "u@meta.com",
+            "disk_name": "default",
+            "pod_name": "gpu-dev-res1",
+        }
+        expiry.expire_reservation_due_to_dead_pod(reservation, "Pod failed (Evicted)")
+        # a stuck in_use flag would permanently block the user, so it must still clear
+        freed.assert_called_once_with("u@meta.com", "default")

--- a/tests/unit/lambda_fn/test_mig_gpu_config.py
+++ b/tests/unit/lambda_fn/test_mig_gpu_config.py
@@ -207,17 +207,18 @@ def test_limits_full_gpu_cpu_capped_at_node_cpus(lambda_index):
 
 # ── cpu-* branch ──────────────────────────────────────────────────────────────
 
-def test_limits_cpu_type_reserves_for_system(lambda_index):
-    # cpu-x86: cpus=32, mem=64 -> cpu = 30, memory = 62Gi (minus 2 each)
+def test_limits_cpu_type_whole_node(lambda_index):
+    # cpu-x86: cpus=32, mem=64 -> cpu = int(32*0.85)=27, memory = int(64*0.80)=51Gi
     lim = lambda_index.get_pod_resource_limits(0, "cpu-x86")
-    assert lim["cpu"] == "30"
-    assert lim["memory"] == "62Gi"
+    assert lim["cpu"] == "27"
+    assert lim["memory"] == "51Gi"
     assert "nvidia.com/gpu" not in lim
 
 
-def test_requests_cpu_type_fixed_small(lambda_index):
-    req = lambda_index.get_pod_resource_requests(0, "cpu-arm")
-    assert req == {"cpu": "2", "memory": "4Gi"}
+def test_requests_cpu_type_equals_limits(lambda_index):
+    # request == limit (whole-node Guaranteed-style sizing, no co-tenant eviction)
+    assert lambda_index.get_pod_resource_requests(0, "cpu-arm") == \
+        lambda_index.get_pod_resource_limits(0, "cpu-arm")
 
 
 # ── EFA gating: MIG must NOT get EFA even at "full" slice count ────────────────

--- a/tests/unit/lambda_fn/test_pod_resources.py
+++ b/tests/unit/lambda_fn/test_pod_resources.py
@@ -117,19 +117,28 @@ class TestMigSizing:
 # CPU-only SKUs: fixed limits/requests, no GPU resource, no EFA
 # --------------------------------------------------------------------------- #
 class TestCpuOnly:
-    def test_cpu_arm_limits_reserve_two_cpu_and_two_gib(self):
-        # cpu = cpus-2 = 30, memory = (memory_gb-2)Gi = 62Gi
+    def test_cpu_arm_limits_whole_node_sizing(self):
+        # cpu = int(32*0.85) = 27, memory = int(64*0.80)Gi = 51Gi (under allocatable)
         lim = index.get_pod_resource_limits(0, "cpu-arm")
-        assert lim == {"cpu": "30", "memory": "62Gi"}
+        assert lim == {"cpu": "27", "memory": "51Gi"}
 
-    def test_cpu_arm_requests_fixed(self):
-        req = index.get_pod_resource_requests(0, "cpu-arm")
-        assert req == {"cpu": "2", "memory": "4Gi"}
+    def test_cpu_request_equals_limit_guaranteed(self):
+        # Whole-node sizing: request == limit so the pod isn't on the eviction
+        # shortlist and a co-tenant can't pack on (no more node-pressure eviction).
+        for sku in ("cpu-arm", "cpu-x86", "cpu-spot"):
+            assert index.get_pod_resource_requests(0, sku) == index.get_pod_resource_limits(0, sku)
+
+    def test_cpu_request_blocks_second_pod(self):
+        # 2x the memory request must exceed the node's nominal capacity so only one
+        # dev pod schedules per CPU node.
+        for sku, mem_gb in (("cpu-arm", 64), ("cpu-x86", 64), ("cpu-spot", 16)):
+            req_mem = int(index.get_pod_resource_requests(0, sku)["memory"][:-2])
+            assert 2 * req_mem > mem_gb
 
     def test_cpu_spot_smaller_node(self):
-        # cpu-spot: cpus=8, memory_gb=16
+        # cpu-spot: cpus=8, memory_gb=16 -> int(8*0.85)=6, int(16*0.80)=12
         lim = index.get_pod_resource_limits(0, "cpu-spot")
-        assert lim == {"cpu": "6", "memory": "14Gi"}
+        assert lim == {"cpu": "6", "memory": "12Gi"}
 
     def test_cpu_has_no_gpu_resource(self):
         lim = index.get_pod_resource_limits(0, "cpu-x86")


### PR DESCRIPTION
## Problem

ezyang reported an OSDC box that `gpu-dev` still listed as **active** but he could no longer SSH into. Root cause: reservation `9b1466cc` (cpu-x86) had its pod **evicted in place by the kubelet for node memory pressure** — the `gpu-dev` container used ~53GB while its memory *request* was only 4Gi on a shared node. The pod went `ContainerStatusUnknown`, so SSH had no live container, but the reservation stayed `active`.

Two gaps:

1. **Nothing cleans up an evicted-but-not-deleted pod.** The expiry lambda's `check_pod_exists()` is phase-agnostic — an `Evicted`/`Failed`/`ContainerStatusUnknown` pod still "exists", so it passes. OOM detection only matches `OOMKilled` and only bumps a counter. Dev pods are bare `V1Pod`s (no controller), so nothing recreates them. The reservation hangs `active` until its expiry time.
2. **CPU pods are eviction-prone.** They requested only 4Gi while bursting to ~62Gi on *shared* nodes (the "dedicated nodes" code comment was wrong — 3 pods were co-scheduled), so the node overcommits and the kubelet evicts the pod most over its request. GPU pods don't hit this: they request ~90% of their limit and effectively get dedicated nodes, so they only ever see *recoverable* container-level OOMKill (kubelet restarts in place) — which is the "OOMs recover" behaviour users expect.

## Fix

**Cleanup** (`reservation_expiry/index.py`):
- `check_pod_dead()` — detects terminal *pod-level* failure (phase `Failed`/`Succeeded`, or a `DisruptionTarget` condition with the `gpu-dev` container no longer running). A recoverable container-level OOMKill/restart returns `None` and is left alone.
- `expire_reservation_due_to_dead_pod()` — snapshots the disk (so data survives), cleans up the pod, marks the reservation **`failed` with the real reason** (e.g. "node was low on resource: memory…", surfaced by the CLI), and frees the disk lock so the user can immediately re-reserve and restore from the snapshot.

**Prevention** (`reservation_processor/index.py`):
- CPU pods now use **request == limit**, sized under real node allocatable (`CPU_POD_CPU_FRACTION=0.85`, `CPU_POD_MEM_FRACTION=0.80`). c7i.8xlarge allocatable is ~53.7GiB/28cpu vs nominal 64/32, so requesting the old 62Gi limit would be unschedulable. Each CPU pod now reserves ~a whole node: a second dev pod can't co-pack, so no co-tenant can trigger node-pressure eviction, and overrunning the limit becomes a **recoverable in-place OOMKill restart** instead of a terminal eviction.

## Tests
- New `tests/unit/lambda_fn/test_dead_pod_cleanup.py`: `check_pod_dead` across evicted / succeeded / running / pending / restarting / disruption-target states + `expire_reservation_due_to_dead_pod` (marks failed, snapshots, frees disk even if cleanup throws).
- Updated CPU sizing assertions in `test_pod_resources.py` / `test_mig_gpu_config.py` (request == limit, blocks a 2nd pod).
- Full suite green: **1181 passed**.

## Deploy
Needs `tofu apply` (both `reservation_expiry` and `reservation_processor` lambdas), prod + east1. CPU sizing change takes effect for **new** reservations/warm pods; existing CPU pods keep their old requests until recycled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
