### PR TITLE
feat(cli): gpu-dev debug — self-serve reservation diagnostics

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -3232,6 +3232,143 @@ def show(ctx: click.Context, reservation_id: Optional[str]) -> None:
         rprint(f"[red]❌ Error: {str(e)}[/red]")
 
 
+def _print_recovery_hints(connection_info: dict) -> None:
+    """Tell the user how to unblock/recover their own reservation based on status."""
+    status = (connection_info.get("status") or "").lower()
+    disk_name = connection_info.get("disk_name") or ""
+    res_id = connection_info.get("reservation_id", "") or ""
+    short_id = res_id[:8] if res_id else "<id>"
+    hints = []
+    if status in ("failed", "expired", "cancelled"):
+        if disk_name:
+            hints.append(
+                f"Your data on disk '{disk_name}' is preserved — re-reserve with: "
+                f"gpu-dev reserve --disk {disk_name}")
+            hints.append(f"If that disk is stuck locked: gpu-dev disk unlock {disk_name}")
+        else:
+            hints.append("Re-reserve a new box with: gpu-dev reserve")
+    elif status == "active":
+        hints.append(
+            f"If status is 'active' but you can't SSH, the pod likely died (e.g. OOM). "
+            f"Free it (and your disk) with: gpu-dev cancel {short_id}  — then re-reserve.")
+        if disk_name:
+            hints.append(f"If the disk stays locked after cancel: gpu-dev disk unlock {disk_name}")
+    if hints:
+        rprint("\n[bold]Recovery:[/bold]")
+        for h in hints:
+            rprint(f"  • {h}")
+
+
+def _show_diagnostics(connection_info: dict) -> None:
+    """Render the extra diagnostics `gpu-dev debug` adds on top of the status panel:
+    failure reason, OOM events, the full status-history timeline, captured pod logs,
+    and recovery hints. All sourced from data the lambdas write to DynamoDB, so it
+    needs no cluster/lambda access."""
+    from rich.text import Text
+
+    status = (connection_info.get("status") or "").lower()
+
+    # Failure reason / latest detailed status — shown for ANY status (the normal
+    # `show` only surfaces failure_reason on 'failed'; for an active-but-dead pod
+    # this is exactly what the user needs).
+    failure_reason = (connection_info.get("failure_reason") or "").strip()
+    detailed = (connection_info.get("current_detailed_status") or "").strip()
+    if failure_reason:
+        rprint(f"\n[bold red]Why it ended:[/bold red] {failure_reason}")
+    elif detailed and status != "active":
+        rprint(f"\n[bold]Latest status:[/bold] {detailed}")
+
+    # OOM events
+    oom_count = int(connection_info.get("oom_count", 0) or 0)
+    if oom_count > 0:
+        last = connection_info.get("last_oom_at") or "unknown"
+        cont = connection_info.get("oom_container") or "?"
+        rprint(f"[red]⚠️  OOM:[/red] {oom_count} event(s) — last {last} (container: {cont})")
+
+    # Status-history timeline (the gold for "what happened to my reservation")
+    history = connection_info.get("status_history") or []
+    if history:
+        table = Table(title="Status timeline (most recent last)", show_header=True,
+                      header_style="bold", box=None, pad_edge=False)
+        table.add_column("Time", style="dim", no_wrap=True)
+        table.add_column("Event")
+        for entry in history[-40:]:
+            if isinstance(entry, dict):
+                table.add_row(str(entry.get("timestamp", "")), str(entry.get("message", "")))
+        console.print("")
+        console.print(table)
+    else:
+        rprint("\n[dim]No status history recorded for this reservation.[/dim]")
+
+    # Captured pod logs (lambda snapshot — last lines around the failure)
+    pod_logs = (connection_info.get("pod_logs") or "").strip()
+    if pod_logs:
+        console.print(Panel(Text(pod_logs[-4000:]), title="Captured pod logs (snapshot)",
+                            border_style="yellow"))
+
+    _print_recovery_hints(connection_info)
+
+
+@main.command()
+@click.argument("reservation_id", required=False)
+@click.pass_context
+def debug(ctx: click.Context, reservation_id: Optional[str]) -> None:
+    """Diagnose your own reservation — why a box died or won't connect.
+
+    Shows the status timeline, failure reason, OOM events, and captured pod logs,
+    plus recovery steps — all without needing cluster or lambda access.
+
+    \b
+    Examples:
+        gpu-dev debug                 # pick from your active reservations
+        gpu-dev debug abc12345        # a specific reservation (id prefix ok)
+
+    For a recently failed/expired box, find its id with 'gpu-dev list' then
+    'gpu-dev debug <id>'.
+    """
+    try:
+        config = load_config()
+        user_info = authenticate_user(config)
+        reservation_mgr = ReservationManager(config)
+
+        # In-pod fast path: the pod's own reservation id is on the env.
+        if reservation_id is None:
+            reservation_id = os.environ.get("GPU_DEV_RESERVATION_ID") or None
+
+        if reservation_id is None:
+            reservations = _fetch_reservations_cross_region(
+                reservation_mgr, user_info["user_id"],
+                ["active", "preparing", "queued", "pending"], config)
+            if not reservations:
+                rprint("[yellow]📋 No active reservations.[/yellow] To debug a recent "
+                       "failed/expired one, find its id with [bold]gpu-dev list[/bold] "
+                       "then run [bold]gpu-dev debug <id>[/bold].")
+                return
+            if len(reservations) == 1:
+                reservation_id = reservations[0].get("reservation_id")
+            else:
+                selected = select_reservation_interactive(reservations, "debug")
+                if not selected or selected in ("__QUIT__", "__ALL__"):
+                    rprint("[yellow]Cancelled.[/yellow]")
+                    return
+                reservation_id = selected
+
+        connection_info = reservation_mgr.get_connection_info(
+            reservation_id, user_info["user_id"])
+        if not connection_info:
+            rprint(f"[red]❌ No reservation found matching '{reservation_id}'[/red] "
+                   "(try a longer id prefix, or check 'gpu-dev list').")
+            return
+
+        _show_single_reservation(connection_info)
+        _show_diagnostics(connection_info)
+
+    except RuntimeError as e:
+        rprint(f"[red]❌ {str(e)}[/red]")
+    except Exception as e:
+        rprint(f"[red]❌ Error: {str(e)}[/red]")
+
+
 
 def _maybe_show_sdk_tip() -> None:
     """For a user's first few reservations, nudge them toward the Python SDK +

--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/reservations.py
@@ -999,11 +999,19 @@ class ReservationManager:
                 "jupyter_enabled": reservation.get("jupyter_enabled", False),
                 "jupyter_error": reservation.get("jupyter_error", ""),
                 "ebs_volume_id": reservation.get("ebs_volume_id", ""),
+                "disk_name": reservation.get("disk_name", ""),
                 "secondary_users": reservation.get("secondary_users", []),
                 "warning": reservation.get("warning", ""),
                 "is_multinode": is_multinode,
                 "pod_ip": reservation.get("pod_ip", ""),
+                "node_ip": reservation.get("node_ip", ""),
+                "node_name": reservation.get("node_name", ""),
                 "fqdn": reservation.get("fqdn", ""),
+                # Health/diagnostics (surfaced by `gpu-dev debug`); written by the
+                # reservation + expiry lambdas. Present off the raw item, not always set.
+                "oom_count": int(reservation.get("oom_count", 0) or 0),
+                "last_oom_at": reservation.get("last_oom_at", ""),
+                "oom_container": reservation.get("oom_container", ""),
             }
 
             # If multi-node, fetch all nodes in the group

--- a/tests/unit/cli/test_debug.py
+++ b/tests/unit/cli/test_debug.py
@@ -1,0 +1,125 @@
+"""Unit tests for the `gpu-dev debug` self-serve diagnostics command.
+
+debug renders the status-history timeline, failure reason, OOM events, captured pod
+logs, and recovery hints — all from DynamoDB fields (no cluster/lambda access).
+"""
+import re
+from unittest.mock import MagicMock, patch
+
+from gpu_dev_cli.cli import main
+
+
+def _clean(s: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+
+def _config():
+    cfg = MagicMock()
+    cfg.environment = "staging"  # avoids prod east1 cross-region fetch
+    return cfg
+
+
+def _ci(**overrides):
+    base = {
+        "ssh_command": "ssh dev@gpu-dev-9b1466cc",
+        "reservation_id": "9b1466cc-f272-40a6-90da-2bf0f4c1e599",
+        "status": "failed",
+        "namespace": "gpu-dev",
+        "gpu_count": 0,
+        "gpu_type": "cpu-x86",
+        "pod_name": "gpu-dev-9b1466cc",
+        "instance_type": "c7i.8xlarge",
+        "disk_name": "default",
+        "ebs_volume_id": "vol-123",
+        "launched_at": "2026-06-09T19:51:37",
+        "expires_at": "2026-06-11T19:51:37",
+        "created_at": "2026-06-09T19:51:00",
+        "failure_reason": "Pod failed (Evicted): The node was low on resource: memory.",
+        "current_detailed_status": "",
+        "status_history": [
+            {"timestamp": "2026-06-09T19:51:07", "message": "Fetching SSH keys"},
+            {"timestamp": "2026-06-09T20:07:30", "message": "Container running"},
+        ],
+        "pod_logs": "",
+        "oom_count": 0,
+        "last_oom_at": "",
+        "oom_container": "",
+        "jupyter_url": "", "jupyter_port": "", "jupyter_token": "",
+        "jupyter_enabled": False, "jupyter_error": "",
+        "secondary_users": [],
+        "warning": "",
+        "is_multinode": False,
+        "pod_ip": "", "node_ip": "", "node_name": "", "fqdn": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def _invoke(cli_runner, mgr, args, fetch=None):
+    from rich.console import Console
+    with patch("gpu_dev_cli.cli.console", Console(width=240, force_terminal=False)), \
+         patch("gpu_dev_cli.cli.load_config", return_value=_config()), \
+         patch("gpu_dev_cli.cli.authenticate_user", return_value={"user_id": "alice@example.com"}), \
+         patch("gpu_dev_cli.cli.ReservationManager", return_value=mgr), \
+         patch("gpu_dev_cli.cli._fetch_reservations_cross_region", return_value=(fetch or [])):
+        return cli_runner.invoke(main, ["debug"] + args)
+
+
+def test_debug_explicit_id_shows_failure_timeline_and_recovery(cli_runner):
+    mgr = MagicMock()
+    mgr.get_connection_info.return_value = _ci()
+    res = _invoke(cli_runner, mgr, ["9b1466cc"])
+    out = _clean(res.output)
+    assert res.exit_code == 0
+    # failure reason surfaced (debug shows it even though `show` only does on 'failed')
+    assert "Why it ended" in out and "low on resource: memory" in out
+    # timeline rendered
+    assert "Status timeline" in out and "Container running" in out
+    # recovery hints for a terminal reservation with a disk
+    assert "Recovery" in out
+    assert "disk unlock default" in out
+    mgr.get_connection_info.assert_called_once_with("9b1466cc", "alice@example.com")
+
+
+def test_debug_oom_surfaced(cli_runner):
+    mgr = MagicMock()
+    mgr.get_connection_info.return_value = _ci(
+        oom_count=3, last_oom_at="2026-06-09T20:00:00", oom_container="gpu-dev")
+    res = _invoke(cli_runner, mgr, ["9b1466cc"])
+    out = _clean(res.output)
+    assert "OOM" in out and "3 event" in out
+
+
+def test_debug_active_box_gives_cancel_recovery_hint(cli_runner):
+    mgr = MagicMock()
+    mgr.get_connection_info.return_value = _ci(status="active", failure_reason="")
+    res = _invoke(cli_runner, mgr, ["9b1466cc"])
+    out = _clean(res.output)
+    # active-but-unreachable guidance: cancel to free the box + disk
+    assert "Recovery" in out
+    assert "gpu-dev cancel" in out
+
+
+def test_debug_not_found(cli_runner):
+    mgr = MagicMock()
+    mgr.get_connection_info.return_value = None
+    res = _invoke(cli_runner, mgr, ["nope"])
+    out = _clean(res.output)
+    assert "No reservation found" in out
+
+
+def test_debug_no_id_no_active_points_to_list(cli_runner):
+    mgr = MagicMock()
+    res = _invoke(cli_runner, mgr, [], fetch=[])  # no active reservations
+    out = _clean(res.output)
+    assert "gpu-dev list" in out
+    mgr.get_connection_info.assert_not_called()
+
+
+def test_debug_no_id_auto_selects_single(cli_runner):
+    mgr = MagicMock()
+    mgr.get_connection_info.return_value = _ci(status="active", failure_reason="")
+    res = _invoke(cli_runner, mgr, [], fetch=[{"reservation_id": "9b1466cc-aaa"}])
+    out = _clean(res.output)
+    assert res.exit_code == 0
+    mgr.get_connection_info.assert_called_once_with("9b1466cc-aaa", "alice@example.com")


### PR DESCRIPTION
Adds `gpu-dev debug [reservation_id]` so users can diagnose why their own box died or won't connect — **without lambda/CloudWatch or kubectl access**.

Renders from DynamoDB (data the reservation + expiry lambdas already write):
- **Why it ended** — `failure_reason` for *any* status (the existing `show` only surfaces it on `failed`; an active-but-dead pod is exactly when you need it)
- **OOM events** — count / last time / container
- **Status timeline** — the full `status_history`
- **Captured pod logs** — the lambda's snapshot
- **Recovery hints** — `gpu-dev cancel` a dead active box to free it + the disk, `gpu-dev disk unlock <name>`, re-reserve `--disk <name>`

Also fixes a latent bug: `oom_count`/`last_oom_at`/`oom_container` (plus `node_name`/`disk_name`) are now included in `get_connection_info` — the OOM banner in `_show_single_reservation` was dead code because those keys were never populated.

Resolves the ezyang thread ("gpu-dev says active but I can't ssh / I don't have lambda logs access"): with #211 deployed, a dead pod flips to `failed` + reason within ~1 min, and `gpu-dev debug` shows it.

Tests: `tests/unit/cli/test_debug.py` (6). Full suite green (1192 passed).

Note: this is the no-infra layer. Full raw lambda-log access is a separate follow-up (see discussion — leaning toward an on-demand CloudWatch Logs Insights query over S3 archival).