### PR TITLE
fix(repro --lint): live progress (SSH PTY) + full-tree heads-up

### DIFF
--- a/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -1748,9 +1748,16 @@ def repro(ctx, ref, test_args, lint, clang, gpu_type, gpus, hours, no_connect, k
         ssh_cmd = ssh_cmd.replace("ssh ", "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ", 1)
     rprint(f"[dim]→ {ssh_cmd}[/dim]\n")
     rid8 = str(rid)[:8]
+    # lintrunner only renders its live progress bar to a TTY -> run lint over an SSH
+    # PTY (-t) so you see per-linter progress instead of silence. (-t is polite: in a
+    # non-TTY CI run it just proceeds without a PTY.)
+    run_ssh = ssh_cmd.replace("ssh ", "ssh -t ", 1) if lint else ssh_cmd
+    if lint and "--all-files" in (scope or ""):
+        rprint("[yellow]note:[/yellow] full-tree lint (ruff/mypy/pyrefly over ALL files) — several minutes. "
+               "Lint a PR (gpu-dev repro --lint pr/N) for a fast diff-only run.\n")
     rc = 1
     try:
-        rc = subprocess.run(f"{ssh_cmd} {shlex.quote(remote)}", shell=True).returncode
+        rc = subprocess.run(f"{run_ssh} {shlex.quote(remote)}", shell=True).returncode
     except KeyboardInterrupt:
         rprint("\n[yellow]interrupted[/yellow]"); rc = 130
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.7.14"
+version = "0.7.15"
 description = "CLI + Python SDK for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"

--- a/tests/unit/cli/test_repro.py
+++ b/tests/unit/cli/test_repro.py
@@ -488,6 +488,20 @@ def test_lint_passes_extra_args_as_scope(cli_runner):
     assert "--merge-base-with" not in cmd
 
 
+def test_lint_run_uses_pty_for_progress(cli_runner):
+    # lint runs over an SSH PTY (-t) so lintrunner renders its live progress bar.
+    res, rm, run = _run(cli_runner, ["--lint", "pr/1"], claim_result=WARM)
+    cmd = _remote_str(run)
+    assert "ssh -t " in cmd
+
+
+def test_test_run_has_no_pty(cli_runner):
+    # the python-test path must NOT allocate a PTY for the run.
+    res, rm, run = _run(cli_runner, ["pr/1", "test/foo.py"], claim_result=WARM)
+    cmd = _remote_str(run)
+    assert "ssh -t " not in cmd
+
+
 def test_lint_explicit_cpu_arm_keeps_zero_gpus(cli_runner):
     res, rm, run = _run(cli_runner, ["--lint", "--gpu-type", "cpu-arm", "pr/1"], claim_result=WARM)
     kwargs = rm.claim_direct.call_args.kwargs


### PR DESCRIPTION
lintrunner only renders its progress bar to a TTY; the lint ran over non-interactive SSH so a clean --all-files run looked silent/hung for minutes while ruff/mypy/pyrefly churned. Run lint over an SSH PTY (`-t`) so progress streams, and print a heads-up that an --all-files (main) lint is the full trunk lint (a PR lints only its diff).

Unit: 1210 passed, 3 pre-existing xfails. Bumps gpu-dev → 0.7.15.