### PR TITLE
fix(image): drop cuda-toolkit-13-3 (cccl conflict broke the build)

### DIFF
--- a/terraform-gpu-devservers/docker/Dockerfile
+++ b/terraform-gpu-devservers/docker/Dockerfile
@@ -46,20 +46,23 @@ RUN for attempt in 1 2 3; do \
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs
 
-# Install additional CUDA toolkits alongside base CUDA 13.2 (13.3 is the latest, May 2026)
+# Install additional CUDA toolkits alongside base CUDA 13.2
 # Base image already has NVIDIA repo configured, no need for cuda-keyring
+# NOTE: cuda-toolkit-13-3 is intentionally NOT here. CUDA 13.3 ships a unified
+# `cccl-13-3` package that `Breaks` `cuda-cccl-12-8`/`-12-9`, so 13.3 cannot coexist
+# with the 12.8/12.9 toolkits in one image. To add 13.3 we'd have to drop 12.8/12.9
+# (or hand-curate 13.3 sub-packages that exclude cccl). Kept 12.8-13.2 for now.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         cuda-toolkit-12-8 \
         cuda-toolkit-12-9 \
         cuda-toolkit-13-0 \
         cuda-toolkit-13-1 \
-        cuda-toolkit-13-3 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # CUDA 13.2 is the default (PyTorch 2.12 compiled against it)
-# All versions available at /usr/local/cuda-{12.8,12.9,13.0,13.1,13.2,13.3}/
-# Switch with: export CUDA_HOME=/usr/local/cuda-13.3
+# All versions available at /usr/local/cuda-{12.8,12.9,13.0,13.1,13.2}/
+# Switch with: export CUDA_HOME=/usr/local/cuda-12.8
 ENV CUDA_HOME=/usr/local/cuda-13.2
 ENV PATH=/usr/local/cuda-13.2/bin:${PATH}
 ENV LD_LIBRARY_PATH=/usr/local/cuda-13.2/lib64:${LD_LIBRARY_PATH}


### PR DESCRIPTION
CUDA 13.3's unified `cccl-13-3` package `Breaks` `cuda-cccl-12-8`/`-12-9`, so `cuda-toolkit-13-3` cannot be installed alongside the 12.8/12.9 toolkits — the image build (#214's CUDA addition) failed with held broken packages. This reverts the 13.3 line back to the working 12.8/12.9/13.0/13.1 + base 13.2 set.

To add 13.3 in future: either drop 12.8/12.9, or hand-curate 13.3 sub-packages that exclude cccl.