### PR TITLE
chore(staging): remove H100 capacity reservation from default workspace

### DIFF
--- a/terraform-gpu-devservers/main.tf
+++ b/terraform-gpu-devservers/main.tf
@@ -457,9 +457,7 @@ locals {
       # h200 = [
       #   { id = "cr-0c0a6073304dd5d03", instance_count = 1 }  # Expired - commented out
       # ]
-      h100 = [
-        { key = "cr0", id = "cr-04d3d1d84e127a562", instance_count = 2 }, # H100 reservation us-west-1c (starts Wed)
-      ]
+      # h100 removed 2026-06-11 — staging should not hold an H100 capacity reservation
     }
     prod = {
       # Production environment capacity reservations
@@ -557,7 +555,7 @@ locals {
       # Empty — no CRs in this workspace.
     }
     default = {
-      "cr-04d3d1d84e127a562" = "secondary" # us-west-1c
+      # Empty — no CRs in this workspace.
     }
     prod = {
       # B200 capacity reservations


### PR DESCRIPTION
## What

Removes the H100 capacity reservation `cr-04d3d1d84e127a562` (`instance_count = 2`, us-west-1c) from the **staging** config (tf `default` workspace, us-west-1):
- `capacity_reservations.default.h100` — the `cr0` entry
- `capacity_reservation_azs.default` — the matching CR→AZ mapping

## Why

Staging should not hold an H100 capacity reservation — staging e2e only exercises `cpu-x86` + `t4`. It was added in March (b994ee3) and shouldn't have been on `default`.

## Impact / deploy

`tofu apply` (workspace `default`) destroys the `pytorch-gpu-dev-gpu-nodes-h100-cr0` ASG. Verified safe at time of writing:
- 0 active reservations on staging.
- The ASG was already at desired/min/max = 0 with its 2 instances in `Terminating` state — Terraform's ASG destroy completes cleanly; no manual node termination needed.

**Does NOT cancel the AWS capacity reservation `cr-04d3d1d84e127a562` itself** — that still exists/bills until cancelled in EC2 separately.
