### PR TITLE
Count idle warm-ready pods as available in the placement gate

### DIFF
--- a/terraform-gpu-devservers/lambda/reservation_processor/index.py
+++ b/terraform-gpu-devservers/lambda/reservation_processor/index.py
@@ -3277,6 +3277,14 @@ def get_available_gpus_on_node(v1_api, node, gpu_type: str = None) -> int:
         used_gpus = 0
         for pod in pods.items:
             if pod.status.phase in ["Running", "Pending"]:
+                # Idle warm-ready pods hold a slice but are disposable: a 2/4/8-GPU
+                # (or full-MIG-node) request frees them via _evict_warm_for_capacity
+                # before placement, so count them as available here. This mirrors
+                # availability_updater.get_available_gpus_on_node and keeps the
+                # placement gate consistent with advertised availability.
+                labels = pod.metadata.labels or {}
+                if labels.get("app") == "gpu-dev-warm" and labels.get("warm-state") == "ready":
+                    continue
                 if pod.spec.containers:
                     for container in pod.spec.containers:
                         if container.resources and container.resources.requests:


### PR DESCRIPTION
## Summary

Whole-node GPU reservations (`--gpus 8` on an 8-GPU SKU, and 2/4-GPU or
full-MIG-node requests) can get stuck queued indefinitely even when `gpu-dev
avail` reports the SKU as reservable and "Available now", whenever an idle
warm-pool pod happens to occupy a slice on the only otherwise-free node.

The placement gate in `reservation_processor` counts idle `warm-state=ready`
pods as *used* capacity, while `availability_updater` (what `gpu-dev avail`
shows) counts them as *available*. Because the two disagree by exactly the
number of warm pods on the node, a node that is idle except for one warm-ready
pod advertises 8 free but the scheduler sees only 7 and refuses to place an
8-GPU job. This PR makes the placement gate skip warm-ready pods too, matching
`availability_updater` and the allocator's own eviction behavior.

## Symptom

- `gpu-dev avail` shows e.g. `H100  Avail 19  Reservable 8  Available now`.
- An `--gpus 8` H100 reservation nonetheless sits `queued` for hours with:
  `Need 8 H100 GPUs on one node, max available on single node is 7 - position #1`
- The number is persistent across the 1-minute `availability_updater` refresh
  (i.e. it is not staleness): `avail` keeps saying 8, the scheduler keeps
  saying 7. The gap is exactly the count of idle warm pods on the best node.

## Root cause

Two code paths compute per-node availability differently:

1. `availability_updater/index.py::get_available_gpus_on_node` **skips**
   idle warm pods when summing used GPUs:

   ```python
   if labels.get("app") == "gpu-dev-warm" and labels.get("warm-state") == "ready":
       continue
   ```

   So a node with one warm-ready pod is reported as fully free, counts as a
   "full node", and drives `max_reservable` / "Available now".

2. `reservation_processor/index.py::get_available_gpus_on_node` (used by both
   `check_gpu_availability` and `check_max_gpus_on_single_node`) has **no such
   skip** and counts the warm pod's GPU as used.

The scheduler's admission check then does (index.py ~2972):

```python
available_gpus   = check_gpu_availability(gpu_type)          # total free
max_single_node  = check_max_gpus_on_single_node(gpu_type)   # best single node
...
if available_gpus >= requested_gpus and max_single_node >= requested_gpus:
    allocate_gpu_resources(...)   # <-- runs _evict_warm_for_capacity
else:
    queue
```

For an 8-GPU request onto a node holding one warm pod, `max_single_node`
evaluates to 7, the gate fails, and the request is queued. Crucially, the
allocation path is the *only* place that would evict the disposable warm pod
(`_evict_warm_for_capacity`, with the module docstring noting "a 2/4/8-GPU (or
full-MIG-node) request evicts them via `_evict_warm_for_capacity` to free the
node"). Because admission is gated on a warm-inclusive count, that eviction is
never reached, and the request that *should* succeed (evict one idle warm pod ->
8 free -> place) instead waits forever.

## Fix

Make `reservation_processor.get_available_gpus_on_node` skip idle
`warm-state=ready` pods, identical to `availability_updater`. This aligns the
admission gate with (a) advertised availability and (b) the allocator's actual
capability, so whole-node requests pass the gate and `_evict_warm_for_capacity`
frees the node as designed.

```diff
             if pod.status.phase in ["Running", "Pending"]:
+                labels = pod.metadata.labels or {}
+                if labels.get("app") == "gpu-dev-warm" and labels.get("warm-state") == "ready":
+                    continue
                 if pod.spec.containers:
```

## Why this is safe / correct

- It only skips pods with `app=gpu-dev-warm` **and** `warm-state=ready`, the
  same disposable-idle set that `_evict_warm_for_capacity` is allowed to delete
  (it re-checks the `warm-state=ready` label before evicting). Claimed/active
  pods (which drop the `warm-state=ready` label) are still counted as used.
- It makes admission consistent with the availability that is already published
  and consumed by users, removing a class of "advertised but unplaceable"
  reservations.
- Single-GPU claims are unaffected (they claim a warm pod directly rather than
  going through this capacity gate).

## Risk / follow-ups

- If a node's warm pods cannot actually be evicted in time (e.g. eviction
  races a concurrent claim), the real pod could momentarily be Pending until
  capacity frees. This matches the pre-existing behavior of the allocation
  path, which already relies on `_evict_warm_for_capacity`; this change just
  lets that path run. Worth a look if you want belt-and-suspenders handling of
  eviction failure at allocation time.
- I could not deploy the Lambda to exercise it end-to-end (it runs in the
  shared cluster/account). Validation so far: `python -m py_compile` on the
  changed module, and confirming the change mirrors the existing, working
  `availability_updater` logic line-for-line. Happy to add a unit test around
  `get_available_gpus_on_node` (fake pod list with a warm-ready pod) if you'd
  like one in this PR.

## How this was found

Debugging why a cron that submits `gpu-dev submit --gpu-type h100 --gpus 8`
stopped producing results: reservations queued for hours behind the
`max available on single node is 7` message while `avail` claimed 8 reservable.
Tracing both lambdas showed the warm-pool accounting mismatch above.
